### PR TITLE
wine-tkg: Debian packaging on Arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.bak
 *.tar.gz
 *.tar.zst
+*.deb
 *.old
 *.db
 *.files

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -25,6 +25,10 @@ _nomakepkg_dep_resolution_distro=""
 # !!! Don't forget that you'll have to use /opt/wine-something/bin/wine instead of just wine (same for winecfg etc.) !!!
 _EXTERNAL_INSTALL="false"
 
+#### GENERATE DEBIAN PACKAGE ####
+# Set to true if you want to generate a debian package after building. Currently doesn't work with _EXTERNAL_INSTALL option.
+# This generates a debian package from build files ready to be packaged.
+_GENERATE_DEBIAN_PACKAGE="false"
 
 #### WINE FLAVOUR SETTINGS ####
 
@@ -94,7 +98,7 @@ _mk11_fix="false"
 # Found to also enable the new launcher (that came with the 5.1 update) to work *with issues*
 _ffxivlauncher_fix="false"
 
-# Background music on King of Fighters 98 and 2002 is silent on Wine-staging and the `xactengine-initial` patchset was found to introduce the issue. Set to "true" to disable it as a workaround. 
+# Background music on King of Fighters 98 and 2002 is silent on Wine-staging and the `xactengine-initial` patchset was found to introduce the issue. Set to "true" to disable it as a workaround.
 _kof98_2002_BGM_fix="false"
 
 

--- a/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
@@ -102,6 +102,10 @@ _DEFAULT_EXTERNAL_PATH="/opt"
 # Set to true to disable versioning in path for external install. For example, this would strip "opt/wine-tkg-opt-git-4.0.r11.gd2a48f1a" to "opt/wine-tkg-opt-git".
 _EXTERNAL_NOVER="false"
 
+#### GENERATE DEBIAN PACKAGE ####
+# Set to true if you want to generate a debian package after building. Currently doesn't work with _EXTERNAL_INSTALL option.
+# This generates a debian package from build files ready to be packaged.
+_GENERATE_DEBIAN_PACKAGE="false"
 
 #### WINE FLAVOUR SETTINGS ####
 
@@ -203,7 +207,7 @@ _staging_pulse_disable="false"
 # Found to also enable the new launcher (that came with the 5.1 update) to work *with issues*
 _ffxivlauncher_fix="false"
 
-# Background music on King of Fighters 98 and 2002 is silent on Wine-staging and the `xactengine-initial` patchset was found to introduce the issue. Set to "true" to disable it as a workaround. 
+# Background music on King of Fighters 98 and 2002 is silent on Wine-staging and the `xactengine-initial` patchset was found to introduce the issue. Set to "true" to disable it as a workaround.
 _kof98_2002_BGM_fix="false"
 
 
@@ -342,4 +346,4 @@ _user_patches_no_confirm="false"
 # Set to "true" to apply all hotfix patches without confirmation, to "ignore" to ignore all hotfix patches without confirmation
 # Default ("false") will prompt at build time
 _hotfixes_no_confirm="false"
- 
+

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg.cfg
@@ -18,7 +18,8 @@ _EXTERNAL_INSTALL="false"
 _DEFAULT_EXTERNAL_PATH="/opt"
 _EXTERNAL_NOVER="false"
 
-# Generate debian package
+# Generate a debian package
+
 _GENERATE_DEBIAN_PACKAGE="false"
 
 # WINE FLAVOUR SETTINGS

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg.cfg
@@ -18,6 +18,8 @@ _EXTERNAL_INSTALL="false"
 _DEFAULT_EXTERNAL_PATH="/opt"
 _EXTERNAL_NOVER="false"
 
