### PR TITLE
Change from True to Mainline in VKD3D

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -110,7 +110,7 @@ makedepends=('git' 'autoconf' 'ncurses' 'bison' 'perl' 'fontforge' 'flex'
 )
 
 # vkd3d deps
-if [ "$_use_vkd3d" == "true" ]; then
+if [ "$_use_vkd3d" == "mainline" ]; then
   makedepends+=('vkd3d' 'lib32-vkd3d')
 fi
 


### PR DESCRIPTION
When doing a clean installation on Arch Linux, it does not do the installation of VKD3D, see that in the PKGBUILD file was the selection of TRUE when it is already "mainline", but I do not know how the Fork installation will take