### PR TITLE
Update FFXIV patch so it works again

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/game-specific/ffxiv-launcher-workaround.patch
+++ b/wine-tkg-git/wine-tkg-patches/game-specific/ffxiv-launcher-workaround.patch
@@ -15,12 +15,9 @@ diff -urN a/dlls/ntdll/misc.c a/dlls/ntdll/misc.c
 diff -urN a/dlls/ntdll/ntdll.spec a/dlls/ntdll/ntdll.spec
 --- a/dlls/ntdll/ntdll.spec	2019-04-24 18:23:50 +0900
 +++ a/dlls/ntdll/ntdll.spec	2019-04-24 18:48:37 +0900
-@@ -1537,6 +1537,8 @@
- 
- # signal handling
- @ cdecl __wine_set_signal_handler(long ptr)
+@@ -1630,3 +1631,5 @@
+ # Filesystem
+ @ cdecl -syscall wine_nt_to_unix_file_name(ptr ptr ptr long)
+ @ cdecl -syscall wine_unix_to_nt_file_name(str ptr ptr)
 +
 +@ cdecl IsTransgaming()
- 
- # Filesystem
- @ cdecl wine_nt_to_unix_file_name(ptr ptr long long)


### PR DESCRIPTION
FFXIV patch was broken due to the extensive changes that have happened with ntdll over the past many months.

This small fix should make that go away. Until it breaks again...

I don't know what commit the current FFXIV patch successfully applies to, and I don't know how to figure that out, so can I leave that to you? frog_donut