### PR TITLE
fix wine_is_running function hang when CI used

### DIFF
--- a/.github/workflows/proton-arch.yml
+++ b/.github/workflows/proton-arch.yml
@@ -1,0 +1,28 @@
+name: Proton Arch Linux CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Compile
+        run: |
+          echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
+          pacman -Syu --noconfirm base-devel sudo lib32-jack2
+          useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          chown user -R ..
+          chown user -R /tmp
+          export CARGO_HOME="$PWD"
+          cd proton-tkg
+          su user -c "yes ''|PKGDEST=/tmp/proton-tkg makepkg --noconfirm -s"
+
+      - name: Archive the artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: proton-tkg-build
+          path: /tmp/proton-tkg

--- a/proton-tkg/proton-tkg.sh
+++ b/proton-tkg/proton-tkg.sh
@@ -510,11 +510,10 @@ function steam_is_running {
 }
 
 function wine_is_running {
-  if pgrep -x wineserver >/dev/null; then
-    echo -e "\n Wineserver is running. Waiting for it to finish..."
-    sleep 3
-    wine_is_running
-  fi
+  pidof -q wineserver || return 0
+  echo -e "\n Wineserver is running. Waiting for it to finish..."
+  sleep 3
+  wine_is_running
 }
 
 function proton_tkg_uninstaller {


### PR DESCRIPTION
It builds well after this small change.
Here action:
<details> <summary>proton-arch.yml</summary> 

``` yaml
name: Proton Arch Linux CI

on:
  workflow_dispatch:

jobs:
  build:
    runs-on: ubuntu-latest
    container: archlinux:latest

    steps:
      - uses: actions/checkout@v2
      - name: Compile
        run: |
          echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
          pacman -Syu --noconfirm base-devel sudo lib32-jack2
          useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
          chown user -R ..
          chown user -R /tmp
          export CARGO_HOME="$PWD"
          cd proton-tkg
          su user -c "yes ''|PKGDEST=/tmp/proton-tkg makepkg --noconfirm -s"

      - name: Archive the artifacts
        uses: actions/upload-artifact@v2
        with:
          name: proton-tkg-build
          path: /tmp/proton-tkg
```