### PR TITLE
Hotfixer: Also revert 1ccab71 when reverting 414b31b (Fix #440)

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -532,9 +532,16 @@ if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 414b31bc0bb
   fi
   if [[ "$_hotfixansw_414b" =~ [yY] ]] || [ "$_hotfixes_no_confirm" = "true" ] && [ "$_hotfixansw_414b" != "n" ]; then
     if [ "$_hotfixes_no_confirm" = "true" ]; then
-      warning "Hotfix: Revert 414b31b to fix battle.net"
+      if ( git merge-base --is-ancestor 1ccab719ee6e87b7399876d4d5b30eb889c49e32 HEAD ); then
+        warning "Hotfix: Revert 414b31b and 1ccab71 to fix battle.net"
+      else
+        warning "Hotfix: Revert 414b31b to fix battle.net"
+      fi
     fi
     _hotfix_mainlinereverts+=(414b31bc0bbbfe005e90a1946a649082dc303c55)
+    if ( git merge-base --is-ancestor 1ccab719ee6e87b7399876d4d5b30eb889c49e32 HEAD ); then
+      _hotfix_mainlinereverts+=(1ccab719ee6e87b7399876d4d5b30eb889c49e32)
+    fi
   fi
 fi
 


### PR DESCRIPTION
I tested it and the build completed successfully. Fix #440

@openglfreak said he also did a fix for wine-tkg but I did this pull request just in case.
