### PR TITLE
Bail on a non-existent passed external config path, instead of blindly forging ahead without the user's awareness

### DIFF
--- a/proton-tkg/proton-tkg.sh
+++ b/proton-tkg/proton-tkg.sh
@@ -280,7 +280,7 @@ elif [ "$1" == "build_steamhelper" ]; then
   build_steamhelper
 else
   # If $1 contains a path, and it exists, use it as default for config
-  if [ -e "$1" ]; then
+  if [ -n "$1" ]; then
     user_config_file_option=$(readlink -m $1)
     if [ ! -f $user_config_file_option ]; then
       echo "External user config file '${user_config_file_option}' not found! Please fix your passed path!"

--- a/proton-tkg/proton-tkg.sh
+++ b/proton-tkg/proton-tkg.sh
@@ -281,7 +281,12 @@ elif [ "$1" == "build_steamhelper" ]; then
 else
   # If $1 contains a path, and it exists, use it as default for config
   if [ -e "$1" ]; then
-    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=$(readlink -m $1)|" "$_nowhere"/proton-tkg-profiles/advanced-customization.cfg
+    user_config_file_option=$(readlink -m $1)
+    if [ ! -f $user_config_file_option ]; then
+      echo "External user config file '${user_config_file_option}' not found! Please fix your passed path!"
+      exit 0
+    fi
+    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=${user_config_file_option}|" "$_nowhere"/proton-tkg-profiles/advanced-customization.cfg
   fi
 
   rm -rf "$_nowhere"/proton_dist_tmp

--- a/wine-tkg-git/non-makepkg-build.sh
+++ b/wine-tkg-git/non-makepkg-build.sh
@@ -245,7 +245,7 @@ elif [ "$1" == "--deps32" ]; then
   msg2 "You might find help regarding dependencies here: https://github.com/Tk-Glitch/PKGBUILDS/wiki/wine-tkg-git#dependencies"
 else
   # If $1 contains a path, and it exists, use it as default for config
-  if [ -e "$1" ]; then
+  if [ -n "$1" ]; then
     user_config_file_option=$(readlink -m $1)
     if [ ! -f $user_config_file_option ]; then
       echo "External user config file '${user_config_file_option}' not found! Please fix your passed path!"

--- a/wine-tkg-git/non-makepkg-build.sh
+++ b/wine-tkg-git/non-makepkg-build.sh
@@ -246,7 +246,12 @@ elif [ "$1" == "--deps32" ]; then
 else
   # If $1 contains a path, and it exists, use it as default for config
   if [ -e "$1" ]; then
-    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=$(readlink -m $1)|" "$_where"/wine-tkg-profiles/advanced-customization.cfg
+    user_config_file_option=$(readlink -m $1)
+    if [ ! -f $user_config_file_option ]; then
+      echo "External user config file '${user_config_file_option}' not found! Please fix your passed path!"
+      exit 0
+    fi
+    sed -i -e "s|_EXT_CONFIG_PATH.*|_EXT_CONFIG_PATH=${user_config_file_option}|" "$_nowhere"/wine-tkg-profiles/advanced-customization.cfg
   fi
 
   build_wine_tkg


### PR DESCRIPTION
When an external config path is passed to proton-tkg.sh or non-makepkg-build.sh, and it doesn't exist, we should bail early, so that the user knows that they screwed up the path.

We don't want them puzzling over what went wrong during building, or with the build, if it completed, so alert them immediately.