### PR TITLE
Update build.sh

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -75,6 +75,7 @@ _build() {
 	  msg2 'Building Wine-64...'
 	  cd  "${srcdir}"/"${pkgname}"-64-build
 	  if [ "$_NUKR" != "debug" ] || [[ "$_DEBUGANSW3" =~ [yY] ]]; then
+	  chmod +x ../"${_winesrcdir}"/configure
 	    ../"${_winesrcdir}"/configure \
 		    --prefix="$_prefix" \
 			--enable-win64 \


### PR DESCRIPTION
Fixing "wine-tkg-git/wine-tkg-scripts/build.sh: line 79: ../wine-mirror-git/configure: Permission Denied" error in Manjaro Linux