### PR TITLE
Partially enable linker time optimization.

### DIFF
--- a/proton-tkg/proton-tkg-profiles/advanced-customization.cfg
+++ b/proton-tkg/proton-tkg-profiles/advanced-customization.cfg
@@ -70,7 +70,7 @@ CUSTOM_GCC_PATH=""
 
 _LOCAL_OPTIMIZED="true"
 _GCC_FLAGS="-O2 -ftree-vectorize"
-_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"
+_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed -flto"
 _CROSS_FLAGS="-O2 -ftree-vectorize"
 _CROSS_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"
 _NUKR="true"

--- a/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
@@ -47,7 +47,7 @@ _LOCAL_OPTIMIZED="true"
 # Custom GCC flags to use instead of system-wide makepkg flags set in /etc/makepkg.conf. Default is "-pipe -O2 -ftree-vectorize". Don't use -march=native if you want to share your builds accross different machines!
 _GCC_FLAGS="-O2 -ftree-vectorize"
 # Custom LD flags to use instead of system-wide makepkg flags set in /etc/makepkg.conf. Default is "-pipe -O2 -ftree-vectorize".
-_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"
+_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed -flto"
 # Same as _GCC_FLAGS but for cross-compiled binaries.
 _CROSS_FLAGS="-O2 -ftree-vectorize"
 # Same as _LD_FLAGS but for cross-compiled binaries.


### PR DESCRIPTION
Partial because when added to `_CROSS_LD_FLAGS` it crash the build, but on `_LD_FLAGS` it work fine.

I found out about LTO because in the document @123-123-nil attached in the #519 issue about PGO.