### PR TITLE
Update fastsync patches for e534d65 and move previous versions to legacy

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-staging.patch
@@ -1952,9 +1952,9 @@ index 662e6312554..96c63db3328 100644
  }
  
 @@ -906,6 +910,7 @@ static void console_server_destroy( struct object *obj )
-     assert( obj->ops == &console_server_ops );
      disconnect_console_server( server );
      if (server->fd) release_object( server->fd );
+     if (do_esync()) close( server->esync_fd );
 +    if (server->fast_sync) release_object( server->fast_sync );
  }
  
@@ -2549,9 +2549,9 @@ index e013f4fb32c..3e70cd92259 100644
  
  static void msg_queue_destroy( struct object *obj )
 @@ -1035,6 +1055,7 @@ static void msg_queue_destroy( struct object *obj )
-     release_object( queue->input );
      if (queue->hooks) release_object( queue->hooks );
      if (queue->fd) release_object( queue->fd );
+     if (do_esync()) close( queue->esync_fd );
 +    if (queue->fast_sync) release_object( queue->fast_sync );
  }
  
@@ -2796,9 +2796,9 @@ index d4a69bf8794..854a8e1f7f2 100644
  {
      struct timer *timer = (struct timer *)obj;
 @@ -223,6 +241,7 @@ static void timer_destroy( struct object *obj )
- 
      if (timer->timeout) remove_timeout_user( timer->timeout );
      if (timer->thread) release_object( timer->thread );
+     if (do_esync()) close( timer->esync_fd );
 +    if (timer->fast_sync) release_object( timer->fast_sync );
  }
  

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-e534d65.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-e534d65.patch
@@ -107,7 +107,7 @@ index 6933195e72d..dd16787c63c 100644
      no_open_file,              /* open_file */
      no_kernel_obj_list,        /* get_kernel_obj_list */
 +    no_get_fast_sync,          /* get_fast_sync */
-     completion_close,          /* close_handle */
+     no_close_handle,           /* close_handle */
      completion_destroy         /* destroy */
  };
 diff --git a/server/console.c b/server/console.c
@@ -1624,16 +1624,15 @@ diff --git a/server/completion.c b/server/completion.c
 index dd16787c63c..5ec6d209d13 100644
 --- a/server/completion.c
 +++ b/server/completion.c
-@@ -61,11 +61,13 @@ struct completion
+@@ -61,10 +61,12 @@ struct completion
+     struct object  obj;
      struct list    queue;
      unsigned int   depth;
-     int            abandoned;
 +    struct fast_sync *fast_sync;
  };
  
  static void completion_dump( struct object*, int );
  static int completion_signaled( struct object *obj, struct wait_queue_entry *entry );
- static int completion_close( struct object *obj, struct process *process, obj_handle_t handle );
 +static struct fast_sync *completion_get_fast_sync( struct object *obj );
  static void completion_destroy( struct object * );
  
@@ -1644,7 +1643,7 @@ index dd16787c63c..5ec6d209d13 100644
      no_kernel_obj_list,        /* get_kernel_obj_list */
 -    no_get_fast_sync,          /* get_fast_sync */
 +    completion_get_fast_sync,  /* get_fast_sync */
-     completion_close,          /* close_handle */
+     no_close_handle,           /* close_handle */
      completion_destroy         /* destroy */
  };
 @@ -110,6 +112,7 @@ static void completion_destroy( struct object *obj)
@@ -1953,9 +1952,9 @@ index 662e6312554..96c63db3328 100644
  }
  
 @@ -906,6 +910,7 @@ static void console_server_destroy( struct object *obj )
+     assert( obj->ops == &console_server_ops );
      disconnect_console_server( server );
      if (server->fd) release_object( server->fd );
-     if (do_esync()) close( server->esync_fd );
 +    if (server->fast_sync) release_object( server->fast_sync );
  }
  
@@ -2329,9 +2328,9 @@ index 4d146dd79fc..b29fb2bc983 100644
      process_destroy              /* destroy */
  };
 @@ -683,6 +684,7 @@ struct process *create_process( int fd, struct process *parent, unsigned int fla
+     memset( &process->image_info, 0, sizeof(process->image_info) );
      process->esync_fd        = -1;
      process->fsync_idx       = 0;
-     process->cpu_override.cpu_count = 0;
 +    process->fast_sync       = NULL;
      list_init( &process->kernel_object );
      list_init( &process->thread_list );
@@ -2375,9 +2374,9 @@ index 632faf9c4bf..5b8bebd31be 100644
 --- a/server/process.h
 +++ b/server/process.h
 @@ -90,6 +90,7 @@ struct process
+     pe_image_info_t      image_info;      /* main exe image info */
      int                  esync_fd;        /* esync file descriptor (signaled on exit) */
      unsigned int         fsync_idx;
-     struct cpu_topology_override cpu_override; /* Overridden CPUs to host CPUs mapping. */
 +    struct fast_sync    *fast_sync;       /* fast synchronization object */
  };
  
