### PR TITLE
futex_waitv: Add check for linux futex header

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton/fsync_futex_waitv.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/fsync_futex_waitv.patch
@@ -587,3 +587,107 @@ index 237e8f2b4a4..45760bc0320 100644
          syscall( __NR_futex_waitv, 0, 0, 0, 0, 0);
          do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
      }
+From 3196885798787b6a52dbef0f3968f6b5e0216c56 Mon Sep 17 00:00:00 2001
+From: Dmitry Skvortsov <lvb.crd@protonmail.com>
+Date: Sun, 26 Dec 2021 16:32:58 +0300
+Subject: [PATCH 1/2] Separate check for definition of FUTEX_32 and struct futex_waitv
+
+---
+ dlls/ntdll/unix/fsync.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index 39d969f061d..c6869b62b4b 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -64,8 +64,10 @@ WINE_DEFAULT_DEBUG_CHANNEL(fsync);
+ /* futex_waitv interface */
+ 
+ #ifndef __NR_futex_waitv
+-
+ # define __NR_futex_waitv 449
++#endif
++
++#ifndef FUTEX_32
+ # define FUTEX_32 2
+ struct futex_waitv {
+     uint64_t   val;
+@@ -73,7 +75,6 @@ struct futex_waitv {
+     uint32_t   flags;
+     uint32_t __reserved;
+ };
+-
+ #endif
+ 
+ #define u64_to_ptr(x) (void *)(uintptr_t)(x)
+-- 
+2.34.1
+
+From 2c15b20ad7dd57778ad2354a14dd441d1cd6cf4f Mon Sep 17 00:00:00 2001
+From: Dmitry Skvortsov <lvb.crd@protonmail.com>
+Date: Sun, 26 Dec 2021 16:45:21 +0300
+Subject: [PATCH 2/2] Add check for linux/futex.h
+
+---
+ configure               | 6 ++++++
+ configure.ac            | 1 +
+ dlls/ntdll/unix/fsync.c | 3 +++
+ include/config.h.in     | 3 +++
+ 4 files changed, 13 insertions(+)
+
+diff --git a/configure b/configure
+index ab3aa34a922..d2bcd778c59 100755
+--- a/configure
++++ b/configure
+@@ -8317,6 +8317,12 @@ if test "x$ac_cv_header_linux_filter_h" = xyes
+ then :
+   printf "%s\n" "#define HAVE_LINUX_FILTER_H 1" >>confdefs.h
+ 
++fi
++ac_fn_c_check_header_compile "$LINENO" "linux/futex.h" "ac_cv_header_linux_futex_h" "$ac_includes_default"
++if test "x$ac_cv_header_linux_futex_h" = xyes
++then :
++  printf "%s\n" "#define HAVE_LINUX_FUTEX_H 1" >>confdefs.h
++
+ fi
+ ac_fn_c_check_header_compile "$LINENO" "linux/hdreg.h" "ac_cv_header_linux_hdreg_h" "$ac_includes_default"
+ if test "x$ac_cv_header_linux_hdreg_h" = xyes
+diff --git a/include/config.h.in b/include/config.h.in
+index 9eb052c6248..910cce10693 100644
+--- a/include/config.h.in
++++ b/include/config.h.in
+@@ -200,6 +200,9 @@
+ /* Define to 1 if you have the <linux/filter.h> header file. */
+ #undef HAVE_LINUX_FILTER_H
+ 
++/* Define to 1 if you have the <linux/futex.h> header file. */
++#undef HAVE_LINUX_FUTEX_H
++
+ /* Define if Linux-style gethostbyname_r and gethostbyaddr_r are available */
+ #undef HAVE_LINUX_GETHOSTBYNAME_R_6
+ 
+diff --git a/configure.ac b/configure.ac
+index 3071da61b62..cfe27460a96 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -450,2 +450,3 @@ AC_CHECK_HEADERS(\
+ 	linux/filter.h \
++	linux/futex.h \
+ 	linux/hdreg.h \
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index c6869b62b4b..6d69c643244 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -27,6 +27,9 @@
+ #include <assert.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#ifdef HAVE_LINUX_FUTEX_H
++# include <linux/futex.h>
++#endif
+ #include <limits.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+-- 
+2.34.1
+


### PR DESCRIPTION
I hope these small changes will be enough to solve the problem of building Wine-TkG in different build environments, and as I expect this should help solve the same problem with some future packages in Archlinux build environments.

Fixes https://github.com/Frogging-Family/wine-tkg-git/issues/643