### PR TITLE
Allow users to add custom runtime dependencies

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -95,6 +95,7 @@ depends=(
     'libpcap'               'lib32-libpcap'
     'faudio'                'lib32-faudio'
     'desktop-file-utils'    'jxrlib'
+    $_user_deps
 )
 
 makedepends=('git' 'autoconf' 'ncurses' 'bison' 'perl' 'fontforge' 'flex'

--- a/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
@@ -81,6 +81,10 @@ _NOCOMPILE="false"
 # Set to true if you want to skip the initial prompt
 _NOINITIALPROMPT="false"
 
+# Optionally set additional dependencies for makepkg builds. Multiple elements should be separated by a space.
+# Only affect makepkg
+_user_deps=""
+
 # Optionally set additional make dependencies for makepkg builds. Multiple elements should be separated by a space.
 # Only affect makepkg
 _user_makedeps=""

--- a/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
@@ -79,6 +79,10 @@ _NOCOMPILE="false"
 # Set to true if you want to skip the initial prompt
 _NOINITIALPROMPT="false"
 
+# Optionally set additional dependencies for makepkg builds. Multiple elements should be separated by a space.
+# Only affect makepkg
+_user_deps=""
+
 # Optionally set additional make dependencies for makepkg builds. Multiple elements should be separated by a space.
 # Only affect makepkg
 _user_makedeps=""


### PR DESCRIPTION
A mechanism to mirror existing `_user_makedeps`; allows to create packages that require additional dependencies at both buildtime and runtime, as defined by user's custom configuration.

Useful for cases like:

```bash
_use_vkd3dlib="true"
_configure_userargs64="${_configure_userargs64} --with-vkd3d"
_configure_userargs32="${_configure_userargs32} --with-vkd3d"
_user_deps="${_user_deps} vkd3d lib32-vkd3d"
```
or
```bash
_configure_userargs64="${_configure_userargs64} --with-gcrypt"
_configure_userargs32="${_configure_userargs32} --with-gcrypt"
_user_deps="${_user_deps} libgcrypt lib32-libgcrypt"
```
or
```bash
_community_patches="${_community_patches} wine_wayland_driver.mypatch"
_user_makedeps="${_user_makedeps} wayland-protocols"
_user_deps="${_user_deps} libxkbcommon lib32-libxkbcommon"
```