### PR TITLE
Skip another patch.

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
@@ -3,7 +3,15 @@
 if [ -d "${srcdir}"/"${_stgsrcdir}" ]; then
     # Community Patches
     
-    # Disable the roblox_fix patch if the Wine version already contains the patch.
+    # Disable Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx patch if the Wine version selected already contains the patch.
+    # NOTE: These patches are not the same.
+    # However, they both add the same text to the same file, with the upstream commit also adding some other stuff.
+    if [[ ${_community_patches[*]} =~ "Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx.mypatch" ]] && ( git merge-base --is-ancestor 0a366f7e4a68c9375b54ace5289989bd81b65d22 $(../"$_stgsrcdir"/patches/patchinstall.sh --upstream-commit) > /dev/null ); then
+      warning "Disabling the Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx community patch because the patch is already in the Wine version selected."
+      _community_patches=$(echo $_community_patches | sed "s/Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx.mypatch//g" | tr -s " ")
+    fi    
+    
+    # Disable the roblox_fix patch if the Wine version selected already contains the patch.
     if [[ ${_community_patches[*]} =~ "roblox_fix.mypatch" ]] && ( git merge-base --is-ancestor 29e1494c72041f3d2ee89e89eff17877df7cabd2 $(../"$_stgsrcdir"/patches/patchinstall.sh --upstream-commit) > /dev/null ); then
       warning "Disabling the roblox_fix community patch because the patch is already in the Wine version selected."
       _community_patches=$(echo $_community_patches | sed "s/roblox_fix.mypatch//g" | tr -s " ")

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
@@ -3,9 +3,8 @@
 if [ -d "${srcdir}"/"${_stgsrcdir}" ]; then
     # Community Patches
     
-    # Disable Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx patch if the Wine version selected already contains the patch.
-    # NOTE: These patches are not the same.
-    # However, they both add the same text to the same file, with the upstream commit also adding some other stuff.
+    # Disable Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx patch if the Wine version selected already contains the commit which implements it.
+    # NOTE: The patch and the commit are not the same, but this is only because the commit adds some other stuff on top of the patch.
     if [[ ${_community_patches[*]} =~ "Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx.mypatch" ]] && ( git merge-base --is-ancestor 0a366f7e4a68c9375b54ace5289989bd81b65d22 $(../"$_stgsrcdir"/patches/patchinstall.sh --upstream-commit) > /dev/null ); then
       warning "Disabling the Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx community patch because the patch is already in the Wine version selected."
       _community_patches=$(echo $_community_patches | sed "s/Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx.mypatch//g" | tr -s " ")


### PR DESCRIPTION
Skips the Add-SORT_DIGITSAS-UMBERS-flag-to-CompareStringsEx patch if the commit that fixes it is in the Wine version selected.

The upstream commit and the patch are not the same, but the commit still adds everything the patch does, plus some extra stuff.