### PR TITLE
proton-tkg: Remove "latest" DXVK option which downloads from git.froggi.es

### DIFF
--- a/proton-tkg/proton-tkg-profiles/sample-external-config.cfg
+++ b/proton-tkg/proton-tkg-profiles/sample-external-config.cfg
@@ -142,7 +142,7 @@ _configure_userargs32="--with-x --with-gstreamer --with-xattr"
 _use_staging="true"
 _staging_version=""
 
-# You can set _use_dxvk to either "prebuilt" (for builds made with dxvk-tools for example), "latest" (latest artifact from git.froggi.es), "release" (using github's latest) or "false" (disabled)
+# You can set _use_dxvk to either "prebuilt" (for builds made with dxvk-tools for example), "release" (using github's latest) or "false" (disabled)
 # Setting it to "true" will default to "release"
 _use_dxvk="git"
 

--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -40,7 +40,6 @@ _proton_winetricks="false"
 # Valid options::
 # "git" - Recommended and default - Will build current master with dxvk_config patch to allow for enhanced vkd3d compatibility
 # "prebuilt" - For builds made with dxvk-tools for example
-# "latest" - latest artifact from git.froggi.es
 # "release" - using github's latest
 # "false" - disabled
 # Setting it to "true" will default to "release"

--- a/proton-tkg/proton-tkg.sh
+++ b/proton-tkg/proton-tkg.sh
@@ -380,47 +380,36 @@ function setup_dxvk_version_url {
 
 function download_dxvk_version {
   while true ; do
-      if [ "$_use_dxvk" = "latest" ]; then
+      setup_dxvk_version_url
+      # If anything goes wrong we get exit code 22 from "curl -f"
+      set +e
+      _dxvk_version_response=$(curl -s -f "$_dxvk_version_url")
+      _dxvk_version_response_status=$?
+      set -e
+      if [ $_dxvk_version_response_status -eq 0 ]; then
         echo "#######################################################"
         echo ""
-        echo " Downloading latest DXVK artifact from git.froggi.es for you..."
+        echo " Downloading ${_dxvk_version} DXVK release from github for you..."
         echo ""
         echo "#######################################################"
         echo ""
-        wget -q -O dxvk-latest-artifact.zip "https://git.froggi.es/doitsujin/dxvk/-/jobs/artifacts/master/download?job=dxvk"
+        echo "$_dxvk_version_response" \
+        | grep "browser_download_url.*tar.gz" \
+        | cut -d : -f 2,3 \
+        | tr -d \" \
+        | wget -qi -
         break
       else
-        setup_dxvk_version_url
-        # If anything goes wrong we get exit code 22 from "curl -f"
-        set +e
-        _dxvk_version_response=$(curl -s -f "$_dxvk_version_url")
-        _dxvk_version_response_status=$?
-        set -e
-        if [ $_dxvk_version_response_status -eq 0 ]; then
-          echo "#######################################################"
-          echo ""
-          echo " Downloading ${_dxvk_version} DXVK release from github for you..."
-          echo ""
-          echo "#######################################################"
-          echo ""
-          echo "$_dxvk_version_response" \
-          | grep "browser_download_url.*tar.gz" \
-          | cut -d : -f 2,3 \
-          | tr -d \" \
-          | wget -qi -
-          break
-        else
-          echo ""
-          echo "#######################################################"
-          echo ""
-          echo " Could not download specified DXVK version (${_dxvk_version})"
-          echo ""
-          echo "#######################################################"
-          echo ""
-          echo "Please select DXVK release version (ex: v1.6.1)"
-          read -rp "> [latest]: " _dxvk_version
-          echo ""
-        fi
+        echo ""
+        echo "#######################################################"
+        echo ""
+        echo " Could not download specified DXVK version (${_dxvk_version})"
+        echo ""
+        echo "#######################################################"
+        echo ""
+        echo "Please select DXVK release version (ex: v1.6.1)"
+        read -rp "> [latest]: " _dxvk_version
+        echo ""
       fi
   done
 }


### PR DESCRIPTION
git.froggi.es was changed from GitLab to Gitea and no longer has DXVK artifacts