### PR TITLE
Proton-tkg: Add vulkan-headers as make dependency

### DIFF
--- a/proton-tkg/PKGBUILD
+++ b/proton-tkg/PKGBUILD
@@ -64,6 +64,7 @@ makedepends=(
     'glslang'               'wget'
     'ocl-icd'               'lib32-ocl-icd'
     'opencl-headers'        'mingw-w64-gcc'
+    'vulkan-headers'
     $_user_makedeps
 )
 optdepends=(


### PR DESCRIPTION
Looks like it's needed for vrclient build otherwise vrclient build fails on `<vulkan/vulkan.h>` include (and then steam fails to launch games with proton-tkg)