### PR TITLE
Enable building with Clang

### DIFF
--- a/proton-tkg/proton-tkg-profiles/advanced-customization.cfg
+++ b/proton-tkg/proton-tkg-profiles/advanced-customization.cfg
@@ -77,6 +77,14 @@ _NUKR="true"
 _NOCOMPILE="false"
 _NOINITIALPROMPT="false"
 
+# Replace with "clang" and "clang++" to use LLVM Clang
+_C_COMPILER="gcc"
+_CXX_COMPILER="g++"
+
+# Replace with "clang" (for both) to use LLVM Clang
+_CROSS_C_COMPILER_64="x86_64-w64-mingw32-gcc"
+_CROSS_C_COMPILER_32="i686-w64-mingw32-gcc"
+
 # Optionally set additional make dependencies for makepkg builds. Multiple elements should be separated by a space.
 # Only affect makepkg
 _user_makedeps=""

--- a/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
@@ -53,6 +53,14 @@ _CROSS_FLAGS="-O2 -ftree-vectorize"
 # Same as _LD_FLAGS but for cross-compiled binaries.
 _CROSS_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"
 
+# Replace with "clang" and "clang++" to use LLVM Clang
+_C_COMPILER="gcc"
+_CXX_COMPILER="g++"
+
+# Replace with "clang" (for both) to use LLVM Clang
+_CROSS_C_COMPILER_64="x86_64-w64-mingw32-gcc"
+_CROSS_C_COMPILER_32="i686-w64-mingw32-gcc"
+
 # By default, tests are disabled to speed up compilation. If you need them for development purposes, set to "true"
 _ENABLE_TESTS="false"
 

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -62,11 +62,16 @@ _build() {
 	  # build wine 64-bit
 	  # (according to the wine wiki, this 64-bit/32-bit building order is mandatory)
 	  if [[ ! ${_makepkg_options[*]} =~ "ccache" ]] && [ -e /usr/bin/ccache ]; then
-	    export CC="ccache gcc" && echo "CC = ${CC}" >> "$_where"/last_build_config.log
-	    export CXX="ccache g++" && echo "CXX = ${CXX}" >> "$_where"/last_build_config.log
+	    export CC="ccache $_C_COMPILER" && echo "CC = ${CC}" >> "$_where"/last_build_config.log
+	    export CXX="ccache $_CXX_COMPILER" && echo "CXX = ${CXX}" >> "$_where"/last_build_config.log
+	  else
+		export CC="$_C_COMPILER" && echo "CC = ${CC}" >> "$_where"/last_build_config.log
+	    export CXX="$_CXX_COMPILER" && echo "CXX = ${CXX}" >> "$_where"/last_build_config.log
 	  fi
 	  if [ -e /usr/bin/ccache ] && [ "$_NOMINGW" != "true" ]; then
-	    export CROSSCC="ccache x86_64-w64-mingw32-gcc" && echo "CROSSCC64 = ${CROSSCC}" >> "$_where"/last_build_config.log
+	    export CROSSCC="ccache $_CROSS_C_COMPILER_64" && echo "CROSSCC64 = ${CROSSCC}" >> "$_where"/last_build_config.log
+	  else
+	  	export CROSSCC="$_CROSS_C_COMPILER_64" && echo "CROSSCC64 = ${CROSSCC}" >> "$_where"/last_build_config.log
 	  fi
 	  # If /usr/lib32 doesn't exist (such as on Fedora), make sure we're using /usr/lib64 for 64-bit pkgconfig path
 	  if [ ! -d '/usr/lib32' ]; then
@@ -103,11 +108,16 @@ _build() {
 	  fi
 	  # /nomakepkg
 	  if [[ ! ${_makepkg_options[*]} =~ "ccache" ]] && [ -e /usr/bin/ccache ]; then
-	    export CC="ccache gcc"
-	    export CXX="ccache g++"
+	    export CC="ccache $_C_COMPILER"
+	    export CXX="ccache $_CXX_COMPILER"
+	  else
+		export CC="$_C_COMPILER"
+	    export CXX="$_CXX_COMPILER"
 	  fi
 	  if [ -e /usr/bin/ccache ] && [ "$_NOMINGW" != "true" ]; then
-	    export CROSSCC="ccache i686-w64-mingw32-gcc" && echo "CROSSCC32 = ${CROSSCC}" >> "$_where"/last_build_config.log
+	    export CROSSCC="ccache $_CROSS_C_COMPILER_32" && echo "CROSSCC32 = ${CROSSCC}" >> "$_where"/last_build_config.log
+	  else
+	  	export CROSSCC="$_CROSS_C_COMPILER_32" && echo "CROSSCC32 = ${CROSSCC}" >> "$_where"/last_build_config.log
 	  fi
 	  # build wine 32-bit
 	  if [ -d '/usr/lib32/pkgconfig' ]; then # Typical Arch path


### PR DESCRIPTION
I toyed around building wine with Clang,

Note that wine has two parts: native and cross-compiled for windows, and the compiler can be arbitrarily chosen for each part. This change enables choosing which compiler for which part. The wine build system supports clang when it detects that the user asked for it.

It indeed produces a functional wine when building wine-mainline without any extra patch, otherwise staging produces errors. And, if using all wine-tkg patches, the `steam.patch` makes an error with `lld-link: error: undefined symbol: _StrStrW`. I do not know if there would be more if that one gets fixed.

Another issue, the produced `wine` executable is 2GB, I guess the stripping tool needs to be updated or something.

I did not plan to open this WIP PR, but people can at least see it and participate.

Adel