### PR TITLE
Fix version tags not getting applied.

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -2017,7 +2017,8 @@ _polish() {
 	      _version_tags+=(Vkd3d)
 	    fi
 	  fi
-	  sed -i "s/\\\1/\\\1  ( ${_version_tags[*]} )/g" "${srcdir}"/"${_winesrcdir}"/libs/wine/Makefile.in
+	  sed -i "s/\"\\\1.*\"/\"\\\1  ( ${_version_tags[*]} )\"/g" "${srcdir}"/"${_winesrcdir}"/libs/wine/Makefile.in
+	  sed -i "s/\"\\\1.*\"/\"\\\1  ( ${_version_tags[*]} )\"/g" "${srcdir}"/"${_winesrcdir}"/dlls/ntdll/Makefile.in
 	fi
 
 	# fix path of opencl headers


### PR DESCRIPTION
Fixes output of `wine --version` not showing version tags, which in turn fixes various checks in Lutris.