### PR TITLE
Add package name check to replaces declaration

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -862,7 +862,9 @@ else
     "wine-esync=$pkgver"
   )
   conflicts=('wine' 'wine-wow64' 'wine-staging' 'wine-esync')
-  replaces=("${pkgname/%-git/-faudio-git}")
+  if [[ "$pkgname" == *-git ]]; then
+    replaces=("${pkgname/%-git/-faudio-git}")
+  fi
 fi
 
 if [ -n "$_localbuild" ]; then


### PR DESCRIPTION
Fixes cases like 'protonified' preset, which produce a package
named 'wine-tkg-git-protonified', and then have a replaces that
points at the same package name, which does funny things when
you add builds to a custom repo, like constantly asking you to
re-download and re-install the package.