+# Generate debian package
+_GENERATE_DEBIAN_PACKAGE="false"
 
 # WINE FLAVOUR SETTINGS
 

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -221,7 +221,7 @@ _package_nomakepkg() {
 	  pkgdir="${_nomakepkg_prefix_path}/${_nomakepkg_pkgname}"
 	fi
 
-	if [ "$_GENERATE_DEBIAN_PACKAGE" = "true" ]; then
+	if [ "$_GENERATE_DEBIAN_PACKAGE" = "true" ] && [ "$_EXTERNAL_INSTALL_TYPE" != "proton" ]; then
 		_generate_debian_package "$_prefix"
 	fi
 
@@ -335,7 +335,7 @@ _package_makepkg() {
 
 	cp "$_where"/last_build_config.log "${pkgdir}$_prefix"/share/wine/wine-tkg-config.txt
 
-	if [ "$_GENERATE_DEBIAN_PACKAGE" = "true" ]; then
+	if [ "$_GENERATE_DEBIAN_PACKAGE" = "true" ] && [ "$_EXTERNAL_INSTALL_TYPE" != "proton" ]; then
 		_generate_debian_package "$_prefix"
 	fi
 

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -129,6 +129,13 @@ _build() {
 	fi
 }
 
+_generate_debian_package() {
+	_prefix=$1
+
+	msg2 'Generating a Debian package'
+	"$_where"/wine-tkg-scripts/package-debian.sh "${pkgdir}" "${_prefix}" "${_where}" "${pkgname}-${pkgver}.deb" "${pkgver}" "${pkgname}"
+}
+
 _package_nomakepkg() {
 	if [ "$_nomakepkg_nover" = "true" ] ; then
 	  _nomakepkg_pkgname="${pkgname}"
@@ -188,6 +195,7 @@ _package_nomakepkg() {
 
 	# wine-tkg path scripts - Might be useful for external builds when using weird env vars - Also workarounds wrong paths issues on non-Arch distros
 	cp -v "$_where"/wine-tkg-scripts/wine-tkg "$_prefix"/bin/wine-tkg
+	cp -v "$_where"/wine-tkg-scripts/wine64-tkg "$_prefix"/bin/wine64-tkg
 	cp -v "$_where"/wine-tkg-scripts/wine-tkg-interactive "$_prefix"/bin/wine-tkg-interactive
 
 	# strip
@@ -211,6 +219,10 @@ _package_nomakepkg() {
 	  pkgdir="$_where/non-makepkg-builds/${_nomakepkg_pkgname}"
 	else
 	  pkgdir="${_nomakepkg_prefix_path}/${_nomakepkg_pkgname}"
+	fi
+
+	if [ "$_GENERATE_DEBIAN_PACKAGE" = "true" ]; then
+		_generate_debian_package "$_prefix"
 	fi
 
 	if [ "$_use_esync" = "true" ] || [ "$_staging_esync" = "true" ]; then
@@ -318,9 +330,14 @@ _package_makepkg() {
 
 	# wine-tkg path scripts - Might be useful for external builds when using weird env vars - Also workarounds wrong paths issues on non-Arch distros
 	cp "$_where"/wine-tkg-scripts/wine-tkg "${pkgdir}$_prefix"/bin/wine-tkg
+	cp "$_where"/wine-tkg-scripts/wine64-tkg "${pkgdir}$_prefix"/bin/wine64-tkg
 	cp "$_where"/wine-tkg-scripts/wine-tkg-interactive "${pkgdir}$_prefix"/bin/wine-tkg-interactive
 
 	cp "$_where"/last_build_config.log "${pkgdir}$_prefix"/share/wine/wine-tkg-config.txt
+
+	if [ "$_GENERATE_DEBIAN_PACKAGE" = "true" ]; then
+		_generate_debian_package "$_prefix"
+	fi
 
 	if [ "$_use_esync" = "true" ] || [ "$_staging_esync" = "true" ]; then
 	  msg2 '##########################################################################################################################'

--- a/wine-tkg-git/wine-tkg-scripts/package-debian.sh
+++ b/wine-tkg-git/wine-tkg-scripts/package-debian.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+files=$1
+prefix=$2
+output=$3
+name=$4
+pkgver=$5
+pkgname=$6
+tmpDir=/tmp/debian-package
+
+# TODO: Support different prefixes
+if [ "$prefix" != "/usr" ]; then
+    echo "Sorry, $prefix as prefix is not supported yet in wine-tkg packaging for Debian on Arch"
+    exit
+fi
+
+# Filesystem that can be found in $files
+lib32name="lib32"
+lib64name="lib"
+
+rm -rf $tmpDir || true
+mkdir $tmpDir
+
+# Package format version number
+echo "2.0" > $tmpDir/debian-binary
+
+# TODO FIX: Make wine64-tkg the default as "wine64", the problem is it causes wine to complain about wine64
+# Make wine-tkg and wine64-tkg the default
+mv "$files"/usr/bin/wine "$files"/usr/bin/_wine
+#mv "$files"/usr/bin/wine64 "$files"/usr/bin/_wine64
+cp "$files"/usr/bin/wine-tkg "$files"/usr/bin/wine
+#cp "$files"/usr/bin/wine64-tkg "$files"/usr/bin/wine64
+
+# Move the resulting build folders to match debian's filesystem
+mkdir "$files"/usr/lib32_
+cp -r "$files"/usr/$lib32name/* "$files"/usr/lib32_
+rm -r "$files"/usr/$lib32name
+mkdir "$files"/usr/lib64_
+cp -r "$files"/usr/$lib64name/* "$files"/usr/lib64_
+rm -r "$files"/usr/$lib64name
+mkdir "$files"/usr/lib
+mkdir "$files"/usr/lib/wine
+cp -r "$files"/usr/bin/* "$files"/usr/lib/wine
+mkdir "$files"/usr/lib/i386-linux-gnu
+mkdir "$files"/usr/lib/x86_64-linux-gnu
+cp -r "$files"/usr/lib32_/* "$files"/usr/lib/i386-linux-gnu && rm -r "$files"/usr/lib32_/*
+cp -r "$files"/usr/lib64_/* "$files"/usr/lib/x86_64-linux-gnu && rm -r "$files"/usr/lib64_/*
+rm -r "$files"/usr/lib32_
+rm -r "$files"/usr/lib64_
+
+# Files
+tar --exclude='.[^/]*' -czf $tmpDir/data.tar.gz -C "$files" ./ >> /dev/null
+
+# Revert "Move the resulting build folders to match debian's filesystem"
+mkdir "$files"/usr/lib64_
+mkdir "$files"/usr/lib32_
+cp -r "$files"/usr/lib/x86_64-linux-gnu/* "$files"/usr/lib64_
+cp -r "$files"/usr/lib/i386-linux-gnu/* "$files"/usr/lib32_
+rm -r "$files"/usr/lib
+mkdir "$files"/usr/$lib64name
+mkdir "$files"/usr/$lib32name
+cp -r "$files"/usr/lib64_/* "$files"/usr/$lib64name
+cp -r "$files"/usr/lib32_/* "$files"/usr/$lib32name
+rm -r "$files"/usr/lib64_
+rm -r "$files"/usr/lib32_
+
+# Revert "Make wine-tkg and wine64-tkg the default"
+#rm "$files"/usr/bin/wine64
+rm "$files"/usr/bin/wine
+#mv "$files"/usr/bin/_wine64 "$files"/usr/bin/wine64
+mv "$files"/usr/bin/_wine "$files"/usr/bin/wine
+
+# Control file
+mkdir $tmpDir/control
+cat >$tmpDir/control/control <<EOL
+Package: ${pkgname}
+Version: ${pkgver}
+Architecture: all
+Maintainer: Tk-Glitch <ti3nou@gmail.com>
+Homepage: https://github.com/Frogging-Family/wine-tkg-git
+Provides: ${pkgname}, wine, wine-development, wine-staging, libwine, fonts-wine, wine32, wine64
+Conflicts: wine, libwine, fonts-wine, wine32, wine64
+Replaces: wine, wine-development, wine-staging, libwine, fonts-wine, wine32, wine64
+License: LGPL
+Depends: libc6 (>= 2.17), libfontconfig1 (>= 2.11), libfreetype6 (>= 2.2.1), libncurses5 (>= 6), libasound2 (>= 1.0.16), libgcc1 (>= 1:3.0), libglu1-mesa | libglu1, liblcms2-2 (>= 2.2+git20110628), libldap-2.4-2 (>= 2.4.7), libmpg123-0 (>= 1.6.2), libopenal1 (>= 1.14), libpcap0.8 (>= 0.9.8), libpulse0 (>= 0.99.1), libx11-6, libxext6, libxml2 (>= 2.9.0), ocl-icd-libopencl1 | libopencl1, ocl-icd-libopencl1 (>= 1.0) | libopencl-1.1-1, zlib1g (>= 1:1.1.4)
+Installed-Size: $(du -sb ${files} | awk '{printf "%1.0f\n",$1/1024}')
+Description: 🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸
+EOL
+tar czf $tmpDir/control.tar.gz -C $tmpDir/control ./ >> /dev/null
+rm -r $tmpDir/control
+
+# Create .deb file
+prev=$PWD
+cd $tmpDir
+ar -r $name debian-binary control.tar.gz data.tar.gz &> /dev/null
+# TODO: better solution
+cp $name "$output"
+cd $prev
+
+rm -rf $tmpDir
+cd ..

--- a/wine-tkg-git/wine-tkg-scripts/package-debian.sh
+++ b/wine-tkg-git/wine-tkg-scripts/package-debian.sh
@@ -84,7 +84,7 @@ Replaces: wine, wine-development, wine-staging, libwine, fonts-wine, wine32, win
 License: LGPL
 Depends: libc6 (>= 2.17), libfontconfig1 (>= 2.11), libfreetype6 (>= 2.2.1), libncurses5 (>= 6), libasound2 (>= 1.0.16), libgcc1 (>= 1:3.0), libglu1-mesa | libglu1, liblcms2-2 (>= 2.2+git20110628), libldap-2.4-2 (>= 2.4.7), libmpg123-0 (>= 1.6.2), libopenal1 (>= 1.14), libpcap0.8 (>= 0.9.8), libpulse0 (>= 0.99.1), libx11-6, libxext6, libxml2 (>= 2.9.0), ocl-icd-libopencl1 | libopencl1, ocl-icd-libopencl1 (>= 1.0) | libopencl-1.1-1, zlib1g (>= 1:1.1.4)
 Installed-Size: $(du -sb ${files} | awk '{printf "%1.0f\n",$1/1024}')
-Description: This "Wine to rule them all" package is the result of some random pkgbuild found online. Looks safe to me, amirite? Some variants of it can be found in lutris runners. 🐸🐸🐸🐸🐸🐸🐸🐸
+Description: This "Wine to rule them all" package is the result of wine-tkg build system found online. Some variants of it can be found in lutris runners. 🐸🐸🐸🐸🐸🐸🐸🐸
 EOL
 tar czf $tmpDir/control.tar.gz -C $tmpDir/control ./ >> /dev/null
 rm -r $tmpDir/control

--- a/wine-tkg-git/wine-tkg-scripts/package-debian.sh
+++ b/wine-tkg-git/wine-tkg-scripts/package-debian.sh
@@ -84,7 +84,7 @@ Replaces: wine, wine-development, wine-staging, libwine, fonts-wine, wine32, win
 License: LGPL
 Depends: libc6 (>= 2.17), libfontconfig1 (>= 2.11), libfreetype6 (>= 2.2.1), libncurses5 (>= 6), libasound2 (>= 1.0.16), libgcc1 (>= 1:3.0), libglu1-mesa | libglu1, liblcms2-2 (>= 2.2+git20110628), libldap-2.4-2 (>= 2.4.7), libmpg123-0 (>= 1.6.2), libopenal1 (>= 1.14), libpcap0.8 (>= 0.9.8), libpulse0 (>= 0.99.1), libx11-6, libxext6, libxml2 (>= 2.9.0), ocl-icd-libopencl1 | libopencl1, ocl-icd-libopencl1 (>= 1.0) | libopencl-1.1-1, zlib1g (>= 1:1.1.4)
 Installed-Size: $(du -sb ${files} | awk '{printf "%1.0f\n",$1/1024}')
-Description: 🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸🐸
+Description: This "Wine to rule them all" package is the result of some random pkgbuild found online. Looks safe to me, amirite? Some variants of it can be found in lutris runners. 🐸🐸🐸🐸🐸🐸🐸🐸
 EOL
 tar czf $tmpDir/control.tar.gz -C $tmpDir/control ./ >> /dev/null
 rm -r $tmpDir/control

--- a/wine-tkg-git/wine-tkg-scripts/wine-tkg-interactive
+++ b/wine-tkg-git/wine-tkg-scripts/wine-tkg-interactive
@@ -14,6 +14,11 @@ else
   LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32:$LD_LIBRARY_PATH"
 fi
 
+# Debian-based distros
+if [ -f "/etc/debian_version" ]; then
+  export WINEDLLPATH="/usr/lib/x86_64-linux-gnu/wine:/usr/lib/i386-linux-gnu/wine"
+fi
+
 cat << 'EOM'
        .---.`               `.---.
     `/syhhhyso-           -osyhhhys/`

--- a/wine-tkg-git/wine-tkg-scripts/wine64-tkg
+++ b/wine-tkg-git/wine-tkg-scripts/wine64-tkg
@@ -41,8 +41,8 @@ cat << 'EOM'
 
 EOM
 
-if [ -x "$(command -v _wine)" ]; then
-  _wine ${@:1}
+if [ -x "$(command -v _wine64)" ]; then
+  _wine64 ${@:1}
 else
-  wine ${@:1}
+  wine64 ${@:1}
 fi


### PR DESCRIPTION
This allows wine-tkg to create debian packages on arch
Can be enabled with _GENERATE_DEBIAN_PACKAGE in config

TODO: Support different prefixes than /usr
TODO FIX: Make wine64-tkg the default as "wine64", the problem is it causes wine to complain about wine64 (invalid ELF header I think)

I didn't fully test this, but winecfg and wine explorer.exe works.
Hope this will be useful for people using Debian-based distros