### PR TITLE
Small fix

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-cpu-topology-overrides.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-cpu-topology-overrides.patch
@@ -394,15 +394,16 @@ index ca5dac43bb0..bc6a5451611 100644
  
      if (NtCurrentTeb()->Peb->NumberOfProcessors > 1)
 diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
-index a3a418cfaa5..8edd529afd8 100644
+index 39ab7912490..b29de19ec8e 100644
 --- a/dlls/ntdll/unix/unix_private.h
 +++ b/dlls/ntdll/unix/unix_private.h
-@@ -247,6 +247,7 @@ extern NTSTATUS open_unix_file( HANDLE *handle, const char *unix_name, ACCESS_MA
+@@ -279,6 +279,7 @@ extern NTSTATUS open_unix_file( HANDLE *handle, const char *unix_name, ACCESS_MA
                                  ULONG options, void *ea_buffer, ULONG ea_length ) DECLSPEC_HIDDEN;
  extern void init_files(void) DECLSPEC_HIDDEN;
  extern void init_cpu_info(void) DECLSPEC_HIDDEN;
 +extern struct cpu_topology_override *get_cpu_topology_override(void) DECLSPEC_HIDDEN;
- 
+ extern void add_completion( HANDLE handle, ULONG_PTR value, NTSTATUS status, ULONG info, BOOL async ) DECLSPEC_HIDDEN;
+
  extern void dbg_init(void) DECLSPEC_HIDDEN;
  
 diff --git a/include/wine/server_protocol.h b/include/wine/server_protocol.h


### PR DESCRIPTION
Wine updated unix_private.h a bit, and it causes the patch to fail. So I just fixed it, it's the same I just changed it to fit the new line numbers and layout of the orig file. Tested and applies cleanly.