### PR TITLE
Add low latency pulse/pipewire patch stolen from ThePoon

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/lowlatency_audio_pulse.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/lowlatency_audio_pulse.patch
@@ -1,0 +1,58 @@
+From 8eeb9e9a2ce69780bba88c98bca8f3833b937bb1 Mon Sep 17 00:00:00 2001
+From: X9VoiD <oscar.silvestrexx@gmail.com>
+Date: Tue, 26 Oct 2021 06:09:55 +0800
+Subject: [PATCH] Add PulseAudio period/duration override support
+
+---
+ dlls/winepulse.drv/pulse.c | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/dlls/winepulse.drv/pulse.c b/dlls/winepulse.drv/pulse.c
+index bce70ac358c..87ddd97319a 100644
+--- a/dlls/winepulse.drv/pulse.c
++++ b/dlls/winepulse.drv/pulse.c
+@@ -91,9 +91,6 @@ static REFERENCE_TIME pulse_min_period[2], pulse_def_period[2];
+ 
+ static UINT g_phys_speakers_mask = 0;
+ 
+-static const REFERENCE_TIME MinimumPeriod = 30000;
+-static const REFERENCE_TIME DefaultPeriod = 100000;
+-
+ static pthread_mutex_t pulse_mutex;
+ static pthread_cond_t pulse_cond = PTHREAD_COND_INITIALIZER;
+ 
+@@ -505,11 +502,12 @@ static void pulse_probe_settings(int render, WAVEFORMATEXTENSIBLE *fmt) {
+     if (length)
+         pulse_def_period[!render] = pulse_min_period[!render] = pa_bytes_to_usec(10 * length, &ss);
+ 
+-    if (pulse_min_period[!render] < MinimumPeriod)
+-        pulse_min_period[!render] = MinimumPeriod;
+-
+-    if (pulse_def_period[!render] < DefaultPeriod)
+-        pulse_def_period[!render] = DefaultPeriod;
++    const char *penv = getenv("STAGING_AUDIO_PERIOD");
++    if (penv) {
++        int val = atoi(penv);
++        pulse_def_period[!render] = pulse_min_period[!render] = val;
++        printf("Staging audio period set to %d.\n", val);
++    }
+ 
+     wfx->wFormatTag = WAVE_FORMAT_EXTENSIBLE;
+     wfx->cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+@@ -860,6 +858,13 @@ static NTSTATUS pulse_create_stream(void *args)
+     if (duration < 3 * period)
+         duration = 3 * period;
+ 
++    const char *denv = getenv("STAGING_AUDIO_DURATION");
++    if (denv) {
++        int val = atoi(denv);
++        duration = val;
++        printf("Staging audio duration set to %d.\n", val);
++    }
++
+     stream->period_bytes = pa_frame_size(&stream->ss) * muldiv(period, stream->ss.rate, 10000000);
+ 
+     stream->bufsize_frames = ceil((duration / 10000000.) * params->fmt->nSamplesPerSec);
+-- 
+2.33.1
+

--- a/wine-tkg-git/wine-tkg-patches/misc/lowlatency_audio_pulse.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/lowlatency_audio_pulse.patch
@@ -1,27 +1,17 @@
-From 8eeb9e9a2ce69780bba88c98bca8f3833b937bb1 Mon Sep 17 00:00:00 2001
+From b6e658f5946df843a7709e22fd753442b98dcedc Mon Sep 17 00:00:00 2001
 From: X9VoiD <oscar.silvestrexx@gmail.com>
-Date: Tue, 26 Oct 2021 06:09:55 +0800
-Subject: [PATCH] Add PulseAudio period/duration override support
+Date: Thu, 28 Oct 2021 02:42:16 +0800
+Subject: [PATCH] Add PulseAudio/Pipewire latency overrides
 
 ---
- dlls/winepulse.drv/pulse.c | 21 +++++++++++++--------
- 1 file changed, 13 insertions(+), 8 deletions(-)
+ dlls/winepulse.drv/pulse.c | 26 +++++++++++++++++++++-----
+ 1 file changed, 21 insertions(+), 5 deletions(-)
 
 diff --git a/dlls/winepulse.drv/pulse.c b/dlls/winepulse.drv/pulse.c
-index bce70ac358c..87ddd97319a 100644
+index bce70ac358c..4d1c5fbdd3d 100644
 --- a/dlls/winepulse.drv/pulse.c
 +++ b/dlls/winepulse.drv/pulse.c
-@@ -91,9 +91,6 @@ static REFERENCE_TIME pulse_min_period[2], pulse_def_period[2];
- 
- static UINT g_phys_speakers_mask = 0;
- 
--static const REFERENCE_TIME MinimumPeriod = 30000;
--static const REFERENCE_TIME DefaultPeriod = 100000;
--
- static pthread_mutex_t pulse_mutex;
- static pthread_cond_t pulse_cond = PTHREAD_COND_INITIALIZER;
- 
-@@ -505,11 +502,12 @@ static void pulse_probe_settings(int render, WAVEFORMATEXTENSIBLE *fmt) {
+@@ -505,11 +505,20 @@ static void pulse_probe_settings(int render, WAVEFORMATEXTENSIBLE *fmt) {
      if (length)
          pulse_def_period[!render] = pulse_min_period[!render] = pa_bytes_to_usec(10 * length, &ss);
  
@@ -33,13 +23,21 @@ index bce70ac358c..87ddd97319a 100644
 +    const char *penv = getenv("STAGING_AUDIO_PERIOD");
 +    if (penv) {
 +        int val = atoi(penv);
-+        pulse_def_period[!render] = pulse_min_period[!render] = val;
-+        printf("Staging audio period set to %d.\n", val);
++        if (val > 0) {
++            pulse_def_period[!render] = pulse_min_period[!render] = val;
++            printf("Audio period set to %d.\n", val);
++        }
++        else if (val < 0) {
++            if (pulse_min_period[!render] < MinimumPeriod)
++                pulse_min_period[!render] = MinimumPeriod;
++            if (pulse_def_period[!render] < DefaultPeriod)
++                pulse_def_period[!render] = DefaultPeriod;
++        }
 +    }
  
      wfx->wFormatTag = WAVE_FORMAT_EXTENSIBLE;
      wfx->cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
-@@ -860,6 +858,13 @@ static NTSTATUS pulse_create_stream(void *args)
+@@ -860,6 +869,13 @@ static NTSTATUS pulse_create_stream(void *args)
      if (duration < 3 * period)
          duration = 3 * period;
  

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg-osu.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg-osu.cfg
@@ -9,5 +9,6 @@ _PKGNAME_OVERRIDE="osu"
 # OTHER PATCHES
 
 _lowlatency_audio="true"
+_lowlatency_audio_pulse="true"
 _FS_bypass_compositor="true"
 _proton_fs_hack="true"

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -1329,6 +1329,13 @@ _prepare() {
 	  _patchname='lowlatency_audio.patch' && _patchmsg="Applied low latency alsa audio patch" && nonuser_patcher
 	fi
 
+	# Low latency pulse/pipewire audio - https://blog.thepoon.fr/osuLinuxAudioLatency/
+	if [ "$_lowlatency_audio_pulse" = "true" ]; then
+	  if ( cd "${srcdir}"/"${_winesrcdir}" && ! git merge-base --is-ancestor f77af3dd6324fadaf153062d77b51f755f71faea HEAD ); then
+	    _patchname='lowlatency_audio_pulse.patch' && _patchmsg="Applied low latency pulse/pipewire audio patch" && nonuser_patcher
+	  fi
+	fi
+
 	# The Sims 2 fix - https://bugs.winehq.org/show_bug.cgi?id=8051
 	if [ "$_sims2_fix" = "true" ]; then
 	  if git merge-base --is-ancestor d88f12950761e9ff8d125a579de6e743979f4945 HEAD; then

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -1331,7 +1331,7 @@ _prepare() {
 
 	# Low latency pulse/pipewire audio - https://blog.thepoon.fr/osuLinuxAudioLatency/
 	if [ "$_lowlatency_audio_pulse" = "true" ]; then
-	  if ( cd "${srcdir}"/"${_winesrcdir}" && ! git merge-base --is-ancestor f77af3dd6324fadaf153062d77b51f755f71faea HEAD ); then
+	  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor f77af3dd6324fadaf153062d77b51f755f71faea HEAD ); then
 	    _patchname='lowlatency_audio_pulse.patch' && _patchmsg="Applied low latency pulse/pipewire audio patch" && nonuser_patcher
 	  fi
 	fi


### PR DESCRIPTION
## Changes

- Added `wine-tkg-git/wine-tkg-patches/misc/lowlatency_audio_pulse.patch`.
- Modified `wine-tkg-osu.cfg` profile to use `_lowlatency_audio_pulse=true`.
- Updated `wine-tkg-git/wine-tkg-scripts/prepare.sh` to support `_lowlatency_audio_pulse` configuration.
> The patch is applied only if [f77af3dd632](https://github.com/wine-mirror/wine/commit/f77af3dd6324fadaf153062d77b51f755f71faea) is applied to current HEAD, which is the earliest commit that the patch applies.

This patch works for both PulseAudio and Pipewire.