### PR TITLE
prepare: Allow _fsync_futex_waitv safelly ignore _use_fsync toggle

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -1559,7 +1559,7 @@ EOM
 	fi
 
 	# fsync - experimental replacement for esync introduced with Proton 4.11-1
-	if [ "$_use_fsync" = "true" ]; then
+	if [ "$_use_fsync" = "true" ] || [ "$_fsync_futex_waitv" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
 	  if [ "$_staging_esync" = "true" ]; then
 	    if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e3001b6a7c087da5a680b412d82da878e0149e8b HEAD ); then
 	      _patchname='fsync-unix-staging.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher


### PR DESCRIPTION
Small addition to the applying of futex_waitv patches. Probably should be especially after https://github.com/Frogging-Family/wine-tkg-git/commit/764ff67d6fd7aad4edc3d03d7d46d69c6bbd07ff