### PR TITLE
Fix syntax error in hotfixer

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -528,7 +528,7 @@ fi
 if [ "$_use_fastsync" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 751a3325a6ac93d11f08088c40b45a9ae05b52de HEAD ); then
   warning "Hotfix: Disable fastsync, known to be broken on your current tree, and enable esync/fsync as a fallback for the time being"
   _use_fastsync="false"
-  if [ "$_use_staging" != "true" ]
+  if [ "$_use_staging" != "true" ]; then
     _use_esync="true"
   fi
   _use_fsync="true"


### PR DESCRIPTION
This PR fixes a script syntax error introduced in https://github.com/Frogging-Family/wine-tkg-git/commit/f5b6ca3e7afb18dc9e8ffa16c8a035593b668e00 :frog: :heart:

closes #667