### PR TITLE
Hotfixer: Remove a TRACE in the DXGIGetDebugInterface1 stub causing segfaults.

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/08cccb5/08cccb5.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/08cccb5/08cccb5.mypatch
@@ -1,0 +1,12 @@
+--- a/dlls/dxgi/dxgi_main.c	
++++ a/dlls/dxgi/dxgi_main.c
+@@ -251,8 +251,6 @@ HRESULT WINAPI DXGID3D10RegisterLayers(const struct dxgi_device_layer *layers, UINT layer_count)
+ 
+ HRESULT WINAPI DXGIGetDebugInterface1(UINT flags, REFIID iid, void **debug)
+ {
+-    TRACE("flags %#x, iid %s, debug %p.\n", flags, debugstr_guid(iid), debug);
+-
+     WARN("Returning E_NOINTERFACE.\n");
+     return E_NOINTERFACE;
+ }
+

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/08cccb5/a608ef1.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/08cccb5/a608ef1.mypatch
@@ -1,0 +1,12 @@
+--- a/dlls/dxgi/dxgi_main.c	
++++ a/dlls/dxgi/dxgi_main.c
+@@ -268,8 +268,6 @@ HRESULT WINAPI DXGID3D10RegisterLayers(const struct dxgi_device_layer *layers, UINT layer_count)
+ 
+ HRESULT WINAPI DXGIGetDebugInterface1(UINT flags, REFIID iid, void **debug)
+ {
+-    TRACE("flags %#x, iid %s, debug %p.\n", flags, debugstr_guid(iid), debug);
+-
+     WARN("Returning DXGI_ERROR_SDK_COMPONENT_MISSING.\n");
+     return DXGI_ERROR_SDK_COMPONENT_MISSING;
+ }
+

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -861,6 +861,16 @@ if [ "$_use_staging" = "true" ] && [ "$_proton_fs_hack" = "true" ] && ( cd "${sr
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/01150d7f/x11drv1)
 fi
 
+# DXGIGetDebugInterface1 TRACE try to read values memory address of parameters, but those are not always memory addresses.
+if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 08cccb522f19b3dc5b397f7c1c519604b601cee0 HEAD); then
+  warning "Hotfix: Remove a TRACE in the DXGIGetDebugInterface1 stub causing segfaults."
+  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor a608ef1f2d9db962bcf2f47bc026144c0148ed41 HEAD); then
+    _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/08cccb5/a608ef1)
+  else
+    _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/08cccb5/08cccb5)
+  fi
+fi
+
 # WINEDEBUG crash - legacy
 if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor ca13f489e18fb1f7944e3bdcfdfc4a810bf80994 HEAD ) && ( cd "${srcdir}"/"${_stgsrcdir}" && ! git merge-base --is-ancestor a1bda115af8ad3484b7c17eac7da74e4906fa9e4 HEAD ); then
   if [ "$_hotfixes_no_confirm" != "true" ] && [ "$_hotfixes_no_confirm" != "ignore" ]; then


### PR DESCRIPTION
This error was triggered by the unity crash reporter.

I tried and tested the patch before posting the pull request, and I can say the error reporter is no longer crashing...  
I can't say the same thing for the game.

I know it's not a lot but I hope it helps.
Also since I saw you liked to support old wine versions, I tried to make it support old versions too.