### PR TITLE
Add a041075cd2c26874757e0b6e1449c23c1326241c to revert list. Fix issue with IDA Pro debugger

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -10,6 +10,10 @@ if ( cd "${srcdir}"/"${_winesrcdir}" && ! git merge-base --is-ancestor 0c249e612
   fi
 fi
 
+if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor a041075cd2c26874757e0b6e1449c23c1326241c HEAD ); then
+    _hotfix_mainlinereverts+=(a041075cd2c26874757e0b6e1449c23c1326241c)
+fi
+
 # Wine Destroyer - fd7992972b252ed262d33ef604e9e1235d2108c5
 # https://bugs.winehq.org/show_bug.cgi?id=48971
 # https://bugs.winehq.org/show_bug.cgi?id=49007


### PR DESCRIPTION
Commit a041075cd2c26874757e0b6e1449c23c1326241c shows some previously hidden bugs by changing the 64bit ntdll address base, causing IDA Pro being unable to attach debugger to  a process . Until these bugs are fixed upstreams, reverting this commit seems the most sensible choice
Relevant bug:
https://bugs.winehq.org/show_bug.cgi?id=52252