### PR TITLE
Add an other warning for League of Legends

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -395,6 +395,7 @@ fi
 if ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor c81093882b2b9ce4a5830437cecdc58b8807d29b HEAD ) && [ "$_lol920_fix" = "true" ]; then
   warning "The _lol920_fix option breaks on your current tree and has been disabled. Please use an older Wine version until a solution is found."
   warning "To use the last known working version, please set _staging_version=\"c81093882b2b9ce4a5830437cecdc58b8807d29b\" in your .cfg (requires _use_staging=\"true\") - Older commits would also work."
+  warning "To start the client (since the patch 10.19), please set _NOMINGW=\"true\" in wine-tkg-profiles/advanced-customization.cfg - https://github.com/M-Reimer/wine-lol/commit/72340aad3e23b71047ace1b05ef4e183fb99d5ff"
   _lol920_fix="false"
 fi
 


### PR DESCRIPTION
As I indicated in this thread https://github.com/Frogging-Family/wine-tkg-git/issues/59#issuecomment-694166096 but we shouldn't force this option. I think that it's a bit contrary to what you want so I suggest this simple solution