### PR TITLE
add _community_patches_auto_update setting

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -151,3 +151,6 @@ _protonify="false"
 # community patches - add patches (separated by a space) of your choice by name from the community-patches dir - https://github.com/Frogging-Family/community-patches
 # example: _community_patches="amdags.mypatch GNUTLShack.mypatch"
 _community_patches=""
+
+# Automatically update community-patches from git - set to false if you don't want this behaviour, useful for example if you have your own fork.
+_community_patches_auto_update="true"

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -495,7 +495,8 @@ _prepare() {
         error "Error while attempting to clone community-patches repo"
         exit 1
       fi
-    else
+    elif [[ "${_community_patches_auto_update}" != "false" ]]
+    then
       msg2 "Updating community-patches repo..."
 
       if ! git -C "${_community_patches_repo_path}" pull origin master


### PR DESCRIPTION
Allows skipping the automatic `git pull` on the `community-patches` directory during wine/proton build. Useful for people with a fork of it.