@@ -2550,9 +2549,9 @@ index e013f4fb32c..3e70cd92259 100644
  
  static void msg_queue_destroy( struct object *obj )
 @@ -1035,6 +1055,7 @@ static void msg_queue_destroy( struct object *obj )
+     release_object( queue->input );
      if (queue->hooks) release_object( queue->hooks );
      if (queue->fd) release_object( queue->fd );
-     if (do_esync()) close( queue->esync_fd );
 +    if (queue->fast_sync) release_object( queue->fast_sync );
  }
  
@@ -2797,9 +2796,9 @@ index d4a69bf8794..854a8e1f7f2 100644
  {
      struct timer *timer = (struct timer *)obj;
 @@ -223,6 +241,7 @@ static void timer_destroy( struct object *obj )
+ 
      if (timer->timeout) remove_timeout_user( timer->timeout );
      if (timer->thread) release_object( timer->thread );
-     if (do_esync()) close( timer->esync_fd );
 +    if (timer->fast_sync) release_object( timer->fast_sync );
  }
  

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-protonify-e534d65.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-protonify-e534d65.patch
@@ -1953,9 +1953,9 @@ index 662e6312554..96c63db3328 100644
  }
  
 @@ -906,6 +910,7 @@ static void console_server_destroy( struct object *obj )
+     assert( obj->ops == &console_server_ops );
      disconnect_console_server( server );
      if (server->fd) release_object( server->fd );
-     if (do_esync()) close( server->esync_fd );
 +    if (server->fast_sync) release_object( server->fast_sync );
  }
  
@@ -2550,9 +2550,9 @@ index e013f4fb32c..3e70cd92259 100644
  
  static void msg_queue_destroy( struct object *obj )
 @@ -1035,6 +1055,7 @@ static void msg_queue_destroy( struct object *obj )
+     release_object( queue->input );
      if (queue->hooks) release_object( queue->hooks );
      if (queue->fd) release_object( queue->fd );
-     if (do_esync()) close( queue->esync_fd );
 +    if (queue->fast_sync) release_object( queue->fast_sync );
  }
  
@@ -2797,9 +2797,9 @@ index d4a69bf8794..854a8e1f7f2 100644
  {
      struct timer *timer = (struct timer *)obj;
 @@ -223,6 +241,7 @@ static void timer_destroy( struct object *obj )
+ 
      if (timer->timeout) remove_timeout_user( timer->timeout );
      if (timer->thread) release_object( timer->thread );
-     if (do_esync()) close( timer->esync_fd );
 +    if (timer->fast_sync) release_object( timer->fast_sync );
  }
  

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -2752,12 +2752,16 @@ EOM
 	  if [ "$_use_staging" = "true" ]; then
 	    if [ "$_staging_esync" = "true" ] && [ "$_use_fsync" = "true" ]; then
 	      if [ "$_protonify" = "true" ]; then
-	        if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 36b45c6d1c124dd16b3475ba743fcbbc99d6862d HEAD ); then
+	        if ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor e534d6546a5be9f1cd53a0ea3ac79db7d977bed7 HEAD ); then
 	          _patchname='fastsync-staging-protonify.patch' && _patchmsg="Using fastsync (Esync/Fsync compatible) patchset" && nonuser_patcher
+	        elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 36b45c6d1c124dd16b3475ba743fcbbc99d6862d HEAD ); then
+	          _patchname='fastsync-staging-protonify-e534d65.patch' && _patchmsg="Using fastsync (Esync/Fsync compatible) patchset" && nonuser_patcher
 	        fi
 	      else
-	        if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 36b45c6d1c124dd16b3475ba743fcbbc99d6862d HEAD ); then
+	        if ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor e534d6546a5be9f1cd53a0ea3ac79db7d977bed7 HEAD ); then
 	          _patchname='fastsync-staging.patch' && _patchmsg="Using fastsync (Esync/Fsync compatible) patchset" && nonuser_patcher
+	        elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 36b45c6d1c124dd16b3475ba743fcbbc99d6862d HEAD ); then
+	          _patchname='fastsync-staging-e534d65.patch' && _patchmsg="Using fastsync (Esync/Fsync compatible) patchset" && nonuser_patcher
 	        fi
 	      fi
 	    else


### PR DESCRIPTION
update due to https://github.com/wine-staging/wine-staging/commit/e534d6546a5be9f1cd53a0ea3ac79db7d977bed7