### PR TITLE
Add shared gpu resources patchset

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -98,6 +98,9 @@ _re4_fix="false"
 # Child window support for vk - Fixes World of Final Fantasy, CEMU vulkan renderer and others - https://bugs.winehq.org/show_bug.cgi?id=45277
 _childwindow_fix="true"
 
+# Shared gpu resources support. Requires DXVK 1.10.3+, VKD3D-Proton 2.7+ https://github.com/doitsujin/dxvk/pull/2516 https://github.com/doitsujin/dxvk/pull/2608
+_shared_gpu_resources="false"
+
 # Fix for LoL 9.20+ crashing - Depends on _use_staging="true" - https://bugs.winehq.org/show_bug.cgi?id=47198 & https://bugs.winehq.org/show_bug.cgi?id=47915 - Requires vdso32 disabled (as root: `echo 0 > /proc/sys/abi/vsyscall32`)
 # lol depends on the following staging patches :
 # winebuild-Fake_Dlls, ntdll-RtlCreateUserThread, ntdll-NtContinue, ntdll-SystemExtendedProcessInformation, ntdll-SystemModuleInformation, ntdll-ThreadHideFromDebugger, wow64cpu-Wow64Transition, user32-InternalGetWindowIcon, ntdll-Pipe_SpecialCharacters, ntdll-NtDevicePath, ntdll-NtQueryVirtualMemory, fonts-Missing_Fonts, crypt32-CMS_Certificates, bcrypt-ECDHSecretAgreement, winex11-ime-check-thread-data

--- a/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/shared-gpu-resources
+++ b/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/shared-gpu-resources
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+	# Shared gpu resources patchset - https://github.com/doitsujin/dxvk/pull/2516
+	if [ "$_shared_gpu_resources" = "true" ] && [ "$_childwindow_fix" = "true" ] && [ "$_use_staging" = "true" ] && git merge-base --is-ancestor c86955d3806879fc97b127730e9fb90e232710a7 HEAD; then
+	  if git merge-base --is-ancestor c86955d3806879fc97b127730e9fb90e232710a7 HEAD; then
+	    _patchname='sharedgpures.patch' && _patchmsg="Applied shared gpu resources patchset" && nonuser_patcher
+	  fi
+	  if git merge-base --is-ancestor c86955d3806879fc97b127730e9fb90e232710a7 HEAD; then
+	    _patchname='sharedgpures-fixup.patch' && nonuser_patcher
+	  fi
+#	  if git merge-base --is-ancestor c86955d3806879fc97b127730e9fb90e232710a7 HEAD; then
+#	    _patchname='sharedgpures-mfplat.patch' && nonuser_patcher
+#	  fi
+	fi

--- a/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-fixup.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-fixup.patch
@@ -1,0 +1,1033 @@
+From 5b04d18945c547144bf692f6418af5ec25315835 Mon Sep 17 00:00:00 2001
+From: Nikolay Sivov <nsivov@codeweavers.com>
+Date: Tue, 17 May 2022 15:30:47 +0300
+Subject: [PATCH 1/5] Revert "mfreadwrite/reader: Propagate resource sharing
+ mode to the sample allocator."
+
+This reverts commit 5b04d18945c547144bf692f6418af5ec25315835.
+---
+ dlls/mfreadwrite/reader.c | 32 +-------------------------------
+ 1 file changed, 1 insertion(+), 31 deletions(-)
+
+diff --git a/dlls/mfreadwrite/reader.c b/dlls/mfreadwrite/reader.c
+index 76348458fac..d1900eef74d 100644
+--- a/dlls/mfreadwrite/reader.c
++++ b/dlls/mfreadwrite/reader.c
+@@ -1655,30 +1655,9 @@ static HRESULT source_reader_set_compatible_media_type(struct source_reader *rea
+     return type_set ? S_OK : S_FALSE;
+ }
+ 
+-static HRESULT source_reader_create_sample_allocator_attributes(const struct source_reader *reader,
+-        IMFAttributes **attributes)
+-{
+-    UINT32 shared = 0, shared_without_mutex = 0;
+-    HRESULT hr;
+-
+-    if (FAILED(hr = MFCreateAttributes(attributes, 1)))
+-        return hr;
+-
+-    IMFAttributes_GetUINT32(reader->attributes, &MF_SA_D3D11_SHARED, &shared);
+-    IMFAttributes_GetUINT32(reader->attributes, &MF_SA_D3D11_SHARED_WITHOUT_MUTEX, &shared_without_mutex);
+-
+-    if (shared_without_mutex)
+-        hr = IMFAttributes_SetUINT32(*attributes, &MF_SA_D3D11_SHARED_WITHOUT_MUTEX, TRUE);
+-    else if (shared)
+-        hr = IMFAttributes_SetUINT32(*attributes, &MF_SA_D3D11_SHARED, TRUE);
+-
+-    return hr;
+-}
+-
+ static HRESULT source_reader_setup_sample_allocator(struct source_reader *reader, unsigned int index)
+ {
+     struct media_stream *stream = &reader->streams[index];
+-    IMFAttributes *attributes = NULL;
+     GUID major = { 0 };
+     HRESULT hr;
+ 
+@@ -1705,17 +1684,8 @@ static HRESULT source_reader_setup_sample_allocator(struct source_reader *reader
+         return hr;
+     }
+ 
+-    if (FAILED(hr = source_reader_create_sample_allocator_attributes(reader, &attributes)))
+-        WARN("Failed to create allocator attributes, hr %#lx.\n", hr);
+-
+-    if (FAILED(hr = IMFVideoSampleAllocatorEx_InitializeSampleAllocatorEx(stream->allocator, 2, 8,
+-            attributes, stream->current)))
+-    {
++    if (FAILED(hr = IMFVideoSampleAllocatorEx_InitializeSampleAllocatorEx(stream->allocator, 2, 8, NULL, stream->current)))
+         WARN("Failed to initialize sample allocator, hr %#lx.\n", hr);
+-    }
+-
+-    if (attributes)
+-        IMFAttributes_Release(attributes);
+ 
+     return hr;
+ }
+-- 
+2.37.1
+
+From 68fa3f673633c138596b86ad2ed1befcd0cc63c5 Mon Sep 17 00:00:00 2001
+From: Nikolay Sivov <nsivov@codeweavers.com>
+Date: Fri, 13 May 2022 19:34:13 +0300
+Subject: [PATCH 2/5] Revert "mfreadwrite/reader: Allocate output samples on
+ read requests."
+
+This reverts commit 68fa3f673633c138596b86ad2ed1befcd0cc63c5.
+---
+ dlls/mfreadwrite/reader.c | 138 +++++++++++++++++++++++++++++++-------
+ 1 file changed, 113 insertions(+), 25 deletions(-)
+
+diff --git a/dlls/mfreadwrite/reader.c b/dlls/mfreadwrite/reader.c
+index d1900eef74d..c6a10fa0e8d 100644
+--- a/dlls/mfreadwrite/reader.c
++++ b/dlls/mfreadwrite/reader.c
+@@ -52,6 +52,7 @@ struct stream_response
+     DWORD stream_flags;
+     LONGLONG timestamp;
+     IMFSample *sample;
++    unsigned int sa_pending : 1;
+ };
+ 
+ enum media_stream_state
+@@ -86,6 +87,7 @@ struct media_stream
+     IMFMediaType *current;
+     struct stream_transform decoder;
+     IMFVideoSampleAllocatorEx *allocator;
++    IMFVideoSampleAllocatorNotify notify_cb;
+     DWORD id;
+     unsigned int index;
+     enum media_stream_state state;
+@@ -102,6 +104,7 @@ enum source_reader_async_op
+     SOURCE_READER_ASYNC_SEEK,
+     SOURCE_READER_ASYNC_FLUSH,
+     SOURCE_READER_ASYNC_SAMPLE_READY,
++    SOURCE_READER_ASYNC_SA_READY,
+ };
+ 
+ struct source_reader_async_command
+@@ -198,6 +201,11 @@ static struct source_reader_async_command *impl_from_async_command_IUnknown(IUnk
+     return CONTAINING_RECORD(iface, struct source_reader_async_command, IUnknown_iface);
+ }
+ 
++static struct media_stream *impl_stream_from_IMFVideoSampleAllocatorNotify(IMFVideoSampleAllocatorNotify *iface)
++{
++    return CONTAINING_RECORD(iface, struct media_stream, notify_cb);
++}
++
+ static void source_reader_release_responses(struct source_reader *reader, struct media_stream *stream);
+ 
+ static ULONG source_reader_addref(struct source_reader *reader)
+@@ -386,7 +394,7 @@ static void source_reader_response_ready(struct source_reader *reader, struct st
+     struct media_stream *stream = &reader->streams[response->stream_index];
+     HRESULT hr;
+ 
+-    if (!stream->requests)
++    if (!stream->requests || response->sa_pending)
+         return;
+ 
+     if (reader->async_callback)
+@@ -438,6 +446,20 @@ static void source_reader_copy_sample_buffer(IMFSample *src, IMFSample *dst)
+     }
+ }
+ 
++static void source_reader_set_sa_response(struct source_reader *reader, struct stream_response *response)
++{
++    struct media_stream *stream = &reader->streams[response->stream_index];
++    IMFSample *sample;
++
++    if (SUCCEEDED(IMFVideoSampleAllocatorEx_AllocateSample(stream->allocator, &sample)))
++    {
++        source_reader_copy_sample_buffer(response->sample, sample);
++        response->sa_pending = 0;
++        IMFSample_Release(response->sample);
++        response->sample = sample;
++    }
++}
++
+ static HRESULT source_reader_queue_response(struct source_reader *reader, struct media_stream *stream, HRESULT status,
+         DWORD stream_flags, LONGLONG timestamp, IMFSample *sample)
+ {
+@@ -454,6 +476,12 @@ static HRESULT source_reader_queue_response(struct source_reader *reader, struct
+     if (response->sample)
+         IMFSample_AddRef(response->sample);
+ 
++    if (response->sample && stream->allocator)
++    {
++        response->sa_pending = 1;
++        source_reader_set_sa_response(reader, response);
++    }
++
+     list_add_tail(&reader->responses, &response->entry);
+     stream->responses++;
+ 
+@@ -949,37 +977,26 @@ static struct stream_response * media_stream_detach_response(struct source_reade
+ static struct stream_response *media_stream_pop_response(struct source_reader *reader, struct media_stream *stream)
+ {
+     struct stream_response *response;
+-    IMFSample *sample;
+-    HRESULT hr;
+ 
+     LIST_FOR_EACH_ENTRY(response, &reader->responses, struct stream_response, entry)
+     {
+-        if (stream && response->stream_index != stream->index)
++        if ((stream && response->stream_index != stream->index) || response->sa_pending)
+             continue;
+ 
+-        if (!stream) stream = &reader->streams[response->stream_index];
++        return media_stream_detach_response(reader, response);
++    }
+ 
+-        if (stream->allocator)
+-        {
+-            /* Return allocation error to the caller, while keeping original response sample in for later. */
+-            if (SUCCEEDED(hr = IMFVideoSampleAllocatorEx_AllocateSample(stream->allocator, &sample)))
+-            {
+-                source_reader_copy_sample_buffer(response->sample, sample);
+-                IMFSample_Release(response->sample);
+-                response->sample = sample;
+-            }
+-            else
+-            {
+-                if (!(response = calloc(1, sizeof(*response))))
+-                    return NULL;
++    return NULL;
++}
+ 
+-                response->status = hr;
+-                response->stream_flags = MF_SOURCE_READERF_ERROR;
+-                return response;
+-            }
+-        }
++static struct stream_response *media_stream_pick_pending_response(struct source_reader *reader, unsigned int stream)
++{
++    struct stream_response *response;
+ 
+-        return media_stream_detach_response(reader, response);
++    LIST_FOR_EACH_ENTRY(response, &reader->responses, struct stream_response, entry)
++    {
++        if (response->stream_index == stream && response->sa_pending)
++            return response;
+     }
+ 
+     return NULL;
+@@ -1055,7 +1072,7 @@ static BOOL source_reader_got_response_for_stream(struct source_reader *reader,
+ 
+     LIST_FOR_EACH_ENTRY(response, &reader->responses, struct stream_response, entry)
+     {
+-        if (response->stream_index == stream->index)
++        if (response->stream_index == stream->index && !response->sa_pending)
+             return TRUE;
+     }
+ 
+@@ -1290,6 +1307,18 @@ static HRESULT WINAPI source_reader_async_commands_callback_Invoke(IMFAsyncCallb
+ 
+             break;
+ 
++        case SOURCE_READER_ASYNC_SA_READY:
++
++            EnterCriticalSection(&reader->cs);
++            if ((response = media_stream_pick_pending_response(reader, command->u.sa.stream_index)))
++            {
++                source_reader_set_sa_response(reader, response);
++                source_reader_response_ready(reader, response);
++            }
++            LeaveCriticalSection(&reader->cs);
++
++            break;
++
+         case SOURCE_READER_ASYNC_SAMPLE_READY:
+ 
+             EnterCriticalSection(&reader->cs);
+@@ -1658,6 +1687,7 @@ static HRESULT source_reader_set_compatible_media_type(struct source_reader *rea
+ static HRESULT source_reader_setup_sample_allocator(struct source_reader *reader, unsigned int index)
+ {
+     struct media_stream *stream = &reader->streams[index];
++    IMFVideoSampleAllocatorCallback *callback;
+     GUID major = { 0 };
+     HRESULT hr;
+ 
+@@ -1687,6 +1717,13 @@ static HRESULT source_reader_setup_sample_allocator(struct source_reader *reader
+     if (FAILED(hr = IMFVideoSampleAllocatorEx_InitializeSampleAllocatorEx(stream->allocator, 2, 8, NULL, stream->current)))
+         WARN("Failed to initialize sample allocator, hr %#lx.\n", hr);
+ 
++    if (SUCCEEDED(IMFVideoSampleAllocatorEx_QueryInterface(stream->allocator, &IID_IMFVideoSampleAllocatorCallback, (void **)&callback)))
++    {
++        if (FAILED(hr = IMFVideoSampleAllocatorCallback_SetCallback(callback, &stream->notify_cb)))
++            WARN("Failed to set allocator callback, hr %#lx.\n", hr);
++        IMFVideoSampleAllocatorCallback_Release(callback);
++    }
++
+     return hr;
+ }
+ 
+@@ -2255,6 +2292,56 @@ static DWORD reader_get_first_stream_index(IMFPresentationDescriptor *descriptor
+     return MF_SOURCE_READER_INVALID_STREAM_INDEX;
+ }
+ 
++static HRESULT WINAPI stream_sample_allocator_cb_QueryInterface(IMFVideoSampleAllocatorNotify *iface,
++        REFIID riid, void **obj)
++{
++    if (IsEqualIID(riid, &IID_IMFVideoSampleAllocatorNotify) ||
++            IsEqualIID(riid, &IID_IUnknown))
++    {
++        *obj = iface;
++        IMFVideoSampleAllocatorNotify_AddRef(iface);
++        return S_OK;
++    }
++
++    *obj = NULL;
++    return E_NOINTERFACE;
++}
++
++static ULONG WINAPI stream_sample_allocator_cb_AddRef(IMFVideoSampleAllocatorNotify *iface)
++{
++    struct media_stream *stream = impl_stream_from_IMFVideoSampleAllocatorNotify(iface);
++    return source_reader_addref(stream->reader);
++}
++
++static ULONG WINAPI stream_sample_allocator_cb_Release(IMFVideoSampleAllocatorNotify *iface)
++{
++    struct media_stream *stream = impl_stream_from_IMFVideoSampleAllocatorNotify(iface);
++    return source_reader_release(stream->reader);
++}
++
++static HRESULT WINAPI stream_sample_allocator_cb_NotifyRelease(IMFVideoSampleAllocatorNotify *iface)
++{
++    struct media_stream *stream = impl_stream_from_IMFVideoSampleAllocatorNotify(iface);
++    struct source_reader_async_command *command;
++
++    if (SUCCEEDED(source_reader_create_async_op(SOURCE_READER_ASYNC_SA_READY, &command)))
++    {
++        command->u.sa.stream_index = stream->index;
++        MFPutWorkItem(stream->reader->queue, &stream->reader->async_commands_callback, &command->IUnknown_iface);
++        IUnknown_Release(&command->IUnknown_iface);
++    }
++
++    return S_OK;
++}
++
++static const IMFVideoSampleAllocatorNotifyVtbl stream_sample_allocator_cb_vtbl =
++{
++    stream_sample_allocator_cb_QueryInterface,
++    stream_sample_allocator_cb_AddRef,
++    stream_sample_allocator_cb_Release,
++    stream_sample_allocator_cb_NotifyRelease,
++};
++
+ static HRESULT create_source_reader_from_source(IMFMediaSource *source, IMFAttributes *attributes,
+         BOOL shutdown_on_release, REFIID riid, void **out)
+ {
+@@ -2326,6 +2413,7 @@ static HRESULT create_source_reader_from_source(IMFMediaSource *source, IMFAttri
+         if (FAILED(hr))
+             break;
+ 
++        object->streams[i].notify_cb.lpVtbl = &stream_sample_allocator_cb_vtbl;
+         object->streams[i].reader = object;
+         object->streams[i].index = i;
+     }
+-- 
+2.37.1
+
+From 3f8767dfb0944c3dbe8f9f9c010cd75502dd86b3 Mon Sep 17 00:00:00 2001
+From: Giovanni Mascellani <gmascellani@codeweavers.com>
+Date: Thu, 4 Nov 2021 12:51:31 +0100
+Subject: [PATCH 3/5] mfreadwrite/reader: Add a passthrough transform.
+
+On Windows media sources typically produce compressed data, so
+the source reader automatically adds a transform to decompress it.
+On Wine media sources already care about decompressing data, so
+there is no need for a transform. However, some applications
+expect it anyway (e.g., to edit transform attributes) and fail
+if it's not present.
+
+Therefore, this patch adds a trivial passthrough transform
+implementation to please such programs.
+
+CW-Bug-Id: #19126
+---
+ dlls/mfreadwrite/reader.c | 487 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 487 insertions(+)
+
+diff --git a/dlls/mfreadwrite/reader.c b/dlls/mfreadwrite/reader.c
+index 20521ff09d7..b5e0c05b171 100644
+--- a/dlls/mfreadwrite/reader.c
++++ b/dlls/mfreadwrite/reader.c
+@@ -251,6 +251,461 @@ static ULONG source_reader_release(struct source_reader *reader)
+     return refcount;
+ }
+ 
++struct passthrough_transform
++{
++    IMFTransform IMFTransform_iface;
++    LONG refcount;
++    IMFMediaType *type;
++    IMFAttributes *attributes;
++    IMFAttributes *input_attributes;
++    IMFAttributes *output_attributes;
++    IMFSample *sample;
++};
++
++static inline struct passthrough_transform *impl_from_IMFTransform(IMFTransform *iface)
++{
++    return CONTAINING_RECORD(iface, struct passthrough_transform, IMFTransform_iface);
++}
++
++static HRESULT WINAPI passthrough_transform_QueryInterface(IMFTransform *iface, REFIID riid, void **out)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %s, %p.\n", iface, debugstr_guid(riid), out);
++
++    if (IsEqualIID(riid, &IID_IUnknown) ||
++        IsEqualIID(riid, &IID_IMFTransform))
++    {
++        *out = &transform->IMFTransform_iface;
++    }
++    else
++    {
++        FIXME("(%s, %p)\n", debugstr_guid(riid), out);
++        *out = NULL;
++        return E_NOINTERFACE;
++    }
++
++    IUnknown_AddRef(iface);
++    return S_OK;
++}
++
++static ULONG WINAPI passthrough_transform_AddRef(IMFTransform *iface)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++    ULONG refcount = InterlockedIncrement(&transform->refcount);
++
++    TRACE("%p, refcount %u.\n", iface, refcount);
++
++    return refcount;
++}
++
++static ULONG WINAPI passthrough_transform_Release(IMFTransform *iface)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++    ULONG refcount = InterlockedDecrement(&transform->refcount);
++
++    TRACE("%p, refcount %u.\n", iface, refcount);
++
++    if (!refcount)
++    {
++        if (transform->type)
++            IMFMediaType_Release(transform->type);
++        IMFAttributes_Release(transform->attributes);
++        IMFAttributes_Release(transform->input_attributes);
++        IMFAttributes_Release(transform->output_attributes);
++        if (transform->sample)
++            IMFSample_Release(transform->sample);
++    }
++
++    return refcount;
++}
++static HRESULT WINAPI passthrough_transform_GetStreamLimits(IMFTransform *iface,
++        DWORD *input_minimum, DWORD *input_maximum, DWORD *output_minimum, DWORD *output_maximum)
++{
++    TRACE("%p, %p, %p, %p, %p.\n", iface, input_minimum, input_maximum, output_minimum, output_maximum);
++
++    *input_minimum = 1;
++    *input_maximum = 1;
++    *output_minimum = 1;
++    *output_maximum = 1;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetStreamCount(IMFTransform *iface, DWORD *inputs, DWORD *outputs)
++{
++    TRACE("%p, %p, %p.\n", iface, inputs, outputs);
++
++    *inputs = 1;
++    *outputs = 1;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetStreamIDs(IMFTransform *iface,
++        DWORD input_size, DWORD *inputs, DWORD output_size, DWORD *outputs)
++{
++    TRACE("%p, %d, %p, %d, %p.\n", iface, input_size, inputs, output_size, outputs);
++
++    if (input_size < 1 || output_size < 1)
++        return MF_E_BUFFERTOOSMALL;
++
++    inputs[0] = 0;
++    outputs[0] = 0;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetInputStreamInfo(IMFTransform *iface, DWORD id, MFT_INPUT_STREAM_INFO *info)
++{
++    TRACE("%p, %d, %p.\n", iface, id, info);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    info->hnsMaxLatency = 0;
++    info->dwFlags = MFT_INPUT_STREAM_PROCESSES_IN_PLACE;
++    info->cbSize = 0;
++    info->cbMaxLookahead = 0;
++    info->cbAlignment = 0;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetOutputStreamInfo(IMFTransform *iface, DWORD id, MFT_OUTPUT_STREAM_INFO *info)
++{
++    TRACE("%p, %d, %p.\n", iface, id, info);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    info->dwFlags = MFT_OUTPUT_STREAM_PROVIDES_SAMPLES;
++    info->cbSize = 0;
++    info->cbAlignment = 0;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetAttributes(IMFTransform *iface, IMFAttributes **attributes)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %p.\n", iface, attributes);
++
++    IMFAttributes_AddRef(transform->attributes);
++
++    *attributes = transform->attributes;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetInputStreamAttributes(IMFTransform *iface, DWORD id, IMFAttributes **attributes)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %p.\n", iface, id, attributes);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    IMFAttributes_AddRef(transform->input_attributes);
++
++    *attributes = transform->input_attributes;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetOutputStreamAttributes(IMFTransform *iface, DWORD id, IMFAttributes **attributes)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %p.\n", iface, id, attributes);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    IMFAttributes_AddRef(transform->output_attributes);
++
++    *attributes = transform->output_attributes;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_DeleteInputStream(IMFTransform *iface, DWORD id)
++{
++    TRACE("%p, %d.\n", iface, id);
++
++    return E_NOTIMPL;
++}
++
++static HRESULT WINAPI passthrough_transform_AddInputStreams(IMFTransform *iface, DWORD streams, DWORD *ids)
++{
++    TRACE("%p, %d, %p.\n", iface, streams, ids);
++
++    return E_NOTIMPL;
++}
++
++static HRESULT WINAPI passthrough_transform_GetInputAvailableType(IMFTransform *iface, DWORD id, DWORD index, IMFMediaType **type)
++{
++    TRACE("%p, %d, %d, %p.\n", iface, id, index, type);
++
++    return E_NOTIMPL;
++}
++
++static HRESULT WINAPI passthrough_transform_GetOutputAvailableType(IMFTransform *iface, DWORD id, DWORD index, IMFMediaType **type)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %d, %p.\n", iface, id, index, type);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    if (index != 0)
++        return MF_E_NO_MORE_TYPES;
++
++    if (!transform->type)
++        return MF_E_TRANSFORM_TYPE_NOT_SET;
++
++    *type = transform->type;
++    IMFMediaType_AddRef(*type);
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_SetInputType(IMFTransform *iface, DWORD id, IMFMediaType *type, DWORD flags)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %p, %d.\n", iface, id, type, flags);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    if (!(flags & MFT_SET_TYPE_TEST_ONLY))
++    {
++        if (transform->type)
++            IMFMediaType_Release(transform->type);
++        transform->type = type;
++        IMFMediaType_AddRef(type);
++    }
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_SetOutputType(IMFTransform *iface, DWORD id, IMFMediaType *type, DWORD flags)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++    DWORD cmp_flags;
++    HRESULT hr;
++
++    TRACE("%p, %d, %p, %d.\n", iface, id, type, flags);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    if (!transform->type)
++        return MF_E_TRANSFORM_TYPE_NOT_SET;
++
++    hr = IMFMediaType_IsEqual(transform->type, type, &cmp_flags);
++    if (FAILED(hr))
++        return hr;
++
++    if (!(cmp_flags & MF_MEDIATYPE_EQUAL_FORMAT_DATA))
++        return MF_E_INVALIDMEDIATYPE;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetInputCurrentType(IMFTransform *iface, DWORD id, IMFMediaType **type)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %p.\n", iface, id, type);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    if (!transform->type)
++        return MF_E_TRANSFORM_TYPE_NOT_SET;
++
++    *type = transform->type;
++    IMFMediaType_AddRef(*type);
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetOutputCurrentType(IMFTransform *iface, DWORD id, IMFMediaType **type)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %p.\n", iface, id, type);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    if (!transform->type)
++        return MF_E_TRANSFORM_TYPE_NOT_SET;
++
++    *type = transform->type;
++    IMFMediaType_AddRef(*type);
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetInputStatus(IMFTransform *iface, DWORD id, DWORD *flags)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %p.\n", iface, id, flags);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    *flags = transform->sample ? 0 : MFT_INPUT_STATUS_ACCEPT_DATA;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_GetOutputStatus(IMFTransform *iface, DWORD *flags)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %p.\n", iface, flags);
++
++    *flags = transform->sample ? MFT_OUTPUT_STATUS_SAMPLE_READY : 0;
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_SetOutputBounds(IMFTransform *iface, LONGLONG lower, LONGLONG upper)
++{
++    FIXME("%p, %s, %s.\n", iface, wine_dbgstr_longlong(lower), wine_dbgstr_longlong(upper));
++
++    return E_NOTIMPL;
++}
++
++static HRESULT WINAPI passthrough_transform_ProcessEvent(IMFTransform *iface, DWORD id, IMFMediaEvent *event)
++{
++    FIXME("%p, %d, %p.\n", iface, id, event);
++
++    return E_NOTIMPL;
++}
++
++static HRESULT WINAPI passthrough_transform_ProcessMessage(IMFTransform *iface, MFT_MESSAGE_TYPE message, ULONG_PTR param)
++{
++    FIXME("%p, %u, %Iu.\n", iface, message, param);
++
++    return E_NOTIMPL;
++}
++
++static HRESULT WINAPI passthrough_transform_ProcessInput(IMFTransform *iface, DWORD id, IMFSample *sample, DWORD flags)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++
++    TRACE("%p, %d, %p, %d.\n", iface, id, sample, flags);
++
++    if (id != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    if (transform->sample)
++        return MF_E_NOTACCEPTING;
++
++    transform->sample = sample;
++    IMFSample_AddRef(sample);
++
++    return S_OK;
++}
++
++static HRESULT WINAPI passthrough_transform_ProcessOutput(IMFTransform *iface, DWORD flags, DWORD count,
++        MFT_OUTPUT_DATA_BUFFER *samples, DWORD *status)
++{
++    struct passthrough_transform *transform = impl_from_IMFTransform(iface);
++    unsigned int i;
++
++    TRACE("%p, %d, %d, %p, %p.\n", iface, flags, count, samples, status);
++
++    if (!transform->sample)
++        return MF_E_TRANSFORM_NEED_MORE_INPUT;
++
++    if (samples[0].dwStreamID != 0)
++        return MF_E_INVALIDSTREAMNUMBER;
++
++    samples[0].pSample = transform->sample;
++    transform->sample = NULL;
++
++    for (i = 1; i < count; ++i)
++        samples[i].dwStatus = MFT_OUTPUT_DATA_BUFFER_NO_SAMPLE;
++
++    *status = 0;
++
++    return S_OK;
++}
++
++static const IMFTransformVtbl passthrough_transform_vtbl = {
++    passthrough_transform_QueryInterface,
++    passthrough_transform_AddRef,
++    passthrough_transform_Release,
++    passthrough_transform_GetStreamLimits,
++    passthrough_transform_GetStreamCount,
++    passthrough_transform_GetStreamIDs,
++    passthrough_transform_GetInputStreamInfo,
++    passthrough_transform_GetOutputStreamInfo,
++    passthrough_transform_GetAttributes,
++    passthrough_transform_GetInputStreamAttributes,
++    passthrough_transform_GetOutputStreamAttributes,
++    passthrough_transform_DeleteInputStream,
++    passthrough_transform_AddInputStreams,
++    passthrough_transform_GetInputAvailableType,
++    passthrough_transform_GetOutputAvailableType,
++    passthrough_transform_SetInputType,
++    passthrough_transform_SetOutputType,
++    passthrough_transform_GetInputCurrentType,
++    passthrough_transform_GetOutputCurrentType,
++    passthrough_transform_GetInputStatus,
++    passthrough_transform_GetOutputStatus,
++    passthrough_transform_SetOutputBounds,
++    passthrough_transform_ProcessEvent,
++    passthrough_transform_ProcessMessage,
++    passthrough_transform_ProcessInput,
++    passthrough_transform_ProcessOutput,
++};
++
++static HRESULT create_passthrough_transform(IMFTransform **transform)
++{
++    struct passthrough_transform *obj;
++    HRESULT hr;
++
++    if (!(obj = calloc(1, sizeof(*obj))))
++        return E_OUTOFMEMORY;
++
++    obj->IMFTransform_iface.lpVtbl = &passthrough_transform_vtbl;
++    obj->refcount = 1;
++
++    hr = MFCreateAttributes(&obj->attributes, 0);
++    if (SUCCEEDED(hr))
++        hr = MFCreateAttributes(&obj->input_attributes, 0);
++    if (SUCCEEDED(hr))
++        hr = MFCreateAttributes(&obj->output_attributes, 0);
++
++    if (SUCCEEDED(hr))
++    {
++        *transform = &obj->IMFTransform_iface;
++    }
++    else
++    {
++        if (obj->attributes)
++            IMFAttributes_Release(obj->attributes);
++        if (obj->input_attributes)
++            IMFAttributes_Release(obj->input_attributes);
++        if (obj->output_attributes)
++            IMFAttributes_Release(obj->output_attributes);
++        free(obj);
++    }
++
++    return hr;
++}
++
+ static HRESULT WINAPI source_reader_async_command_QueryInterface(IUnknown *iface, REFIID riid, void **obj)
+ {
+     if (IsEqualIID(riid, &IID_IUnknown))
+@@ -1778,6 +2233,36 @@ static HRESULT source_reader_configure_decoder(struct source_reader *reader, DWO
+     return MF_E_TOPO_CODEC_NOT_FOUND;
+ }
+ 
++static HRESULT source_reader_add_passthrough_transform(struct source_reader *reader, DWORD index, IMFMediaType *type)
++{
++    IMFTransform *transform;
++    HRESULT hr;
++
++    if (FAILED(hr = create_passthrough_transform(&transform)))
++        return hr;
++
++    if (FAILED(hr = IMFTransform_SetInputType(transform, 0, type, 0)))
++    {
++        WARN("Failed to set decoder input type, hr %#x.\n", hr);
++        IMFTransform_Release(transform);
++        return hr;
++    }
++
++    if (FAILED(hr = IMFTransform_SetOutputType(transform, 0, type, 0)))
++    {
++        WARN("Failed to set decoder input type, hr %#x.\n", hr);
++        IMFTransform_Release(transform);
++        return hr;
++    }
++
++    if (reader->streams[index].decoder.transform)
++        IMFTransform_Release(reader->streams[index].decoder.transform);
++    reader->streams[index].decoder.transform = transform;
++    reader->streams[index].decoder.min_buffer_size = 0;
++
++    return S_OK;
++}
++
+ static HRESULT source_reader_create_decoder_for_stream(struct source_reader *reader, DWORD index, IMFMediaType *output_type)
+ {
+     MFT_REGISTER_TYPE_INFO in_type, out_type;
+@@ -1866,6 +2351,8 @@ static HRESULT WINAPI src_reader_SetCurrentMediaType(IMFSourceReader *iface, DWO
+     hr = source_reader_set_compatible_media_type(reader, index, type);
+     if (hr == S_FALSE)
+         hr = source_reader_create_decoder_for_stream(reader, index, type);
++    else if (hr == S_OK)
++        hr = source_reader_add_passthrough_transform(reader, index, reader->streams[index].current);
+     if (SUCCEEDED(hr))
+         hr = source_reader_setup_sample_allocator(reader, index);
+ 
+-- 
+2.37.1
+
+From 40041c494d569c416da23e57f90221b48ab9444e Mon Sep 17 00:00:00 2001
+From: Giovanni Mascellani <gmascellani@codeweavers.com>
+Date: Thu, 4 Nov 2021 16:36:06 +0100
+Subject: [PATCH 4/5] mfreadwrite/reader: Initialize the sample allocators
+ with attributes from both the reader and the transform.
+
+Some applications (e.g., Trailmakers) set the output attribute
+MF_SA_D3D11_SHARED_WITHOUT_MUTEX on the source reader's transform,
+seemingly expecting that it will be picked up by
+IMFVideoSampleAllocatorEx::InitializeSampleAllocator(), so that the
+generated samples will be shareable.
+
+The same happens with the reader's own attributes (e.g., Halo Infinite),
+so we collect attributes from there as well.
+
+CW-Bug-Id: #19126
+---
+ dlls/mfreadwrite/reader.c | 34 +++++++++++++++++++++++++++++++++-
+ 1 file changed, 33 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/mfreadwrite/reader.c b/dlls/mfreadwrite/reader.c
+index b5e0c05b171..61c8bfd3210 100644
+--- a/dlls/mfreadwrite/reader.c
++++ b/dlls/mfreadwrite/reader.c
+@@ -2125,6 +2125,7 @@ static HRESULT source_reader_setup_sample_allocator(struct source_reader *reader
+ {
+     struct media_stream *stream = &reader->streams[index];
+     IMFVideoSampleAllocatorCallback *callback;
++    IMFAttributes *attributes;
+     GUID major = { 0 };
+     HRESULT hr;
+ 
+@@ -2151,9 +2152,40 @@ static HRESULT source_reader_setup_sample_allocator(struct source_reader *reader
+         return hr;
+     }
+ 
+-    if (FAILED(hr = IMFVideoSampleAllocatorEx_InitializeSampleAllocatorEx(stream->allocator, 2, 8, NULL, stream->current)))
++    if (FAILED(hr = MFCreateAttributes(&attributes, 8)))
++    {
++        WARN("Failed to create attributes object, hr %#x.\n", hr);
++        return hr;
++    }
++
++    if (reader->attributes)
++    {
++        if (FAILED(hr = IMFAttributes_CopyAllItems(reader->attributes, attributes)))
++            WARN("Failed to copy reader attributes, hr %#x.\n", hr);
++    }
++
++    if (stream->decoder.transform)
++    {
++        IMFAttributes *output_attributes;
++
++        if (FAILED(hr = IMFTransform_GetOutputStreamAttributes(stream->decoder.transform, 0, &output_attributes)))
++        {
++            WARN("Failed to get output stream attributes, hr %#x.\n", hr);
++        }
++        else
++        {
++            if (FAILED(hr = IMFAttributes_CopyAllItems(output_attributes, attributes)))
++                WARN("Failed to copy transform output attributes, hr %#x.\n", hr);
++
++            IMFAttributes_Release(output_attributes);
++        }
++    }
++
++    if (FAILED(hr = IMFVideoSampleAllocatorEx_InitializeSampleAllocatorEx(stream->allocator, 2, 8, attributes, stream->current)))
+         WARN("Failed to initialize sample allocator, hr %#lx.\n", hr);
+ 
++    IMFAttributes_Release(attributes);
++
+     if (SUCCEEDED(IMFVideoSampleAllocatorEx_QueryInterface(stream->allocator, &IID_IMFVideoSampleAllocatorCallback, (void **)&callback)))
+     {
+         if (FAILED(hr = IMFVideoSampleAllocatorCallback_SetCallback(callback, &stream->notify_cb)))
+-- 
+2.37.1
+
+From 649717ad0a34e07886fd2568623b5e33b2a875f3 Mon Sep 17 00:00:00 2001
+From: Giovanni Mascellani <gmascellani@codeweavers.com>
+Date: Mon, 15 Nov 2021 13:06:10 +0100
+Subject: [PATCH 5/5] mfreadwrite/reader: Setup the sample allocator in
+ ReadSample.
+
+Currently the source reader creates a sample allocator as soon as
+SetCurrentMediaType() is called. However on Windows if the output
+attribute MF_SA_D3D11_SHARED_WITHOUT_MUTEX is set on the transform
+after SetCurrentMediaType() is called, but before ReadSample() is
+called, the sample allocator will generate shareable samples.
+
+In order to emulate the same behavior, we defer creating the sample
+allocator to the first ReadSample() call, so the most updated
+attributes are picked up.
+
+With this and the previous two patches, some video playback bugs
+are solved for some games (e.g. Trailmakers, Rustler, TOHU and
+others) when using DXVK (wined3d doesn't currently support
+shared resources, so there is no way to check with it).
+
+CW-Bug-Id: #19126
+---
+ dlls/mfreadwrite/reader.c | 30 ++++++++++++++++++++++++++----
+ 1 file changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/dlls/mfreadwrite/reader.c b/dlls/mfreadwrite/reader.c
+index 61c8bfd3210..78e72c05db2 100644
+--- a/dlls/mfreadwrite/reader.c
++++ b/dlls/mfreadwrite/reader.c
+@@ -1695,6 +1695,8 @@ static HRESULT source_reader_flush(struct source_reader *reader, unsigned int in
+     return hr;
+ }
+ 
++static HRESULT source_reader_setup_sample_allocator(struct source_reader *reader, unsigned int index);
++
+ static HRESULT WINAPI source_reader_async_commands_callback_Invoke(IMFAsyncCallback *iface, IMFAsyncResult *result)
+ {
+     struct source_reader *reader = impl_from_async_commands_callback_IMFAsyncCallback(iface);
+@@ -1724,7 +1726,15 @@ static HRESULT WINAPI source_reader_async_commands_callback_Invoke(IMFAsyncCallb
+                 {
+                     stream = &reader->streams[stream_index];
+ 
+-                    if (!(report_sample = source_reader_get_read_result(reader, stream, command->u.read.flags, &status,
++                    if (!stream->allocator)
++                    {
++                        hr = source_reader_setup_sample_allocator(reader, stream_index);
++
++                        if (FAILED(hr))
++                            WARN("Failed to setup the sample allocator, hr %#x.\n", hr);
++                    }
++
++                    if (SUCCEEDED(hr) && !(report_sample = source_reader_get_read_result(reader, stream, command->u.read.flags, &status,
+                             &stream_index, &stream_flags, &timestamp, &sample)))
+                     {
+                         stream->requests++;
+@@ -2385,8 +2395,12 @@ static HRESULT WINAPI src_reader_SetCurrentMediaType(IMFSourceReader *iface, DWO
+         hr = source_reader_create_decoder_for_stream(reader, index, type);
+     else if (hr == S_OK)
+         hr = source_reader_add_passthrough_transform(reader, index, reader->streams[index].current);
+-    if (SUCCEEDED(hr))
+-        hr = source_reader_setup_sample_allocator(reader, index);
++
++    if (reader->streams[index].allocator)
++    {
++        IMFVideoSampleAllocatorEx_Release(reader->streams[index].allocator);
++        reader->streams[index].allocator = NULL;
++    }
+ 
+     LeaveCriticalSection(&reader->cs);
+ 
+@@ -2484,7 +2498,15 @@ static HRESULT source_reader_read_sample(struct source_reader *reader, DWORD ind
+ 
+             stream = &reader->streams[stream_index];
+ 
+-            if (!source_reader_get_read_result(reader, stream, flags, &hr, actual_index, stream_flags,
++            if (!stream->allocator)
++            {
++                hr = source_reader_setup_sample_allocator(reader, stream_index);
++
++                if (FAILED(hr))
++                    WARN("Failed to setup the sample allocator, hr %#x.\n", hr);
++            }
++
++            if (SUCCEEDED(hr) && !source_reader_get_read_result(reader, stream, flags, &hr, actual_index, stream_flags,
+                    timestamp, sample))
+             {
+                 while (!source_reader_got_response_for_stream(reader, stream) && stream->state != STREAM_STATE_EOS)
+-- 
+2.37.1
+

--- a/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-mfplat.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-mfplat.patch
@@ -1,0 +1,343 @@
+From dcb7d79931982a15553c5be0b136457f31bceb1a Mon Sep 17 00:00:00 2001
+From: Giovanni Mascellani <gmascellani@codeweavers.com>
+Date: Mon, 6 Jun 2022 12:28:58 +0200
+Subject: [PATCH 1/3] mfplat: Implement IMF2DBuffer2::Copy2DTo().
+
+Signed-off-by: Giovanni Mascellani <gmascellani@codeweavers.com>
+---
+ dlls/mfplat/buffer.c | 84 ++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 65 insertions(+), 19 deletions(-)
+
+diff --git a/dlls/mfplat/buffer.c b/dlls/mfplat/buffer.c
+index e3d38438b88..9f3c11f97e1 100644
+--- a/dlls/mfplat/buffer.c
++++ b/dlls/mfplat/buffer.c
+@@ -32,7 +32,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(mfplat);
+ 
+ #define ALIGN_SIZE(size, alignment) (((size) + (alignment)) & ~((alignment)))
+ 
+-typedef void (*p_copy_image_func)(BYTE *dest, LONG dest_stride, const BYTE *src, LONG src_stride, DWORD width, DWORD lines);
++typedef HRESULT (*p_copy_image_func)(BYTE *dest, LONG dest_stride, const BYTE *src, LONG src_stride, DWORD width, DWORD lines, DWORD dest_size);
+ 
+ struct buffer
+ {
+@@ -75,32 +75,49 @@ struct buffer
+     CRITICAL_SECTION cs;
+ };
+ 
+-static void copy_image(const struct buffer *buffer, BYTE *dest, LONG dest_stride, const BYTE *src,
+-        LONG src_stride, DWORD width, DWORD lines)
++static HRESULT copy_image(const struct buffer *buffer, BYTE *dest, LONG dest_stride, const BYTE *src,
++        LONG src_stride, DWORD width, DWORD lines, DWORD dest_size)
+ {
+     MFCopyImage(dest, dest_stride, src, src_stride, width, lines);
+ 
++    if (width > abs(dest_stride) || abs(dest_stride) * lines > dest_size)
++        return E_NOT_SUFFICIENT_BUFFER;
++
+     if (buffer->_2d.copy_image)
+     {
+         dest += dest_stride * lines;
+         src += src_stride * lines;
+-        buffer->_2d.copy_image(dest, dest_stride, src, src_stride, width, lines);
++        return buffer->_2d.copy_image(dest, dest_stride, src, src_stride, width, lines, dest_size);
+     }
++
++    return S_OK;
+ }
+ 
+-static void copy_image_nv12(BYTE *dest, LONG dest_stride, const BYTE *src, LONG src_stride, DWORD width, DWORD lines)
++static HRESULT copy_image_nv12(BYTE *dest, LONG dest_stride, const BYTE *src,
++        LONG src_stride, DWORD width, DWORD lines, DWORD dest_size)
+ {
+-    MFCopyImage(dest, dest_stride, src, src_stride, width, lines / 2);
++    if (abs(dest_stride) * lines * 3 / 2 > dest_size)
++        return E_NOT_SUFFICIENT_BUFFER;
++
++    return MFCopyImage(dest, dest_stride, src, src_stride, width, lines / 2);
+ }
+ 
+-static void copy_image_imc1(BYTE *dest, LONG dest_stride, const BYTE *src, LONG src_stride, DWORD width, DWORD lines)
++static HRESULT copy_image_imc1(BYTE *dest, LONG dest_stride, const BYTE *src,
++        LONG src_stride, DWORD width, DWORD lines, DWORD dest_size)
+ {
+-    MFCopyImage(dest, dest_stride, src, src_stride, width / 2, lines);
++    if (abs(dest_stride) * lines * 2 > dest_size)
++        return E_NOT_SUFFICIENT_BUFFER;
++
++    return MFCopyImage(dest, dest_stride, src, src_stride, width / 2, lines);
+ }
+ 
+-static void copy_image_imc2(BYTE *dest, LONG dest_stride, const BYTE *src, LONG src_stride, DWORD width, DWORD lines)
++static HRESULT copy_image_imc2(BYTE *dest, LONG dest_stride, const BYTE *src,
++        LONG src_stride, DWORD width, DWORD lines, DWORD dest_size)
+ {
+-    MFCopyImage(dest, dest_stride / 2, src, src_stride / 2, width / 2, lines);
++    if (abs(dest_stride) * 3 / 2 * lines > dest_size)
++        return E_NOT_SUFFICIENT_BUFFER;
++
++    return MFCopyImage(dest, dest_stride / 2, src, src_stride / 2, width / 2, lines);
+ }
+ 
+ static inline struct buffer *impl_from_IMFMediaBuffer(IMFMediaBuffer *iface)
+@@ -313,7 +330,7 @@ static HRESULT WINAPI memory_1d_2d_buffer_Lock(IMFMediaBuffer *iface, BYTE **dat
+ 
+         if (SUCCEEDED(hr))
+             copy_image(buffer, buffer->_2d.linear_buffer, buffer->_2d.width, buffer->data, buffer->_2d.pitch,
+-                    buffer->_2d.width, buffer->_2d.height);
++                    buffer->_2d.width, buffer->_2d.height, buffer->_2d.plane_size);
+     }
+ 
+     if (SUCCEEDED(hr))
+@@ -342,7 +359,7 @@ static HRESULT WINAPI memory_1d_2d_buffer_Unlock(IMFMediaBuffer *iface)
+     if (buffer->_2d.linear_buffer && !--buffer->_2d.locks)
+     {
+         copy_image(buffer, buffer->data, buffer->_2d.pitch, buffer->_2d.linear_buffer, buffer->_2d.width,
+-                buffer->_2d.width, buffer->_2d.height);
++                buffer->_2d.width, buffer->_2d.height, buffer->max_length);
+ 
+         free(buffer->_2d.linear_buffer);
+         buffer->_2d.linear_buffer = NULL;
+@@ -392,7 +409,7 @@ static HRESULT WINAPI d3d9_surface_buffer_Lock(IMFMediaBuffer *iface, BYTE **dat
+             if (SUCCEEDED(hr))
+             {
+                 copy_image(buffer, buffer->_2d.linear_buffer, buffer->_2d.width, rect.pBits, rect.Pitch,
+-                        buffer->_2d.width, buffer->_2d.height);
++                        buffer->_2d.width, buffer->_2d.height, buffer->_2d.plane_size);
+                 IDirect3DSurface9_UnlockRect(buffer->d3d9_surface.surface);
+             }
+         }
+@@ -431,7 +448,7 @@ static HRESULT WINAPI d3d9_surface_buffer_Unlock(IMFMediaBuffer *iface)
+         if (SUCCEEDED(hr = IDirect3DSurface9_LockRect(buffer->d3d9_surface.surface, &rect, NULL, 0)))
+         {
+             copy_image(buffer, rect.pBits, rect.Pitch, buffer->_2d.linear_buffer, buffer->_2d.width,
+-                    buffer->_2d.width, buffer->_2d.height);
++                    buffer->_2d.width, buffer->_2d.height, buffer->max_length);
+             IDirect3DSurface9_UnlockRect(buffer->d3d9_surface.surface);
+         }
+ 
+@@ -632,11 +649,40 @@ static HRESULT WINAPI memory_2d_buffer_Lock2DSize(IMF2DBuffer2 *iface, MF2DBuffe
+     return hr;
+ }
+ 
+-static HRESULT WINAPI memory_2d_buffer_Copy2DTo(IMF2DBuffer2 *iface, IMF2DBuffer2 *dest_buffer)
++static HRESULT WINAPI memory_2d_buffer_Copy2DTo(IMF2DBuffer2 *iface, IMF2DBuffer2 *dst_buffer)
+ {
+-    FIXME("%p, %p.\n", iface, dest_buffer);
++    BYTE *src_scanline0, *dst_scanline0, *src_buffer_start, *dst_buffer_start;
++    struct buffer *buffer = impl_from_IMF2DBuffer2(iface);
++    BOOL src_locked = FALSE, dst_locked = FALSE;
++    DWORD src_length, dst_length;
++    LONG src_pitch, dst_pitch;
++    HRESULT hr;
+ 
+-    return E_NOTIMPL;
++    TRACE("%p, %p.\n", iface, dst_buffer);
++
++    hr = IMF2DBuffer2_Lock2DSize(iface, MF2DBuffer_LockFlags_Read, &src_scanline0,
++            &src_pitch, &src_buffer_start, &src_length);
++    if (FAILED(hr))
++        goto end;
++    src_locked = TRUE;
++
++    hr = IMF2DBuffer2_Lock2DSize(dst_buffer, MF2DBuffer_LockFlags_Write, &dst_scanline0,
++            &dst_pitch, &dst_buffer_start, &dst_length);
++    if (FAILED(hr))
++        goto end;
++    dst_locked = TRUE;
++
++    hr = copy_image(buffer, dst_scanline0, dst_pitch, src_scanline0, src_pitch,
++            buffer->_2d.width, buffer->_2d.height, dst_length);
++
++end:
++    if (src_locked && FAILED(IMF2DBuffer2_Unlock2D(iface)))
++        WARN("Couldn't unlock source buffer %p, hr %#lx.\n", iface, hr);
++
++    if (dst_locked && FAILED(IMF2DBuffer2_Unlock2D(dst_buffer)))
++        WARN("Couldn't unlock destination buffer %p, hr %#lx.\n", dst_buffer, hr);
++
++    return hr;
+ }
+ 
+ static const IMF2DBuffer2Vtbl memory_2d_buffer_vtbl =
+@@ -971,7 +1017,7 @@ static HRESULT WINAPI dxgi_surface_buffer_Lock(IMFMediaBuffer *iface, BYTE **dat
+             if (SUCCEEDED(hr))
+             {
+                 copy_image(buffer, buffer->_2d.linear_buffer, buffer->_2d.width, buffer->dxgi_surface.map_desc.pData,
+-                        buffer->dxgi_surface.map_desc.RowPitch, buffer->_2d.width, buffer->_2d.height);
++                        buffer->dxgi_surface.map_desc.RowPitch, buffer->_2d.width, buffer->_2d.height, buffer->_2d.plane_size);
+             }
+         }
+     }
+@@ -1005,7 +1051,7 @@ static HRESULT WINAPI dxgi_surface_buffer_Unlock(IMFMediaBuffer *iface)
+     else if (!--buffer->_2d.locks)
+     {
+         copy_image(buffer, buffer->dxgi_surface.map_desc.pData, buffer->dxgi_surface.map_desc.RowPitch,
+-                buffer->_2d.linear_buffer, buffer->_2d.width, buffer->_2d.width, buffer->_2d.height);
++                buffer->_2d.linear_buffer, buffer->_2d.width, buffer->_2d.width, buffer->_2d.height, buffer->max_length);
+         dxgi_surface_buffer_unmap(buffer);
+ 
+         free(buffer->_2d.linear_buffer);
+-- 
+GitLab
+
+
+From 94a4b28634eef9c866370dc9470cca90b032c9a6 Mon Sep 17 00:00:00 2001
+From: Giovanni Mascellani <gmascellani@codeweavers.com>
+Date: Mon, 11 Jul 2022 11:30:48 +0200
+Subject: [PATCH 2/3] mfplat/tests: Test IMF2DBuffer2::Copy2DTo().
+
+Signed-off-by: Giovanni Mascellani <gmascellani@codeweavers.com>
+---
+ dlls/mfplat/tests/mfplat.c | 33 ++++++++++++++++++++++-----------
+ 1 file changed, 22 insertions(+), 11 deletions(-)
+
+diff --git a/dlls/mfplat/tests/mfplat.c b/dlls/mfplat/tests/mfplat.c
+index 0249e7a13fb..577811aa1d0 100644
+--- a/dlls/mfplat/tests/mfplat.c
++++ b/dlls/mfplat/tests/mfplat.c
+@@ -5728,12 +5728,12 @@ static void test_MFCreate2DMediaBuffer(void)
+ {
+     static const char two_aas[] = { 0xaa, 0xaa };
+     static const char eight_bbs[] = { 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb };
++    IMF2DBuffer2 *_2dbuffer2, *_2dtarget2;
+     DWORD max_length, length, length2;
+     BYTE *buffer_start, *data, *data2;
++    IMFMediaBuffer *buffer, *target;
+     LONG pitch, pitch2, stride;
+-    IMF2DBuffer2 *_2dbuffer2;
+     IMF2DBuffer *_2dbuffer;
+-    IMFMediaBuffer *buffer;
+     int i, j, k;
+     HRESULT hr;
+     BOOL ret;
+@@ -5935,10 +5935,10 @@ static void test_MFCreate2DMediaBuffer(void)
+         ok(length == ptr->max_length, "%u: unexpected maximum length %lu for %u x %u, format %s.\n",
+                 i, length, ptr->width, ptr->height, wine_dbgstr_guid(ptr->subtype));
+ 
+-        hr = IMFMediaBuffer_QueryInterface(buffer, &IID_IMF2DBuffer, (void **)&_2dbuffer);
++        hr = IMFMediaBuffer_QueryInterface(buffer, &IID_IMF2DBuffer2, (void **)&_2dbuffer2);
+         ok(hr == S_OK, "Failed to get interface, hr %#lx.\n", hr);
+ 
+-        hr = IMF2DBuffer_GetContiguousLength(_2dbuffer, &length);
++        hr = IMF2DBuffer2_GetContiguousLength(_2dbuffer2, &length);
+         ok(hr == S_OK, "Failed to get length, hr %#lx.\n", hr);
+         ok(length == ptr->contiguous_length, "%d: unexpected contiguous length %lu for %u x %u, format %s.\n",
+                 i, length, ptr->width, ptr->height, wine_dbgstr_guid(ptr->subtype));
+@@ -5994,10 +5994,22 @@ static void test_MFCreate2DMediaBuffer(void)
+         hr = IMFMediaBuffer_Unlock(buffer);
+         ok(hr == S_OK, "Failed to unlock buffer, hr %#lx.\n", hr);
+ 
+-        hr = IMF2DBuffer_Lock2D(_2dbuffer, &data, &pitch);
++        hr = pMFCreate2DMediaBuffer(ptr->width, ptr->height, ptr->subtype->Data1, FALSE, &target);
++        ok(hr == S_OK, "Failed to create a buffer, hr %#lx.\n", hr);
++
++        hr = IMFMediaBuffer_QueryInterface(target, &IID_IMF2DBuffer2, (void **)&_2dtarget2);
++        ok(hr == S_OK, "Failed to get interface, hr %#lx.\n", hr);
++
++        hr = IMF2DBuffer2_Copy2DTo(_2dbuffer2, _2dtarget2);
++        ok(hr == S_OK, "Failed to copy buffer, hr %#lx.\n", hr);
++
++        IMF2DBuffer2_Release(_2dbuffer2);
++        IMFMediaBuffer_Release(buffer);
++
++        hr = IMF2DBuffer2_Lock2D(_2dtarget2, &data, &pitch);
+         ok(hr == S_OK, "Failed to lock buffer, hr %#lx.\n", hr);
+ 
+-        hr = IMF2DBuffer_GetScanline0AndPitch(_2dbuffer, &data2, &pitch2);
++        hr = IMF2DBuffer2_GetScanline0AndPitch(_2dtarget2, &data2, &pitch2);
+         ok(hr == S_OK, "Failed to get scanline, hr %#lx.\n", hr);
+         ok(data2 == data, "Unexpected data pointer.\n");
+         ok(pitch == pitch2, "Unexpected pitch.\n");
+@@ -6044,20 +6056,19 @@ static void test_MFCreate2DMediaBuffer(void)
+                 ;
+         }
+ 
+-        hr = IMF2DBuffer_Unlock2D(_2dbuffer);
++        hr = IMF2DBuffer2_Unlock2D(_2dtarget2);
+         ok(hr == S_OK, "Failed to unlock buffer, hr %#lx.\n", hr);
+ 
+         ok(pitch == ptr->pitch, "%d: unexpected pitch %ld, expected %d, %u x %u, format %s.\n", i, pitch, ptr->pitch,
+                 ptr->width, ptr->height, wine_dbgstr_guid(ptr->subtype));
+ 
+         ret = TRUE;
+-        hr = IMF2DBuffer_IsContiguousFormat(_2dbuffer, &ret);
++        hr = IMF2DBuffer2_IsContiguousFormat(_2dtarget2, &ret);
+         ok(hr == S_OK, "Failed to get format flag, hr %#lx.\n", hr);
+         ok(!ret, "%d: unexpected format flag %d.\n", i, ret);
+ 
+-        IMF2DBuffer_Release(_2dbuffer);
+-
+-        IMFMediaBuffer_Release(buffer);
++        IMF2DBuffer2_Release(_2dtarget2);
++        IMFMediaBuffer_Release(target);
+     }
+ 
+     /* Alignment tests */
+-- 
+GitLab
+
+
+From 7b5adc0afd520e426f4f5a3bf3c6c3a93bf2af89 Mon Sep 17 00:00:00 2001
+From: Giovanni Mascellani <gmascellani@codeweavers.com>
+Date: Mon, 6 Jun 2022 13:37:48 +0200
+Subject: [PATCH 3/3] mfplat/sample: Use Copy2DTo when copying samples, if
+ available.
+
+Signed-off-by: Giovanni Mascellani <gmascellani@codeweavers.com>
+---
+ dlls/mfplat/sample.c | 31 +++++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/dlls/mfplat/sample.c b/dlls/mfplat/sample.c
+index 687ada1a477..a0082660235 100644
+--- a/dlls/mfplat/sample.c
++++ b/dlls/mfplat/sample.c
+@@ -791,6 +791,28 @@ static HRESULT WINAPI sample_GetTotalLength(IMFSample *iface, DWORD *total_lengt
+     return S_OK;
+ }
+ 
++static HRESULT copy_2d_buffer(IMFMediaBuffer *src, IMFMediaBuffer *dst)
++{
++    IMF2DBuffer2 *src2d = NULL, *dst2d = NULL;
++    HRESULT hr = S_OK;
++
++    hr = IMFMediaBuffer_QueryInterface(src, &IID_IMF2DBuffer2, (void **)&src2d);
++
++    if (SUCCEEDED(hr))
++        hr = IMFMediaBuffer_QueryInterface(dst, &IID_IMF2DBuffer2, (void **)&dst2d);
++
++    if (SUCCEEDED(hr))
++        hr = IMF2DBuffer2_Copy2DTo(src2d, dst2d);
++
++    if (src2d)
++        IMF2DBuffer2_Release(src2d);
++
++    if (dst2d)
++        IMF2DBuffer2_Release(dst2d);
++
++    return hr;
++}
++
+ static HRESULT WINAPI sample_CopyToBuffer(IMFSample *iface, IMFMediaBuffer *buffer)
+ {
+     struct sample *sample = impl_from_IMFSample(iface);
+@@ -804,6 +826,15 @@ static HRESULT WINAPI sample_CopyToBuffer(IMFSample *iface, IMFMediaBuffer *buff
+ 
+     EnterCriticalSection(&sample->attributes.cs);
+ 
++    if (sample->buffer_count == 1)
++    {
++        if (SUCCEEDED(hr = copy_2d_buffer(sample->buffers[0], buffer)))
++        {
++            LeaveCriticalSection(&sample->attributes.cs);
++            return hr;
++        }
++    }
++
+     total_length = sample_get_total_length(sample);
+     dst_current_length = 0;
+ 
+-- 
+GitLab
+

--- a/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures.patch
@@ -1,0 +1,5730 @@
+From 8d8fa98e3e439e8b00afb769a2086fe0de3d859f Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 19 May 2021 13:33:36 -0400
+Subject: [PATCH 1/4] winevulkan: Implement VK_KHR_external_memory_win32 for
+ buffers.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/vulkan-1/tests/vulkan.c     |   5 +-
+ dlls/winevulkan/make_vulkan      |  27 ++-
+ dlls/winevulkan/vulkan.c         | 396 ++++++++++++++++++++++++++++++-
+ dlls/winevulkan/vulkan_private.h |  24 ++
+ 4 files changed, 432 insertions(+), 20 deletions(-)
+
+diff --git a/dlls/vulkan-1/tests/vulkan.c b/dlls/vulkan-1/tests/vulkan.c
+index 11d20120d1d..ee323c69ec0 100644
+--- a/dlls/vulkan-1/tests/vulkan.c
++++ b/dlls/vulkan-1/tests/vulkan.c
+@@ -615,8 +615,9 @@ static void import_memory(VkDevice vk_device, VkMemoryAllocateInfo alloc_info, V
+         import_handle_info.name = L"wine_test_buffer_export_name";
+ 
+         vr = vkAllocateMemory(vk_device, &alloc_info, NULL, &memory);
+-        ok(vr == VK_SUCCESS, "vkAllocateMemory failed, VkResult %d.\n", vr);
+-        vkFreeMemory(vk_device, memory, NULL);
++        todo_wine ok(vr == VK_SUCCESS, "vkAllocateMemory failed, VkResult %d.\n", vr);
++        if (vr == VK_SUCCESS)
++            vkFreeMemory(vk_device, memory, NULL);
+     }
+ }
+ 
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index d905412ca0d..5dd441c5b44 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -111,7 +111,6 @@ UNSUPPORTED_EXTENSIONS = [
+     "VK_EXT_physical_device_drm",
+     "VK_GOOGLE_surfaceless_query",
+     "VK_KHR_external_fence_fd",
+-    "VK_KHR_external_memory_fd",
+     "VK_KHR_external_semaphore_fd",
+ 
+     # Extensions which require callback handling
+@@ -126,7 +125,7 @@ UNSUPPORTED_EXTENSIONS = [
+ # winevulkan may nonetheless use, or extensions we want to generate headers for
+ # but not expose to applications (useful for test commits)
+ UNEXPOSED_EXTENSIONS = {
+-    "VK_KHR_external_memory_win32",
++    "VK_KHR_external_memory_fd",
+ }
+ 
+ # The Vulkan loader provides entry-points for core functionality and important
+@@ -191,7 +190,7 @@ FUNCTION_OVERRIDES = {
+     "vkEnumerateDeviceLayerProperties": {"dispatch": True, "driver": False, "thunk": ThunkType.NONE},
+     "vkEnumeratePhysicalDeviceGroups" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkEnumeratePhysicalDevices" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetPhysicalDeviceExternalBufferProperties" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetPhysicalDeviceExternalBufferProperties" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetPhysicalDeviceExternalFenceProperties" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetPhysicalDeviceExternalSemaphoreProperties" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetPhysicalDeviceImageFormatProperties2" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+@@ -200,12 +199,15 @@ FUNCTION_OVERRIDES = {
+ 
+     # Device functions
+     "vkAllocateCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkAllocateMemory" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkCreateBuffer" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkCreateCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkCreateComputePipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+     "vkCreateGraphicsPipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+     "vkDestroyCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkDestroyDevice" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkFreeCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkFreeMemory" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetDeviceProcAddr" : {"dispatch" : False, "driver" : True, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.NONE},
+     "vkGetDeviceQueue" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetDeviceQueue2" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+@@ -237,7 +239,7 @@ FUNCTION_OVERRIDES = {
+     "vkGetPhysicalDeviceExternalFencePropertiesKHR" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
+ 
+     # VK_KHR_external_memory_capabilities
+-    "vkGetPhysicalDeviceExternalBufferPropertiesKHR" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetPhysicalDeviceExternalBufferPropertiesKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetPhysicalDeviceImageFormatProperties2KHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+ 
+     # VK_KHR_external_semaphore_capabilities
+@@ -267,12 +269,20 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_NV_ray_tracing
+     "vkCreateRayTracingPipelinesNV" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
++
++    # VK_KHR_external_memory_win32
++    "vkGetMemoryWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetMemoryWin32HandlePropertiesKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+ }
+ 
+ STRUCT_CHAIN_CONVERSIONS = {
+     # Ignore to not confuse host loader.
+     "VkDeviceCreateInfo": ["VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO"],
+     "VkInstanceCreateInfo": ["VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO"],
++
++    # Structs which require pNext chain modification
++    "VkBufferCreateInfo": [],
++    "VkMemoryAllocateInfo": ["VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"],
+ }
+ 
+ 
+@@ -1096,6 +1106,8 @@ class VkHandle(object):
+             return "wine_debug_report_callback_from_handle({0})->debug_callback".format(name)
+         if self.name == "VkSurfaceKHR":
+             return "wine_surface_from_handle({0})->surface".format(name)
++        if self.name == "VkDeviceMemory":
++            return "wine_dev_mem_from_handle({0})->dev_mem".format(name)
+ 
+         native_handle_name = None
+ 
+@@ -1255,7 +1267,8 @@ class VkMember(object):
+                     LOGGER.err("OUTPUT parameter {0}.{1} cannot be unwrapped".format(self.type, self.name))
+                 else:
+                     handle = self.type_info["data"]
+-                    return "{0}{1} = {2};\n".format(output, self.name, handle.driver_handle("{0}{1}".format(input, self.name)))
++                    input_name = "{0}{1}".format(input, self.name)
++                    return "{0}{1} = {2} ? {3} : VK_NULL_HANDLE;\n".format(output, self.name, input_name, handle.driver_handle(input_name))
+             elif self.is_generic_handle():
+                 if direction == Direction.OUTPUT:
+                     LOGGER.err("OUTPUT parameter {0}.{1} cannot be unwrapped".format(self.type, self.name))
+@@ -2188,7 +2201,7 @@ class ConversionFunction(object):
+                         body += "#endif /* USE_STRUCT_CONVERSION */\n"
+ 
+         elif isinstance(self.operand, VkHandle) and self.direction == Direction.INPUT:
+-            body += "        out[i] = " + self.operand.driver_handle("in[i]") + ";\n"
++            body += "        out[i] = in[i] ? " + self.operand.driver_handle("in[i]") + " : VK_NULL_HANDLE;\n"
+         else:
+             LOGGER.warn("Unhandled conversion operand type")
+             body += "        out[i] = in[i];\n"
+@@ -2330,7 +2343,7 @@ class ConversionFunction(object):
+                         body += "    " + unwrap
+                         body += "#endif /* USE_STRUCT_CONVERSION */\n"
+         elif isinstance(self.operand, VkHandle) and self.direction == Direction.INPUT:
+-            body += "        out[i] = " + self.operand.driver_handle("in[i]") + ";\n"
++            body += "        out[i] = in[i] ? " + self.operand.driver_handle("in[i]") + " : VK_NULL_HANDLE;\n"
+         else:
+             LOGGER.warn("Unhandled conversion operand type")
+             body += "        out[i] = in[i];\n"
+diff --git a/dlls/winevulkan/vulkan.c b/dlls/winevulkan/vulkan.c
+index da89cdd5ba2..5b0774c32bb 100644
+--- a/dlls/winevulkan/vulkan.c
++++ b/dlls/winevulkan/vulkan.c
+@@ -24,6 +24,11 @@
+ #include "config.h"
+ #include <time.h>
+ #include <stdlib.h>
++#include <unistd.h>
++
++#include "ntstatus.h"
++#define WIN32_NO_STATUS
++#include "wine/server.h"
+ 
+ #include "vulkan_private.h"
+ #include "wine/vulkan_driver.h"
+@@ -268,6 +273,15 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
+      */
+     for (i = 0; i < num_host_properties; i++)
+     {
++        if (!strcmp(host_properties[i].extensionName, "VK_KHR_external_memory_fd"))
++        {
++            TRACE("Substituting VK_KHR_external_memory_fd for VK_KHR_external_memory_win32\n");
++
++            snprintf(host_properties[i].extensionName, sizeof(host_properties[i].extensionName),
++                    VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
++            host_properties[i].specVersion = VK_KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION;
++        }
++
+         if (wine_vk_device_extension_supported(host_properties[i].extensionName))
+         {
+             TRACE("Enabling extension '%s' for physical device %p\n", host_properties[i].extensionName, object);
+@@ -366,12 +380,15 @@ static void wine_vk_device_get_queues(struct VkDevice_T *device,
+ static void wine_vk_device_free_create_info(VkDeviceCreateInfo *create_info)
+ {
+     free_VkDeviceCreateInfo_struct_chain(create_info);
++
++    if (create_info->enabledExtensionCount)
++        free((void *)create_info->ppEnabledExtensionNames);
+ }
+ 
+ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src,
+         VkDeviceCreateInfo *dst)
+ {
+-    unsigned int i;
++    unsigned int i, replace_win32 = 0;
+     VkResult res;
+ 
+     *dst = *src;
+@@ -386,19 +403,41 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
+     dst->enabledLayerCount = 0;
+     dst->ppEnabledLayerNames = NULL;
+ 
+-    TRACE("Enabled %u extensions.\n", dst->enabledExtensionCount);
+-    for (i = 0; i < dst->enabledExtensionCount; i++)
++    for (i = 0; i < src->enabledExtensionCount; i++)
+     {
+-        const char *extension_name = dst->ppEnabledExtensionNames[i];
+-        TRACE("Extension %u: %s.\n", i, debugstr_a(extension_name));
+-        if (!wine_vk_device_extension_supported(extension_name))
++        if (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
+         {
+-            WARN("Extension %s is not supported.\n", debugstr_a(extension_name));
+-            wine_vk_device_free_create_info(dst);
+-            return VK_ERROR_EXTENSION_NOT_PRESENT;
++            replace_win32 = 1;
++            break;
+         }
+     }
+ 
++    if (replace_win32)
++    {
++        unsigned int o = 0;
++        char **new_extensions_list;
++ 
++        new_extensions_list = malloc(sizeof(char *) * (dst->enabledExtensionCount));
++
++        for (i = 0; i < dst->enabledExtensionCount; i++)
++        {
++            if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
++                new_extensions_list[o] = strdup("VK_KHR_external_memory_fd");
++            else
++                new_extensions_list[o] = strdup(dst->ppEnabledExtensionNames[i]);
++            ++o;
++        }
++
++        dst->enabledExtensionCount = o;
++        dst->ppEnabledExtensionNames = (const char * const *)new_extensions_list;
++    }
++
++    TRACE("Enabled %u extensions.\n", dst->enabledExtensionCount);
++    for (i = 0; i < dst->enabledExtensionCount; i++)
++    {
++        TRACE("Extension %u: %s.\n", i, debugstr_a(dst->ppEnabledExtensionNames[i]));
++    }
++
+     return VK_SUCCESS;
+ }
+ 
+@@ -1272,6 +1311,57 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalFencePropertiesKHR(void *args)
+     return STATUS_SUCCESS;
+ }
+ 
++static inline void wine_vk_normalize_handle_types_win(VkExternalMemoryHandleTypeFlags *types)
++{
++    *types &=
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT;
++}
++
++static inline void wine_vk_normalize_handle_types_host(VkExternalMemoryHandleTypeFlags *types)
++{
++    *types &=
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT |
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT |
++/*      predicated on VK_KHR_external_memory_dma_buf
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT | */
++        VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT;
++}
++
++static void wine_vk_get_physical_device_external_buffer_properties(VkPhysicalDevice phys_dev,
++        void (*p_vkGetPhysicalDeviceExternalBufferProperties)(VkPhysicalDevice, const VkPhysicalDeviceExternalBufferInfo *, VkExternalBufferProperties *),
++        const VkPhysicalDeviceExternalBufferInfo *buffer_info, VkExternalBufferProperties *properties)
++{
++    VkPhysicalDeviceExternalBufferInfo buffer_info_dup = *buffer_info;
++
++    wine_vk_normalize_handle_types_win(&buffer_info_dup.handleType);
++    if (buffer_info_dup.handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++        buffer_info_dup.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
++    wine_vk_normalize_handle_types_host(&buffer_info_dup.handleType);
++
++    if (buffer_info->handleType && !buffer_info_dup.handleType)
++    {
++        memset(&properties->externalMemoryProperties, 0, sizeof(properties->externalMemoryProperties));
++        return;
++    }
++
++    p_vkGetPhysicalDeviceExternalBufferProperties(phys_dev->phys_dev, &buffer_info_dup, properties);
++
++    if (properties->externalMemoryProperties.exportFromImportedHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
++        properties->externalMemoryProperties.exportFromImportedHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++    wine_vk_normalize_handle_types_win(&properties->externalMemoryProperties.exportFromImportedHandleTypes);
++
++    if (properties->externalMemoryProperties.compatibleHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
++        properties->externalMemoryProperties.compatibleHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++    wine_vk_normalize_handle_types_win(&properties->externalMemoryProperties.compatibleHandleTypes);
++}
++
+ NTSTATUS wine_vkGetPhysicalDeviceExternalBufferProperties(void *args)
+ {
+     struct vkGetPhysicalDeviceExternalBufferProperties_params *params = args;
+@@ -1280,7 +1370,8 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalBufferProperties(void *args)
+     VkExternalBufferProperties *properties = params->pExternalBufferProperties;
+ 
+     TRACE("%p, %p, %p\n", phys_dev, buffer_info, properties);
+-    memset(&properties->externalMemoryProperties, 0, sizeof(properties->externalMemoryProperties));
++
++    wine_vk_get_physical_device_external_buffer_properties(phys_dev, phys_dev->instance->funcs.p_vkGetPhysicalDeviceExternalBufferProperties, buffer_info, properties);
+     return STATUS_SUCCESS;
+ }
+ 
+@@ -1292,7 +1383,8 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalBufferPropertiesKHR(void *args)
+     VkExternalBufferProperties *properties = params->pExternalBufferProperties;
+ 
+     TRACE("%p, %p, %p\n", phys_dev, buffer_info, properties);
+-    memset(&properties->externalMemoryProperties, 0, sizeof(properties->externalMemoryProperties));
++
++    wine_vk_get_physical_device_external_buffer_properties(phys_dev, phys_dev->instance->funcs.p_vkGetPhysicalDeviceExternalBufferPropertiesKHR, buffer_info, properties);
+     return STATUS_SUCCESS;
+ }
+ 
+@@ -1879,5 +1971,287 @@ BOOL WINAPI wine_vk_is_available_instance_function(VkInstance instance, const ch
+ 
+ BOOL WINAPI wine_vk_is_available_device_function(VkDevice device, const char *name)
+ {
++    if (!strcmp(name, "vkGetMemoryWin32HandleKHR") || !strcmp(name, "vkGetMemoryWin32HandlePropertiesKHR"))
++        name = "vkGetMemoryFdKHR";
+     return !!vk_funcs->p_vkGetDeviceProcAddr(device->device, name);
+ }
++
++static HANDLE create_gpu_resource(int fd, LPCWSTR name)
++{
++    HANDLE ret = INVALID_HANDLE_VALUE;
++
++    TRACE("Creating shared vulkan resource fd %d name %s.\n", fd, debugstr_w(name));
++
++    if (name)
++        FIXME("Naming gpu resources not supported.\n");
++
++    wine_server_fd_to_handle(fd, GENERIC_ALL, 0, &ret);
++
++    return ret;
++}
++
++NTSTATUS wine_vkAllocateMemory(void *args)
++{
++    struct vkAllocateMemory_params *params = args;
++    VkDevice device = params->device;
++    const VkMemoryAllocateInfo *allocate_info = params->pAllocateInfo;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++    VkDeviceMemory *memory = params->pMemory;
++
++    const VkImportMemoryWin32HandleInfoKHR *handle_import_info;
++    const VkExportMemoryWin32HandleInfoKHR *handle_export_info;
++    VkMemoryAllocateInfo allocate_info_dup = *allocate_info;
++    VkExportMemoryAllocateInfo *export_info;
++    VkImportMemoryFdInfoKHR fd_import_info;
++    struct wine_dev_mem *object;
++    VkResult res;
++    int fd;
++
++#if defined(USE_STRUCT_CONVERSION)
++    VkMemoryAllocateInfo_host allocate_info_host;
++    VkMemoryGetFdInfoKHR_host get_fd_info;
++#else
++    VkMemoryAllocateInfo allocate_info_host;
++    VkMemoryGetFdInfoKHR get_fd_info;
++#endif
++
++    TRACE("%p %p %p %p\n", device, allocate_info, allocator, memory);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if ((res = convert_VkMemoryAllocateInfo_struct_chain(allocate_info->pNext, &allocate_info_dup)) < 0)
++    {
++        WARN("Failed to convert VkMemoryAllocateInfo pNext chain, res=%d.\n", res);
++        return res;
++    }
++
++    if (!(object = calloc(1, sizeof(*object))))
++    {
++        free_VkMemoryAllocateInfo_struct_chain(&allocate_info_dup);
++        return VK_ERROR_OUT_OF_HOST_MEMORY;
++    }
++
++    object->dev_mem = VK_NULL_HANDLE;
++    object->handle = INVALID_HANDLE_VALUE;
++    fd_import_info.fd = -1;
++    fd_import_info.pNext = NULL;
++
++    /* find and process handle import/export info and grab it */
++    handle_import_info = wine_vk_find_struct(allocate_info, IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR);
++    handle_export_info = wine_vk_find_struct(allocate_info, EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR);
++    if (handle_export_info && handle_export_info->pAttributes && handle_export_info->pAttributes->lpSecurityDescriptor)
++        FIXME("Support for custom security descriptor not implemented.\n");
++
++    if ((export_info = wine_vk_find_struct(&allocate_info_dup, EXPORT_MEMORY_ALLOCATE_INFO)))
++    {
++        object->handle_types = export_info->handleTypes;
++        if (export_info->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++            export_info->handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
++        wine_vk_normalize_handle_types_host(&export_info->handleTypes);
++    }
++
++    /* Vulkan consumes imported FDs, but not imported HANDLEs */
++    if (handle_import_info)
++    {
++        fd_import_info.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR;
++        fd_import_info.pNext = allocate_info_dup.pNext;
++        fd_import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
++
++        switch (handle_import_info->handleType)
++        {
++            case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT:
++                if (handle_import_info->handle)
++                    NtDuplicateObject( NtCurrentProcess(), handle_import_info->handle, NtCurrentProcess(), &object->handle, 0, 0, DUPLICATE_SAME_ACCESS );
++                else if (handle_import_info->name)
++                    FIXME("Importing device memory by resource name not supported.\n");
++                break;
++            default:
++                WARN("Invalid handle type %08x passed in.\n", handle_import_info->handleType);
++                res = VK_ERROR_INVALID_EXTERNAL_HANDLE;
++                goto done;
++        }
++
++        if (object->handle != INVALID_HANDLE_VALUE)
++            wine_server_handle_to_fd(object->handle, FILE_READ_DATA, &fd_import_info.fd, NULL);
++
++        if (fd_import_info.fd == -1)
++        {
++            TRACE("Couldn't access resource handle or name. type=%08x handle=%p name=%s\n", handle_import_info->handleType, handle_import_info->handle,
++                    handle_import_info->name ? debugstr_w(handle_import_info->name) : "");
++            res = VK_ERROR_INVALID_EXTERNAL_HANDLE;
++            goto done;
++        }
++    }
++
++    allocate_info_host.sType = allocate_info_dup.sType;
++    allocate_info_host.pNext = fd_import_info.fd == -1 ? allocate_info_dup.pNext : &fd_import_info;
++    allocate_info_host.allocationSize = allocate_info_dup.allocationSize;
++    allocate_info_host.memoryTypeIndex = allocate_info_dup.memoryTypeIndex;
++
++    if ((res = device->funcs.p_vkAllocateMemory(device->device, &allocate_info_host, NULL, &object->dev_mem)) == VK_SUCCESS)
++    {
++        if (object->handle == INVALID_HANDLE_VALUE && export_info && export_info->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
++        {
++            get_fd_info.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
++            get_fd_info.pNext = NULL;
++            get_fd_info.memory = object->dev_mem;
++            get_fd_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
++
++            if (device->funcs.p_vkGetMemoryFdKHR(device->device, &get_fd_info, &fd) == VK_SUCCESS)
++            {
++                object->handle = create_gpu_resource(fd, handle_export_info ? handle_export_info->name : NULL);
++                object->access = handle_export_info ? handle_export_info->dwAccess : GENERIC_ALL;
++                if (handle_export_info && handle_export_info->pAttributes)
++                    object->inherit = handle_export_info->pAttributes->bInheritHandle;
++                else
++                    object->inherit = FALSE;
++                close(fd);
++            }
++
++            if (object->handle == INVALID_HANDLE_VALUE)
++            {
++                res = VK_ERROR_OUT_OF_HOST_MEMORY;
++                goto done;
++            }
++        }
++
++        WINE_VK_ADD_NON_DISPATCHABLE_MAPPING(device->phys_dev->instance, object, object->dev_mem);
++        *memory = wine_dev_mem_to_handle(object);
++    }
++
++    done:
++
++    if (res != VK_SUCCESS)
++    {
++        device->funcs.p_vkFreeMemory(device->device, object->dev_mem, NULL);
++        if (fd_import_info.fd != -1)
++            close(fd_import_info.fd);
++        if (object->handle != INVALID_HANDLE_VALUE)
++            NtClose(object->handle);
++        free(object);
++    }
++
++    free_VkMemoryAllocateInfo_struct_chain(&allocate_info_dup);
++
++    return res;
++}
++
++NTSTATUS wine_vkGetMemoryWin32HandleKHR(void *args)
++{
++    struct vkGetMemoryWin32HandleKHR_params *params = args;
++    VkDevice device = params->device;
++    const VkMemoryGetWin32HandleInfoKHR *handle_info = params->pGetWin32HandleInfo;
++    HANDLE *handle = params->pHandle;
++
++    struct wine_dev_mem *dev_mem = wine_dev_mem_from_handle(handle_info->memory);
++    const VkBaseInStructure *chain;
++
++    TRACE("%p, %p %p\n", device, handle_info, handle);
++
++    if (!(dev_mem->handle_types & handle_info->handleType))
++        return VK_ERROR_UNKNOWN;
++
++    if ((chain = handle_info->pNext))
++        FIXME("Ignoring a linked structure of type %u.\n", chain->sType);
++
++    switch(handle_info->handleType)
++    {
++        case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT:
++            return !NtDuplicateObject( NtCurrentProcess(), dev_mem->handle, NtCurrentProcess(), handle, dev_mem->access, dev_mem->inherit ? OBJ_INHERIT : 0, 0) ?
++                VK_SUCCESS : VK_ERROR_OUT_OF_HOST_MEMORY;
++        default:
++            FIXME("Unable to get handle of type %x, did the application ignore the capabilities?\n", handle_info->handleType);
++            return VK_ERROR_UNKNOWN;
++    }
++}
++
++NTSTATUS wine_vkFreeMemory(void *args)
++{
++    struct vkFreeMemory_params *params = args;
++    VkDevice device = params->device;
++    VkDeviceMemory handle = params->memory;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++
++    struct wine_dev_mem *dev_mem = wine_dev_mem_from_handle(handle);
++
++    TRACE("%p 0x%s, %p\n", device, wine_dbgstr_longlong(handle), allocator);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if (!handle)
++        return STATUS_SUCCESS;
++
++    WINE_VK_REMOVE_HANDLE_MAPPING(device->phys_dev->instance, dev_mem);
++    device->funcs.p_vkFreeMemory(device->device, dev_mem->dev_mem, NULL);
++    if (dev_mem->handle != INVALID_HANDLE_VALUE)
++        NtClose(dev_mem->handle);
++    free(dev_mem);
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS wine_vkGetMemoryWin32HandlePropertiesKHR(void *args)
++{
++    struct vkGetMemoryWin32HandlePropertiesKHR_params *params = args;
++    VkDevice device = params->device;
++    VkExternalMemoryHandleTypeFlagBits type = params->handleType;
++    HANDLE handle = params->handle;
++    VkMemoryWin32HandlePropertiesKHR *properties = params->pMemoryWin32HandleProperties;
++
++    TRACE("%p %u %p %p\n", device, type, handle, properties);
++
++    /* VUID-vkGetMemoryWin32HandlePropertiesKHR-handleType-00666
++       handleType must not be one of the handle types defined as opaque */
++    return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++}
++
++NTSTATUS wine_vkCreateBuffer(void *args)
++{
++    struct vkCreateBuffer_params *params = args;
++    VkDevice device = params->device;
++    const VkBufferCreateInfo *create_info = params->pCreateInfo;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++    VkBuffer *buffer = params->pBuffer;
++
++    VkExternalMemoryBufferCreateInfo *external_memory_info;
++    VkResult res;
++
++#if defined(USE_STRUCT_CONVERSION)
++    VkBufferCreateInfo_host create_info_host;
++#else
++    VkBufferCreateInfo create_info_host;
++#endif
++
++    TRACE("%p %p %p %p\n", device, create_info, allocator, buffer);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if ((res = convert_VkBufferCreateInfo_struct_chain(create_info->pNext, (VkBufferCreateInfo *) &create_info_host)))
++    {
++        WARN("Failed to convert VkBufferCreateInfo pNext chain, res=%d.\n", res);
++        return res;
++    }
++
++    if ((external_memory_info = wine_vk_find_struct(&create_info_host, EXTERNAL_MEMORY_BUFFER_CREATE_INFO)))
++    {
++        if (external_memory_info->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++            external_memory_info->handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
++        wine_vk_normalize_handle_types_host(&external_memory_info->handleTypes);
++    }
++
++    create_info_host.sType = create_info->sType;
++    create_info_host.flags = create_info->flags;
++    create_info_host.size = create_info->size;
++    create_info_host.usage = create_info->usage;
++    create_info_host.sharingMode = create_info->sharingMode;
++    create_info_host.queueFamilyIndexCount = create_info->queueFamilyIndexCount;
++    create_info_host.pQueueFamilyIndices = create_info->pQueueFamilyIndices;
++
++    res = device->funcs.p_vkCreateBuffer(device->device, &create_info_host, NULL, buffer);
++
++    free_VkBufferCreateInfo_struct_chain((VkBufferCreateInfo *) &create_info_host);
++
++    return res;
++}
+diff --git a/dlls/winevulkan/vulkan_private.h b/dlls/winevulkan/vulkan_private.h
+index 83a26988e8b..66d9bde2745 100644
+--- a/dlls/winevulkan/vulkan_private.h
++++ b/dlls/winevulkan/vulkan_private.h
+@@ -204,6 +204,30 @@ static inline VkSurfaceKHR wine_surface_to_handle(struct wine_surface *surface)
+     return (VkSurfaceKHR)(uintptr_t)surface;
+ }
+ 
++struct wine_dev_mem
++{
++    VkDeviceMemory dev_mem;
++
++    VkExternalMemoryHandleTypeFlagBits handle_types;
++
++    BOOL inherit;
++    DWORD access;
++
++    HANDLE handle;
++
++    struct wine_vk_mapping mapping;
++};
++
++static inline struct wine_dev_mem *wine_dev_mem_from_handle(VkDeviceMemory handle)
++{
++    return (struct wine_dev_mem *)(uintptr_t)handle;
++}
++
++static inline VkDeviceMemory wine_dev_mem_to_handle(struct wine_dev_mem *dev_mem)
++{
++    return (VkDeviceMemory)(uintptr_t)dev_mem;
++}
++
+ BOOL wine_vk_device_extension_supported(const char *name) DECLSPEC_HIDDEN;
+ BOOL wine_vk_instance_extension_supported(const char *name) DECLSPEC_HIDDEN;
+ 
+-- 
+2.37.1
+
+From 68174a6f43ae83ba317666d829b90f9a065ec575 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 19 May 2021 13:38:12 -0400
+Subject: [PATCH 2/4] winevulkan: Implement VK_KHR_external_memory_win32 for
+ images.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/winevulkan/make_vulkan |   3 +
+ dlls/winevulkan/vulkan.c    | 111 ++++++++++++++++++++++++++++--------
+ 2 files changed, 91 insertions(+), 23 deletions(-)
+
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 5dd441c5b44..89b2e7ee1e2 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -204,6 +204,7 @@ FUNCTION_OVERRIDES = {
+     "vkCreateCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkCreateComputePipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+     "vkCreateGraphicsPipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
++    "vkCreateImage" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkDestroyCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkDestroyDevice" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkFreeCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+@@ -282,7 +283,9 @@ STRUCT_CHAIN_CONVERSIONS = {
+ 
+     # Structs which require pNext chain modification
+     "VkBufferCreateInfo": [],
++    "VkImageCreateInfo": [],
+     "VkMemoryAllocateInfo": ["VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"],
++    "VkPhysicalDeviceImageFormatInfo2": [],
+ }
+ 
+ 
+diff --git a/dlls/winevulkan/vulkan.c b/dlls/winevulkan/vulkan.c
+index 0c09114f68f..3a27a28b7c8 100644
+--- a/dlls/winevulkan/vulkan.c
++++ b/dlls/winevulkan/vulkan.c
+@@ -1394,52 +1394,80 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalBufferPropertiesKHR(void *args)
+     return STATUS_SUCCESS;
+ }
+ 
+-NTSTATUS wine_vkGetPhysicalDeviceImageFormatProperties2(void *args)
++static VkResult wine_vk_get_physical_device_image_format_properties_2(VkPhysicalDevice phys_dev,
++        VkResult (*p_vkGetPhysicalDeviceImageFormatProperties2)(VkPhysicalDevice, const VkPhysicalDeviceImageFormatInfo2 *, VkImageFormatProperties2 *),
++        const VkPhysicalDeviceImageFormatInfo2 *format_info, VkImageFormatProperties2 *properties)
+ {
+-    struct vkGetPhysicalDeviceImageFormatProperties2_params *params = args;
+-    VkPhysicalDevice phys_dev = params->physicalDevice;
+-    const VkPhysicalDeviceImageFormatInfo2 *format_info = params->pImageFormatInfo;
+-    VkImageFormatProperties2 *properties = params->pImageFormatProperties;
++    VkPhysicalDeviceExternalImageFormatInfo *external_image_info_dup = NULL;
++    const VkPhysicalDeviceExternalImageFormatInfo *external_image_info;
++    VkPhysicalDeviceImageFormatInfo2 format_info_host = *format_info;
+     VkExternalImageFormatProperties *external_image_properties;
+     VkResult res;
+ 
+-    TRACE("%p, %p, %p\n", phys_dev, format_info, properties);
++    if ((external_image_info = wine_vk_find_struct(format_info, PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO)) && external_image_info->handleType)
++    {
++        if ((res = convert_VkPhysicalDeviceImageFormatInfo2_struct_chain(format_info->pNext, &format_info_host)) < 0)
++        {
++            WARN("Failed to convert VkPhysicalDeviceImageFormatInfo2 pNext chain, res=%d.\n", res);
++            return res;
++        }
++        external_image_info_dup = wine_vk_find_struct(&format_info_host, PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO);
++
++        wine_vk_normalize_handle_types_win(&external_image_info_dup->handleType);
++
++        if (external_image_info_dup->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++            external_image_info_dup->handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
++
++        wine_vk_normalize_handle_types_host(&external_image_info_dup->handleType);
++        if (!external_image_info_dup->handleType)
++        {
++            WARN("Unsupported handle type %#x.\n", external_image_info->handleType);
++            return VK_ERROR_FORMAT_NOT_SUPPORTED;
++        }
++    }
+ 
+-    res = thunk_vkGetPhysicalDeviceImageFormatProperties2(phys_dev, format_info, properties);
++    res = p_vkGetPhysicalDeviceImageFormatProperties2(phys_dev, &format_info_host, properties);
++
++    if (external_image_info_dup)
++        free_VkPhysicalDeviceImageFormatInfo2_struct_chain(&format_info_host);
+ 
+     if ((external_image_properties = wine_vk_find_struct(properties, EXTERNAL_IMAGE_FORMAT_PROPERTIES)))
+     {
+         VkExternalMemoryProperties *p = &external_image_properties->externalMemoryProperties;
+-        p->externalMemoryFeatures = 0;
+-        p->exportFromImportedHandleTypes = 0;
+-        p->compatibleHandleTypes = 0;
++        if (p->exportFromImportedHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
++            p->exportFromImportedHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++        wine_vk_normalize_handle_types_win(&p->exportFromImportedHandleTypes);
++
++        if (p->compatibleHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
++            p->compatibleHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++        wine_vk_normalize_handle_types_win(&p->compatibleHandleTypes);
+     }
+ 
+     return res;
+ }
+ 
+-NTSTATUS wine_vkGetPhysicalDeviceImageFormatProperties2KHR(void *args)
++NTSTATUS wine_vkGetPhysicalDeviceImageFormatProperties2(void *args)
+ {
+-    struct vkGetPhysicalDeviceImageFormatProperties2KHR_params *params = args;
++    struct vkGetPhysicalDeviceImageFormatProperties2_params *params = args;
+     VkPhysicalDevice phys_dev = params->physicalDevice;
+     const VkPhysicalDeviceImageFormatInfo2 *format_info = params->pImageFormatInfo;
+     VkImageFormatProperties2 *properties = params->pImageFormatProperties;
+-    VkExternalImageFormatProperties *external_image_properties;
+-    VkResult res;
+ 
+     TRACE("%p, %p, %p\n", phys_dev, format_info, properties);
+ 
+-    res = thunk_vkGetPhysicalDeviceImageFormatProperties2KHR(phys_dev, format_info, properties);
++    return wine_vk_get_physical_device_image_format_properties_2(phys_dev, thunk_vkGetPhysicalDeviceImageFormatProperties2, format_info, properties);
++}
+ 
+-    if ((external_image_properties = wine_vk_find_struct(properties, EXTERNAL_IMAGE_FORMAT_PROPERTIES)))
+-    {
+-        VkExternalMemoryProperties *p = &external_image_properties->externalMemoryProperties;
+-        p->externalMemoryFeatures = 0;
+-        p->exportFromImportedHandleTypes = 0;
+-        p->compatibleHandleTypes = 0;
+-    }
++NTSTATUS wine_vkGetPhysicalDeviceImageFormatProperties2KHR(void *args)
++{
++    struct vkGetPhysicalDeviceImageFormatProperties2KHR_params *params = args;
++    VkPhysicalDevice phys_dev = params->physicalDevice;
++    const VkPhysicalDeviceImageFormatInfo2 *format_info = params->pImageFormatInfo;
++    VkImageFormatProperties2 *properties = params->pImageFormatProperties;
+ 
+-    return res;
++    TRACE("%p, %p, %p\n", phys_dev, format_info, properties);
++
++    return wine_vk_get_physical_device_image_format_properties_2(phys_dev, thunk_vkGetPhysicalDeviceImageFormatProperties2KHR, format_info, properties);
+ }
+ 
+ /* From ntdll/unix/sync.c */
+@@ -2261,3 +2289,40 @@ NTSTATUS wine_vkCreateBuffer(void *args)
+ 
+     return res;
+ }
++
++NTSTATUS wine_vkCreateImage(void *args)
++{
++    struct vkCreateImage_params *params = args;
++    VkDevice device = params->device;
++    const VkImageCreateInfo *create_info = params->pCreateInfo;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++    VkImage *image = params->pImage;
++
++    VkExternalMemoryImageCreateInfo *external_memory_info;
++    VkImageCreateInfo create_info_host = *create_info;
++    VkResult res;
++
++    TRACE("%p %p %p %p\n", device, create_info, allocator, image);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if ((res = convert_VkImageCreateInfo_struct_chain(create_info->pNext, &create_info_host)))
++    {
++        WARN("Failed to convert VkImageCreateInfo pNext chain, res=%d.\n", res);
++        return res;
++    }
++
++    if ((external_memory_info = wine_vk_find_struct(&create_info_host, EXTERNAL_MEMORY_IMAGE_CREATE_INFO)))
++    {
++        if (external_memory_info->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR)
++            external_memory_info->handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
++        wine_vk_normalize_handle_types_host(&external_memory_info->handleTypes);
++    }
++
++    res = device->funcs.p_vkCreateImage(device->device, &create_info_host, NULL, image);
++
++    free_VkImageCreateInfo_struct_chain(&create_info_host);
++
++    return res;
++}
+-- 
+2.37.1
+
+From ff767b24a65fa9e75928b56a23859b81e9eeb299 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 13 Oct 2021 13:16:44 +0200
+Subject: [PATCH 3/4] winevulkan: Implement support for KMT handles and named
+ objects.
+
+---
+ configure.ac                                |   1 +
+ dlls/sharedgpures.sys/Makefile.in           |   6 +
+ dlls/sharedgpures.sys/shared_resource.c     | 348 ++++++++++++++++++++
+ dlls/sharedgpures.sys/sharedgpures.sys.spec |   1 +
+ dlls/winevulkan/vulkan.c                    | 190 ++++++++++-
+ dlls/winevulkan/vulkan_private.h            |   7 +
+ include/ddk/wdm.h                           |   1 +
+ loader/wine.inf.in                          |  13 +
+ 8 files changed, 552 insertions(+), 15 deletions(-)
+ create mode 100644 dlls/sharedgpures.sys/Makefile.in
+ create mode 100644 dlls/sharedgpures.sys/shared_resource.c
+ create mode 100644 dlls/sharedgpures.sys/sharedgpures.sys.spec
+
+diff --git a/configure.ac b/configure.ac
+index 16933496b7a..66a138ebe95 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3071,6 +3071,7 @@ WINE_CONFIG_MAKEFILE(dlls/setupapi/tests)
+ WINE_CONFIG_MAKEFILE(dlls/setupx.dll16,enable_win16)
+ WINE_CONFIG_MAKEFILE(dlls/sfc)
+ WINE_CONFIG_MAKEFILE(dlls/sfc_os)
++WINE_CONFIG_MAKEFILE(dlls/sharedgpures.sys)
+ WINE_CONFIG_MAKEFILE(dlls/shcore)
+ WINE_CONFIG_MAKEFILE(dlls/shcore/tests)
+ WINE_CONFIG_MAKEFILE(dlls/shdoclc)
+diff --git a/dlls/sharedgpures.sys/Makefile.in b/dlls/sharedgpures.sys/Makefile.in
+new file mode 100644
+index 00000000000..2d64a476826
+--- /dev/null
++++ b/dlls/sharedgpures.sys/Makefile.in
+@@ -0,0 +1,6 @@
++MODULE    = sharedgpures.sys
++IMPORTS   = ntoskrnl
++EXTRADLLFLAGS = -Wl,--subsystem,native -mno-cygwin
++
++C_SRCS = \
++	shared_resource.c
+diff --git a/dlls/sharedgpures.sys/shared_resource.c b/dlls/sharedgpures.sys/shared_resource.c
+new file mode 100644
+index 00000000000..b9f34eb978f
+--- /dev/null
++++ b/dlls/sharedgpures.sys/shared_resource.c
+@@ -0,0 +1,348 @@
++#include <stdarg.h>
++
++#define NONAMELESSUNION
++#include "ntstatus.h"
++#define WIN32_NO_STATUS
++#include "windef.h"
++#include "winbase.h"
++#include "winternl.h"
++#include "winioctl.h"
++
++#include "ddk/wdm.h"
++
++#include "wine/debug.h"
++#include "wine/list.h"
++#include "wine/server.h"
++
++WINE_DEFAULT_DEBUG_CHANNEL(sharedgpures);
++
++static DRIVER_OBJECT *sharedgpures_driver;
++
++struct shared_resource
++{
++    unsigned int ref_count;
++    void *unix_resource;
++    WCHAR *name;
++};
++
++static struct shared_resource *resource_pool;
++static unsigned int resource_pool_size;
++
++/* TODO: If/when ntoskrnl gets support for referencing user handles directly, remove this function */
++static void *reference_client_handle(obj_handle_t handle)
++{
++    HANDLE client_process, kernel_handle;
++    OBJECT_ATTRIBUTES attr;
++    void *object = NULL;
++    CLIENT_ID cid;
++
++    attr.Length = sizeof(OBJECT_ATTRIBUTES);
++    attr.RootDirectory = 0;
++    attr.Attributes = OBJ_KERNEL_HANDLE;
++    attr.ObjectName = NULL;
++    attr.SecurityDescriptor = NULL;
++    attr.SecurityQualityOfService = NULL;
++
++    cid.UniqueProcess = PsGetCurrentProcessId();
++    cid.UniqueThread = 0;
++
++    if (NtOpenProcess(&client_process, PROCESS_ALL_ACCESS, &attr, &cid) != STATUS_SUCCESS)
++        return NULL;
++
++    if (NtDuplicateObject(client_process, wine_server_ptr_handle(handle), NtCurrentProcess(), &kernel_handle,
++                               0, OBJ_KERNEL_HANDLE, DUPLICATE_SAME_ACCESS) != STATUS_SUCCESS)
++    {
++        NtClose(client_process);
++        return NULL;
++    }
++
++    ObReferenceObjectByHandle(kernel_handle, 0, NULL, KernelMode, &object, NULL);
++
++    NtClose(client_process);
++    NtClose(kernel_handle);
++
++    return object;
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_CREATE           CTL_CODE(FILE_DEVICE_VIDEO, 0, METHOD_BUFFERED, FILE_WRITE_ACCESS)
++
++struct shared_resource_create
++{
++    obj_handle_t unix_handle;
++    WCHAR name[1];
++};
++
++static NTSTATUS shared_resource_create(struct shared_resource **res, void *buff, SIZE_T insize, IO_STATUS_BLOCK *iosb)
++{
++    struct shared_resource_create *input = buff;
++    void *unix_resource;
++    unsigned int i;
++    LPWSTR name;
++
++    if (insize < sizeof(*input))
++        return STATUS_INFO_LENGTH_MISMATCH;
++
++    if (input->name[ ((insize - offsetof(struct shared_resource_create, name)) / sizeof(WCHAR)) - 1 ])
++        return STATUS_INVALID_PARAMETER;
++
++    if (!(unix_resource = reference_client_handle(input->unix_handle)))
++        return STATUS_INVALID_HANDLE;
++
++    if (insize == sizeof(*input))
++        name = NULL;
++    else
++    {
++        name = ExAllocatePoolWithTag(NonPagedPool, insize - offsetof(struct shared_resource_create, name), 0);
++        wcscpy(name, &input->name[0]);
++    }
++
++    for (i = 0; i < resource_pool_size; i++)
++        if (!resource_pool[i].ref_count)
++            break;
++
++    if (i == resource_pool_size)
++    {
++        struct shared_resource *expanded_pool =
++            ExAllocatePoolWithTag(NonPagedPool, sizeof(struct shared_resource) * (resource_pool_size + 1024), 0);
++
++        if (resource_pool)
++        {
++            memcpy(expanded_pool, resource_pool, resource_pool_size * sizeof(struct shared_resource));
++            ExFreePoolWithTag(resource_pool, 0);
++        }
++
++        memset(&expanded_pool[resource_pool_size], 0, 1024 * sizeof (struct shared_resource));
++
++        resource_pool = expanded_pool;
++        resource_pool_size += 1024;
++    }
++
++    *res = &resource_pool[i];
++    (*res)->ref_count = 1;
++    (*res)->unix_resource = unix_resource;
++    (*res)->name = name;
++
++    iosb->Information = 0;
++    return STATUS_SUCCESS;
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_OPEN             CTL_CODE(FILE_DEVICE_VIDEO, 1, METHOD_BUFFERED, FILE_WRITE_ACCESS)
++
++struct shared_resource_open
++{
++    obj_handle_t kmt_handle;
++    WCHAR name[1];
++};
++
++static unsigned int kmt_to_index(obj_handle_t kmt)
++{
++    if (!(kmt & 0x40000000) || (kmt - 2) % 4)
++        return -1;
++    return (((unsigned int) kmt & ~0x40000000) - 2) / 4;
++}
++
++static NTSTATUS shared_resource_open(struct shared_resource **res, void *buff, SIZE_T insize, IO_STATUS_BLOCK *iosb)
++{
++    struct shared_resource_open *input = buff;
++    unsigned int i;
++
++    if (insize < sizeof(*input))
++        return STATUS_INFO_LENGTH_MISMATCH;
++
++    if (input->kmt_handle)
++    {
++        if (kmt_to_index(input->kmt_handle) >= resource_pool_size)
++            return STATUS_INVALID_HANDLE;
++
++        *res = &resource_pool[kmt_to_index(input->kmt_handle)];
++    }
++    else
++    {
++        if (input->name[ ((insize - offsetof(struct shared_resource_open, name)) / sizeof(WCHAR)) - 1 ])
++            return STATUS_INVALID_PARAMETER;
++
++        /* name lookup */
++        for (i = 0; i < resource_pool_size; i++)
++        {
++            if (!wcscmp(resource_pool[i].name, &input->name[0]))
++            {
++                *res = &resource_pool[i];
++                break;
++            }
++        }
++
++        if (i == resource_pool_size)
++            return STATUS_OBJECT_NAME_NOT_FOUND;
++    }
++
++    (*res)->ref_count++;
++    iosb->Information = 0;
++    return STATUS_SUCCESS;
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_GETKMT           CTL_CODE(FILE_DEVICE_VIDEO, 2, METHOD_BUFFERED, FILE_READ_ACCESS)
++
++static obj_handle_t index_to_kmt(unsigned int idx)
++{
++    return (idx * 4 + 2) | 0x40000000;
++}
++
++static NTSTATUS shared_resource_getkmt(struct shared_resource *res, void *buff, SIZE_T outsize, IO_STATUS_BLOCK *iosb)
++{
++    if (outsize < sizeof(unsigned int))
++        return STATUS_INFO_LENGTH_MISMATCH;
++
++    *((unsigned int *)buff) = index_to_kmt(res - resource_pool);
++
++    iosb->Information = sizeof(unsigned int);
++    return STATUS_SUCCESS;
++}
++
++/* TODO: If/when ntoskrnl gets support for opening user handles directly, remove this function */
++static obj_handle_t open_client_handle(void *object)
++{
++    HANDLE client_process, kernel_handle, handle = NULL;
++    OBJECT_ATTRIBUTES attr;
++    CLIENT_ID cid;
++
++    attr.Length = sizeof(OBJECT_ATTRIBUTES);
++    attr.RootDirectory = 0;
++    attr.Attributes = OBJ_KERNEL_HANDLE;
++    attr.ObjectName = NULL;
++    attr.SecurityDescriptor = NULL;
++    attr.SecurityQualityOfService = NULL;
++
++    cid.UniqueProcess = PsGetCurrentProcessId();
++    cid.UniqueThread = 0;
++
++    if (NtOpenProcess(&client_process, PROCESS_ALL_ACCESS, &attr, &cid) != STATUS_SUCCESS)
++        return 0;
++
++    if (ObOpenObjectByPointer(object, 0, NULL, GENERIC_ALL, NULL, KernelMode, &kernel_handle) != STATUS_SUCCESS)
++    {
++        NtClose(client_process);
++        return 0;
++    }
++
++    NtDuplicateObject(NtCurrentProcess(), kernel_handle, client_process, &handle,
++                        0, 0, DUPLICATE_SAME_ACCESS);
++
++    NtClose(client_process);
++    NtClose(kernel_handle);
++
++    return wine_server_obj_handle(handle);
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_GET_UNIX_RESOURCE           CTL_CODE(FILE_DEVICE_VIDEO, 3, METHOD_BUFFERED, FILE_READ_ACCESS)
++
++static NTSTATUS shared_resource_get_unix_resource(struct shared_resource *res, void *buff, SIZE_T outsize, IO_STATUS_BLOCK *iosb)
++{
++    if (outsize < sizeof(obj_handle_t))
++        return STATUS_INFO_LENGTH_MISMATCH;
++
++    *((obj_handle_t *)buff) = open_client_handle(res->unix_resource);
++
++    iosb->Information = sizeof(obj_handle_t);
++    return STATUS_SUCCESS;
++}
++
++static NTSTATUS WINAPI dispatch_create(DEVICE_OBJECT *device, IRP *irp)
++{
++    irp->IoStatus.u.Status = STATUS_SUCCESS;
++    IoCompleteRequest(irp, IO_NO_INCREMENT);
++    return STATUS_SUCCESS;
++}
++
++static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
++{
++    IO_STACK_LOCATION *stack = IoGetCurrentIrpStackLocation(irp);
++    struct shared_resource *res = stack->FileObject->FsContext;
++
++    TRACE("Freeing shared resouce %p.\n", res);
++
++    if (res)
++    {
++        res->ref_count--;
++        if (!res->ref_count && res->unix_resource)
++        {
++            /* TODO: see if its possible to destroy the object here (unlink?) */
++            ObDereferenceObject(res->unix_resource);
++            res->unix_resource = NULL;
++        }
++    }
++
++    irp->IoStatus.u.Status = STATUS_SUCCESS;
++    IoCompleteRequest(irp, IO_NO_INCREMENT);
++    return STATUS_SUCCESS;
++}
++
++static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
++{
++    IO_STACK_LOCATION *stack = IoGetCurrentIrpStackLocation( irp );
++    struct shared_resource **res = (struct shared_resource **) &stack->FileObject->FsContext;
++    NTSTATUS status;
++
++    TRACE( "ioctl %lx insize %lu outsize %lu\n",
++           stack->Parameters.DeviceIoControl.IoControlCode,
++           stack->Parameters.DeviceIoControl.InputBufferLength,
++           stack->Parameters.DeviceIoControl.OutputBufferLength );
++
++    switch (stack->Parameters.DeviceIoControl.IoControlCode)
++    {
++        case IOCTL_SHARED_GPU_RESOURCE_CREATE:
++            status = shared_resource_create( res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.InputBufferLength,
++                                      &irp->IoStatus );
++            break;
++        case IOCTL_SHARED_GPU_RESOURCE_OPEN:
++            status = shared_resource_open( res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.InputBufferLength,
++                                      &irp->IoStatus );
++            break;
++        case IOCTL_SHARED_GPU_RESOURCE_GETKMT:
++            status = shared_resource_getkmt( *res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.OutputBufferLength,
++                                      &irp->IoStatus );
++            break;
++        case IOCTL_SHARED_GPU_RESOURCE_GET_UNIX_RESOURCE:
++            status = shared_resource_get_unix_resource( *res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.OutputBufferLength,
++                                      &irp->IoStatus );
++            break;
++    default:
++        FIXME( "ioctl %lx not supported\n", stack->Parameters.DeviceIoControl.IoControlCode );
++        status = STATUS_NOT_SUPPORTED;
++        break;
++    }
++
++    irp->IoStatus.u.Status = status;
++    IoCompleteRequest( irp, IO_NO_INCREMENT );
++    return status;
++}
++
++NTSTATUS WINAPI DriverEntry( DRIVER_OBJECT *driver, UNICODE_STRING *path )
++{
++    static const WCHAR device_nameW[] = L"\\Device\\SharedGpuResource";
++    static const WCHAR link_nameW[] = L"\\??\\SharedGpuResource";
++    UNICODE_STRING device_name, link_name;
++    DEVICE_OBJECT *device;
++    NTSTATUS status;
++
++    sharedgpures_driver = driver;
++
++    driver->MajorFunction[IRP_MJ_CREATE] = dispatch_create;
++    driver->MajorFunction[IRP_MJ_CLOSE] = dispatch_close;
++    driver->MajorFunction[IRP_MJ_DEVICE_CONTROL] = dispatch_ioctl;
++
++    RtlInitUnicodeString(&device_name, device_nameW);
++    RtlInitUnicodeString(&link_name, link_nameW);
++
++    if ((status = IoCreateDevice(driver, 0, &device_name, 0, 0, FALSE, &device)))
++        return status;
++
++    return IoCreateSymbolicLink(&link_name, &device_name);
++}
+diff --git a/dlls/sharedgpures.sys/sharedgpures.sys.spec b/dlls/sharedgpures.sys/sharedgpures.sys.spec
+new file mode 100644
+index 00000000000..76421d7e35b
+--- /dev/null
++++ b/dlls/sharedgpures.sys/sharedgpures.sys.spec
+@@ -0,0 +1 @@
++# nothing to export
+diff --git a/dlls/winevulkan/vulkan.c b/dlls/winevulkan/vulkan.c
+index 3a27a28b7c8..0765c7b7454 100644
+--- a/dlls/winevulkan/vulkan.c
++++ b/dlls/winevulkan/vulkan.c
+@@ -28,6 +28,9 @@
+ 
+ #include "ntstatus.h"
+ #define WIN32_NO_STATUS
++#include "windef.h"
++#include "winnt.h"
++#include "winioctl.h"
+ #include "wine/server.h"
+ 
+ #include "vulkan_private.h"
+@@ -1340,6 +1343,10 @@ static inline void wine_vk_normalize_handle_types_host(VkExternalMemoryHandleTyp
+         VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT;
+ }
+ 
++static const VkExternalMemoryHandleTypeFlagBits wine_vk_handle_over_fd_types =
++                VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT |
++                VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
++
+ static void wine_vk_get_physical_device_external_buffer_properties(VkPhysicalDevice phys_dev,
+         void (*p_vkGetPhysicalDeviceExternalBufferProperties)(VkPhysicalDevice, const VkPhysicalDeviceExternalBufferInfo *, VkExternalBufferProperties *),
+         const VkPhysicalDeviceExternalBufferInfo *buffer_info, VkExternalBufferProperties *properties)
+@@ -1347,7 +1354,7 @@ static void wine_vk_get_physical_device_external_buffer_properties(VkPhysicalDev
+     VkPhysicalDeviceExternalBufferInfo buffer_info_dup = *buffer_info;
+ 
+     wine_vk_normalize_handle_types_win(&buffer_info_dup.handleType);
+-    if (buffer_info_dup.handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++    if (buffer_info_dup.handleType & wine_vk_handle_over_fd_types)
+         buffer_info_dup.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+     wine_vk_normalize_handle_types_host(&buffer_info_dup.handleType);
+ 
+@@ -1360,11 +1367,11 @@ static void wine_vk_get_physical_device_external_buffer_properties(VkPhysicalDev
+     p_vkGetPhysicalDeviceExternalBufferProperties(phys_dev->phys_dev, &buffer_info_dup, properties);
+ 
+     if (properties->externalMemoryProperties.exportFromImportedHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
+-        properties->externalMemoryProperties.exportFromImportedHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++        properties->externalMemoryProperties.exportFromImportedHandleTypes |= wine_vk_handle_over_fd_types;
+     wine_vk_normalize_handle_types_win(&properties->externalMemoryProperties.exportFromImportedHandleTypes);
+ 
+     if (properties->externalMemoryProperties.compatibleHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
+-        properties->externalMemoryProperties.compatibleHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++        properties->externalMemoryProperties.compatibleHandleTypes |= wine_vk_handle_over_fd_types;
+     wine_vk_normalize_handle_types_win(&properties->externalMemoryProperties.compatibleHandleTypes);
+ }
+ 
+@@ -1415,7 +1422,7 @@ static VkResult wine_vk_get_physical_device_image_format_properties_2(VkPhysical
+ 
+         wine_vk_normalize_handle_types_win(&external_image_info_dup->handleType);
+ 
+-        if (external_image_info_dup->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++        if (external_image_info_dup->handleType & wine_vk_handle_over_fd_types)
+             external_image_info_dup->handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+ 
+         wine_vk_normalize_handle_types_host(&external_image_info_dup->handleType);
+@@ -1435,11 +1442,11 @@ static VkResult wine_vk_get_physical_device_image_format_properties_2(VkPhysical
+     {
+         VkExternalMemoryProperties *p = &external_image_properties->externalMemoryProperties;
+         if (p->exportFromImportedHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
+-            p->exportFromImportedHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++            p->exportFromImportedHandleTypes |= wine_vk_handle_over_fd_types;
+         wine_vk_normalize_handle_types_win(&p->exportFromImportedHandleTypes);
+ 
+         if (p->compatibleHandleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
+-            p->compatibleHandleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++            p->compatibleHandleTypes |= wine_vk_handle_over_fd_types;
+         wine_vk_normalize_handle_types_win(&p->compatibleHandleTypes);
+     }
+ 
+@@ -2010,18 +2017,154 @@ BOOL WINAPI wine_vk_is_available_device_function(VkDevice device, const char *na
+     return !!vk_funcs->p_vkGetDeviceProcAddr(device->device, name);
+ }
+ 
++#define IOCTL_SHARED_GPU_RESOURCE_CREATE           CTL_CODE(FILE_DEVICE_VIDEO, 0, METHOD_BUFFERED, FILE_WRITE_ACCESS)
++
++struct shared_resource_create
++{
++    obj_handle_t unix_handle;
++    WCHAR name[1];
++};
++
+ static HANDLE create_gpu_resource(int fd, LPCWSTR name)
+ {
+-    HANDLE ret = INVALID_HANDLE_VALUE;
++    static const WCHAR shared_gpu_resourceW[] = {'\\','?','?','\\','S','h','a','r','e','d','G','p','u','R','e','s','o','u','r','c','e',0};
++    HANDLE unix_resource = INVALID_HANDLE_VALUE;
++    struct shared_resource_create *inbuff;
++    UNICODE_STRING shared_gpu_resource_us;
++    HANDLE shared_resource;
++    OBJECT_ATTRIBUTES attr;
++    IO_STATUS_BLOCK iosb;
++    NTSTATUS status;
++    DWORD in_size;
+ 
+     TRACE("Creating shared vulkan resource fd %d name %s.\n", fd, debugstr_w(name));
+ 
++    if (wine_server_fd_to_handle(fd, GENERIC_ALL, 0, &unix_resource) != STATUS_SUCCESS)
++        return INVALID_HANDLE_VALUE;
++
++    init_unicode_string(&shared_gpu_resource_us, shared_gpu_resourceW);
++
++    attr.Length = sizeof(attr);
++    attr.RootDirectory = 0;
++    attr.Attributes = 0;
++    attr.ObjectName = &shared_gpu_resource_us;
++    attr.SecurityDescriptor = NULL;
++    attr.SecurityQualityOfService = NULL;
++
++    if ((status = NtCreateFile(&shared_resource, GENERIC_READ | GENERIC_WRITE, &attr, &iosb, NULL, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ | FILE_SHARE_WRITE, FILE_OPEN, 0, NULL, 0)))
++    {
++        ERR("Failed to load open a shared resource handle, status %#lx.\n", (long int)status);
++        NtClose(unix_resource);
++        return INVALID_HANDLE_VALUE;
++    }
++
++    in_size = sizeof(*inbuff) + (name ? lstrlenW(name) * sizeof(WCHAR) : 0);
++    inbuff = calloc(1, in_size);
++    inbuff->unix_handle = wine_server_obj_handle(unix_resource);
++    if (name)
++        lstrcpyW(&inbuff->name[0], name);
++
++    if ((status = NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_CREATE,
++            inbuff, in_size, NULL, 0)))
++
++    free(inbuff);
++    NtClose(unix_resource);
++
++    if (status)
++    {
++        ERR("Failed to create video resource, status %#lx.\n", (long int)status);
++        NtClose(shared_resource);
++        return INVALID_HANDLE_VALUE;
++    }
++
++    return shared_resource;
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_OPEN             CTL_CODE(FILE_DEVICE_VIDEO, 1, METHOD_BUFFERED, FILE_WRITE_ACCESS)
++
++struct shared_resource_open
++{
++    obj_handle_t kmt_handle;
++    WCHAR name[1];
++};
++
++static HANDLE open_shared_resource(HANDLE kmt_handle, LPCWSTR name)
++{
++    static const WCHAR shared_gpu_resourceW[] = {'\\','?','?','\\','S','h','a','r','e','d','G','p','u','R','e','s','o','u','r','c','e',0};
++    UNICODE_STRING shared_gpu_resource_us;
++    struct shared_resource_open *inbuff;
++    HANDLE shared_resource;
++    OBJECT_ATTRIBUTES attr;
++    IO_STATUS_BLOCK iosb;
++    NTSTATUS status;
++    DWORD in_size;
++
++    init_unicode_string(&shared_gpu_resource_us, shared_gpu_resourceW);
++
++    attr.Length = sizeof(attr);
++    attr.RootDirectory = 0;
++    attr.Attributes = 0;
++    attr.ObjectName = &shared_gpu_resource_us;
++    attr.SecurityDescriptor = NULL;
++    attr.SecurityQualityOfService = NULL;
++
++    if ((status = NtCreateFile(&shared_resource, GENERIC_READ | GENERIC_WRITE, &attr, &iosb, NULL, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ | FILE_SHARE_WRITE, FILE_OPEN, 0, NULL, 0)))
++    {
++        ERR("Failed to load open a shared resource handle, status %#lx.\n", (long int)status);
++        return INVALID_HANDLE_VALUE;
++    }
++
++    in_size = sizeof(*inbuff) + (name ? lstrlenW(name) * sizeof(WCHAR) : 0);
++    inbuff = calloc(1, in_size);
++    inbuff->kmt_handle = wine_server_obj_handle(kmt_handle);
+     if (name)
+-        FIXME("Naming gpu resources not supported.\n");
++        lstrcpyW(&inbuff->name[0], name);
++
++    status = NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_OPEN,
++            inbuff, in_size, NULL, 0);
++
++    free(inbuff);
++
++    if (status)
++    {
++        ERR("Failed to open video resource, status %#lx.\n", (long int)status);
++        NtClose(shared_resource);
++        return INVALID_HANDLE_VALUE;
++    }
++
++    return shared_resource;
++}
+ 
+-    wine_server_fd_to_handle(fd, GENERIC_ALL, 0, &ret);
++#define IOCTL_SHARED_GPU_RESOURCE_GET_UNIX_RESOURCE           CTL_CODE(FILE_DEVICE_VIDEO, 3, METHOD_BUFFERED, FILE_READ_ACCESS)
+ 
+-    return ret;
++static int get_shared_resource_fd(HANDLE shared_resource)
++{
++    IO_STATUS_BLOCK iosb;
++    obj_handle_t unix_resource;
++    NTSTATUS status;
++    int ret;
++
++    if (NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_GET_UNIX_RESOURCE,
++            NULL, 0, &unix_resource, sizeof(unix_resource)))
++        return -1;
++
++    status = wine_server_handle_to_fd(wine_server_ptr_handle(unix_resource), FILE_READ_DATA, &ret, NULL);
++    NtClose(wine_server_ptr_handle(unix_resource));
++    return status == STATUS_SUCCESS ? ret : -1;
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_GETKMT           CTL_CODE(FILE_DEVICE_VIDEO, 2, METHOD_BUFFERED, FILE_READ_ACCESS)
++
++static HANDLE get_shared_resource_kmt_handle(HANDLE shared_resource)
++{
++    IO_STATUS_BLOCK iosb;
++    obj_handle_t kmt_handle;
++
++    if (NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_GETKMT,
++            NULL, 0, &kmt_handle, sizeof(kmt_handle)))
++        return INVALID_HANDLE_VALUE;
++
++    return wine_server_ptr_handle(kmt_handle);
+ }
+ 
+ NTSTATUS wine_vkAllocateMemory(void *args)
+@@ -2080,7 +2223,7 @@ NTSTATUS wine_vkAllocateMemory(void *args)
+     if ((export_info = wine_vk_find_struct(&allocate_info_dup, EXPORT_MEMORY_ALLOCATE_INFO)))
+     {
+         object->handle_types = export_info->handleTypes;
+-        if (export_info->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++        if (export_info->handleTypes & wine_vk_handle_over_fd_types)
+             export_info->handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+         wine_vk_normalize_handle_types_host(&export_info->handleTypes);
+     }
+@@ -2098,7 +2241,16 @@ NTSTATUS wine_vkAllocateMemory(void *args)
+                 if (handle_import_info->handle)
+                     NtDuplicateObject( NtCurrentProcess(), handle_import_info->handle, NtCurrentProcess(), &object->handle, 0, 0, DUPLICATE_SAME_ACCESS );
+                 else if (handle_import_info->name)
+-                    FIXME("Importing device memory by resource name not supported.\n");
++                    object->handle = open_shared_resource( 0, handle_import_info->name );
++                break;
++            case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT:
++                /* FIXME: the spec says that device memory imported from a KMT handle doesn't keep a reference to the underyling payload.
++                   This means that in cases where on windows an application leaks VkDeviceMemory objects, we leak the full payload.  To
++                   fix this, we would need wine_dev_mem objects to store no reference to the payload, that means no host VkDeviceMemory
++                   object (as objects imported from FDs hold a reference to the payload), and no win32 handle to the object. We would then
++                   extend make_vulkan to have the thunks converting wine_dev_mem to native handles open the VkDeviceMemory from the KMT
++                   handle, use it in the host function, then close it again. */
++                object->handle = open_shared_resource( handle_import_info->handle, NULL );
+                 break;
+             default:
+                 WARN("Invalid handle type %08x passed in.\n", handle_import_info->handleType);
+@@ -2107,7 +2259,7 @@ NTSTATUS wine_vkAllocateMemory(void *args)
+         }
+ 
+         if (object->handle != INVALID_HANDLE_VALUE)
+-            wine_server_handle_to_fd(object->handle, FILE_READ_DATA, &fd_import_info.fd, NULL);
++            fd_import_info.fd = get_shared_resource_fd(object->handle);
+ 
+         if (fd_import_info.fd == -1)
+         {
+@@ -2180,6 +2332,7 @@ NTSTATUS wine_vkGetMemoryWin32HandleKHR(void *args)
+ 
+     struct wine_dev_mem *dev_mem = wine_dev_mem_from_handle(handle_info->memory);
+     const VkBaseInStructure *chain;
++    HANDLE ret;
+ 
+     TRACE("%p, %p %p\n", device, handle_info, handle);
+ 
+@@ -2194,6 +2347,13 @@ NTSTATUS wine_vkGetMemoryWin32HandleKHR(void *args)
+         case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT:
+             return !NtDuplicateObject( NtCurrentProcess(), dev_mem->handle, NtCurrentProcess(), handle, dev_mem->access, dev_mem->inherit ? OBJ_INHERIT : 0, 0) ?
+                 VK_SUCCESS : VK_ERROR_OUT_OF_HOST_MEMORY;
++        case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT:
++        {
++            if ((ret = get_shared_resource_kmt_handle(dev_mem->handle)) == INVALID_HANDLE_VALUE)
++                return VK_ERROR_OUT_OF_HOST_MEMORY;
++            *handle = ret;
++            return VK_SUCCESS;
++        }
+         default:
+             FIXME("Unable to get handle of type %x, did the application ignore the capabilities?\n", handle_info->handleType);
+             return VK_ERROR_UNKNOWN;
+@@ -2270,7 +2430,7 @@ NTSTATUS wine_vkCreateBuffer(void *args)
+ 
+     if ((external_memory_info = wine_vk_find_struct(&create_info_host, EXTERNAL_MEMORY_BUFFER_CREATE_INFO)))
+     {
+-        if (external_memory_info->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++        if (external_memory_info->handleTypes & wine_vk_handle_over_fd_types)
+             external_memory_info->handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+         wine_vk_normalize_handle_types_host(&external_memory_info->handleTypes);
+     }
+@@ -2315,7 +2475,7 @@ NTSTATUS wine_vkCreateImage(void *args)
+ 
+     if ((external_memory_info = wine_vk_find_struct(&create_info_host, EXTERNAL_MEMORY_IMAGE_CREATE_INFO)))
+     {
+-        if (external_memory_info->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR)
++        if (external_memory_info->handleTypes & wine_vk_handle_over_fd_types)
+             external_memory_info->handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
+         wine_vk_normalize_handle_types_host(&external_memory_info->handleTypes);
+     }
+diff --git a/dlls/winevulkan/vulkan_private.h b/dlls/winevulkan/vulkan_private.h
+index 66d9bde2745..16b18c67622 100644
+--- a/dlls/winevulkan/vulkan_private.h
++++ b/dlls/winevulkan/vulkan_private.h
+@@ -241,4 +241,11 @@ extern const struct unix_funcs loader_funcs;
+ BOOL WINAPI wine_vk_is_available_instance_function(VkInstance instance, const char *name) DECLSPEC_HIDDEN;
+ BOOL WINAPI wine_vk_is_available_device_function(VkDevice device, const char *name) DECLSPEC_HIDDEN;
+ 
++static inline void init_unicode_string( UNICODE_STRING *str, const WCHAR *data )
++{
++    str->Length = lstrlenW(data) * sizeof(WCHAR);
++    str->MaximumLength = str->Length + sizeof(WCHAR);
++    str->Buffer = (WCHAR *)data;
++}
++
+ #endif /* __WINE_VULKAN_PRIVATE_H */
+diff --git a/include/ddk/wdm.h b/include/ddk/wdm.h
+index 0aad83ade8c..97e978af801 100644
+--- a/include/ddk/wdm.h
++++ b/include/ddk/wdm.h
+@@ -1818,6 +1818,7 @@ NTSTATUS  WINAPI ObRegisterCallbacks(POB_CALLBACK_REGISTRATION, void**);
+ NTSTATUS  WINAPI ObReferenceObjectByHandle(HANDLE,ACCESS_MASK,POBJECT_TYPE,KPROCESSOR_MODE,PVOID*,POBJECT_HANDLE_INFORMATION);
+ NTSTATUS  WINAPI ObReferenceObjectByName(UNICODE_STRING*,ULONG,ACCESS_STATE*,ACCESS_MASK,POBJECT_TYPE,KPROCESSOR_MODE,void*,void**);
+ NTSTATUS  WINAPI ObReferenceObjectByPointer(void*,ACCESS_MASK,POBJECT_TYPE,KPROCESSOR_MODE);
++NTSTATUS  WINAPI ObOpenObjectByPointer(void *,ULONG,ACCESS_STATE*,ACCESS_MASK,POBJECT_TYPE,KPROCESSOR_MODE,HANDLE*);
+ void      WINAPI ObUnRegisterCallbacks(void*);
+ 
+ NTSTATUS  WINAPI PoCallDriver(DEVICE_OBJECT*,IRP*);
+diff --git a/loader/wine.inf.in b/loader/wine.inf.in
+index c13c9b8d9a3..79e216844f3 100644
+--- a/loader/wine.inf.in
++++ b/loader/wine.inf.in
+@@ -187,6 +187,7 @@ AddService=Winmgmt,0,WinmgmtService
+ AddService=wuauserv,0,wuauService
+ AddService=NDIS,0x800,NDISService
+ AddService=nsiproxy,0x800,NsiProxyService
++AddService=SharedGpuResources,0x800,SharedGpuResourcesService
+ 
+ [DefaultInstall.NT.Services]
+ AddService=BITS,0,BITSService
+@@ -206,6 +207,7 @@ AddService=Winmgmt,0,WinmgmtService
+ AddService=wuauserv,0,wuauService
+ AddService=NDIS,0x800,NDISService
+ AddService=nsiproxy,0x800,NsiProxyService
++AddService=SharedGpuResources,0x800,SharedGpuResourcesService
+ 
+ [DefaultInstall.ntamd64.Services]
+ AddService=BITS,0,BITSService
+@@ -225,6 +227,7 @@ AddService=Winmgmt,0,WinmgmtService
+ AddService=wuauserv,0,wuauService
+ AddService=NDIS,0x800,NDISService
+ AddService=nsiproxy,0x800,NsiProxyService
++AddService=SharedGpuResources,0x800,SharedGpuResourcesService
+ 
+ [DefaultInstall.ntarm64.Services]
+ AddService=BITS,0,BITSService
+@@ -244,6 +247,7 @@ AddService=Winmgmt,0,WinmgmtService
+ AddService=wuauserv,0,wuauService
+ AddService=NDIS,0x800,NDISService
+ AddService=nsiproxy,0x800,NsiProxyService
++AddService=SharedGpuResources,0x800,SharedGpuResourcesService
+ 
+ [Strings]
+ MciExtStr="Software\Microsoft\Windows NT\CurrentVersion\MCI Extensions"
+@@ -2571,6 +2575,15 @@ LoadOrderGroup="System Bus Extender"
+ [NsiProxyServiceKeys]
+ HKR,,"Tag",0x10001,1
+ 
++[SharedGpuResourcesService]
++Description="Shared GPU Resources Manager Service"
++DisplayName="Shared GPU Resources Manager"
++ServiceBinary="%12%\sharedgpures.sys"
++ServiceType=1
++StartType=2
++ErrorControl=1
++LoadOrderGroup="System Bus Extender"
++
+ [RpcSsService]
+ Description="RPC service"
+ DisplayName="Remote Procedure Call (RPC)"
+-- 
+2.37.1
+
+From 3d367c1bb0d48dd803fc0a8029c26c1b5cc3902f Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 13 Oct 2021 13:34:49 +0200
+Subject: [PATCH 4/4] sharedgpures: Add support for arbitrary metadata.
+
+---
+ dlls/sharedgpures.sys/shared_resource.c | 57 +++++++++++++++++++++++--
+ 1 file changed, 53 insertions(+), 4 deletions(-)
+
+diff --git a/dlls/sharedgpures.sys/shared_resource.c b/dlls/sharedgpures.sys/shared_resource.c
+index b9f34eb978f..b0a2aebdb01 100644
+--- a/dlls/sharedgpures.sys/shared_resource.c
++++ b/dlls/sharedgpures.sys/shared_resource.c
+@@ -23,6 +23,8 @@ struct shared_resource
+     unsigned int ref_count;
+     void *unix_resource;
+     WCHAR *name;
++    void *metadata;
++    SIZE_T metadata_size;
+ };
+ 
+ static struct shared_resource *resource_pool;
+@@ -246,6 +248,33 @@ static NTSTATUS shared_resource_get_unix_resource(struct shared_resource *res, v
+     return STATUS_SUCCESS;
+ }
+ 
++#define IOCTL_SHARED_GPU_RESOURCE_SET_METADATA           CTL_CODE(FILE_DEVICE_VIDEO, 4, METHOD_BUFFERED, FILE_WRITE_ACCESS)
++
++static NTSTATUS shared_resource_set_metadata(struct shared_resource *res, void *buff, SIZE_T insize, IO_STATUS_BLOCK *iosb)
++{
++    res->metadata = ExAllocatePoolWithTag(NonPagedPool, insize, 0);
++    memcpy(res->metadata, buff, insize);
++    res->metadata_size = insize;
++
++    iosb->Information = 0;
++    return STATUS_SUCCESS;
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_GET_METADATA           CTL_CODE(FILE_DEVICE_VIDEO, 5, METHOD_BUFFERED, FILE_READ_ACCESS)
++
++static NTSTATUS shared_resource_get_metadata(struct shared_resource *res, void *buff, SIZE_T outsize, IO_STATUS_BLOCK *iosb)
++{
++    if (!res->metadata)
++        return STATUS_NOT_FOUND;
++
++    if (res->metadata_size > outsize)
++        return STATUS_BUFFER_TOO_SMALL;
++
++    memcpy(buff, res->metadata, res->metadata_size);
++    iosb->Information = res->metadata_size;
++    return STATUS_SUCCESS;
++}
++
+ static NTSTATUS WINAPI dispatch_create(DEVICE_OBJECT *device, IRP *irp)
+ {
+     irp->IoStatus.u.Status = STATUS_SUCCESS;
+@@ -263,11 +292,19 @@ static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
+     if (res)
+     {
+         res->ref_count--;
+-        if (!res->ref_count && res->unix_resource)
++        if (!res->ref_count)
+         {
+-            /* TODO: see if its possible to destroy the object here (unlink?) */
+-            ObDereferenceObject(res->unix_resource);
+-            res->unix_resource = NULL;
++            if (res->unix_resource)
++            {
++                /* TODO: see if its possible to destroy the object here (unlink?) */
++                ObDereferenceObject(res->unix_resource);
++                res->unix_resource = NULL;
++            }
++            if (res->metadata)
++            {
++                ExFreePoolWithTag(res->metadata, 0);
++                res->metadata = NULL;
++            }
+         }
+     }
+ 
+@@ -313,6 +350,18 @@ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
+                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
+                                       &irp->IoStatus );
+             break;
++        case IOCTL_SHARED_GPU_RESOURCE_SET_METADATA:
++            status = shared_resource_set_metadata( *res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.InputBufferLength,
++                                      &irp->IoStatus );
++            break;
++        case IOCTL_SHARED_GPU_RESOURCE_GET_METADATA:
++            status = shared_resource_get_metadata( *res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.OutputBufferLength,
++                                      &irp->IoStatus );
++            break;
+     default:
+         FIXME( "ioctl %lx not supported\n", stack->Parameters.DeviceIoControl.IoControlCode );
+         status = STATUS_NOT_SUPPORTED;
+-- 
+2.37.1
+
+From d552e54dc4bc8cea60058aba95ca27d27ba2d796 Mon Sep 17 00:00:00 2001
+From: Andrew Eikum <aeikum@codeweavers.com>
+Date: Tue, 1 Mar 2022 10:27:30 +0100
+Subject: [PATCH 1/5] winegstreamer: Don't flip RGB for Media Foundation
+ clients
+
+---
+ dlls/winegstreamer/gst_private.h   |  2 +-
+ dlls/winegstreamer/main.c          |  3 +-
+ dlls/winegstreamer/media_source.c  |  2 +-
+ dlls/winegstreamer/quartz_parser.c |  2 +-
+ dlls/winegstreamer/unixlib.h       |  3 ++
+ dlls/winegstreamer/wg_parser.c     | 47 ++++++++++++++++--------------
+ dlls/winegstreamer/wm_reader.c     |  6 ++--
+ 7 files changed, 36 insertions(+), 29 deletions(-)
+
+diff --git a/dlls/winegstreamer/gst_private.h b/dlls/winegstreamer/gst_private.h
+index f9130d975ac..cc9f547b6fe 100644
+--- a/dlls/winegstreamer/gst_private.h
++++ b/dlls/winegstreamer/gst_private.h
+@@ -84,7 +84,7 @@ uint32_t wg_parser_get_stream_count(struct wg_parser *parser);
+ struct wg_parser_stream *wg_parser_get_stream(struct wg_parser *parser, uint32_t index);
+ 
+ void wg_parser_stream_get_preferred_format(struct wg_parser_stream *stream, struct wg_format *format);
+-void wg_parser_stream_enable(struct wg_parser_stream *stream, const struct wg_format *format);
++void wg_parser_stream_enable(struct wg_parser_stream *stream, const struct wg_format *format, uint32_t flags);
+ void wg_parser_stream_disable(struct wg_parser_stream *stream);
+ 
+ bool wg_parser_stream_get_buffer(struct wg_parser_stream *stream, struct wg_parser_buffer *buffer);
+diff --git a/dlls/winegstreamer/main.c b/dlls/winegstreamer/main.c
+index 519ee4062ca..d2e05246bfd 100644
+--- a/dlls/winegstreamer/main.c
++++ b/dlls/winegstreamer/main.c
+@@ -179,12 +179,13 @@ void wg_parser_stream_get_preferred_format(struct wg_parser_stream *stream, stru
+     __wine_unix_call(unix_handle, unix_wg_parser_stream_get_preferred_format, &params);
+ }
+ 
+-void wg_parser_stream_enable(struct wg_parser_stream *stream, const struct wg_format *format)
++void wg_parser_stream_enable(struct wg_parser_stream *stream, const struct wg_format *format, uint32_t flags)
+ {
+     struct wg_parser_stream_enable_params params =
+     {
+         .stream = stream,
+         .format = format,
++        .flags = flags,
+     };
+ 
+     TRACE("stream %p, format %p.\n", stream, format);
+diff --git a/dlls/winegstreamer/media_source.c b/dlls/winegstreamer/media_source.c
+index 537363c1cdf..68912f4235b 100644
+--- a/dlls/winegstreamer/media_source.c
++++ b/dlls/winegstreamer/media_source.c
+@@ -358,7 +358,7 @@ static void start_pipeline(struct media_source *source, struct source_async_comm
+             IMFMediaTypeHandler_GetCurrentMediaType(mth, &current_mt);
+ 
+             mf_media_type_to_wg_format(current_mt, &format);
+-            wg_parser_stream_enable(stream->wg_stream, &format);
++            wg_parser_stream_enable(stream->wg_stream, &format, 0);
+ 
+             IMFMediaType_Release(current_mt);
+             IMFMediaTypeHandler_Release(mth);
+diff --git a/dlls/winegstreamer/quartz_parser.c b/dlls/winegstreamer/quartz_parser.c
+index eb90875909d..23ec764df16 100644
+--- a/dlls/winegstreamer/quartz_parser.c
++++ b/dlls/winegstreamer/quartz_parser.c
+@@ -986,7 +986,7 @@ static HRESULT parser_init_stream(struct strmbase_filter *iface)
+         {
+             ret = amt_to_wg_format(&source->pin.pin.mt, &format);
+             assert(ret);
+-            wg_parser_stream_enable(source->wg_stream, &format);
++            wg_parser_stream_enable(source->wg_stream, &format, STREAM_ENABLE_FLAG_FLIP_RGB);
+         }
+         else
+         {
+diff --git a/dlls/winegstreamer/unixlib.h b/dlls/winegstreamer/unixlib.h
+index d976bedd7f5..1e5d61e3356 100644
+--- a/dlls/winegstreamer/unixlib.h
++++ b/dlls/winegstreamer/unixlib.h
+@@ -207,10 +207,13 @@ struct wg_parser_stream_get_preferred_format_params
+     struct wg_format *format;
+ };
+ 
++#define STREAM_ENABLE_FLAG_FLIP_RGB 0x1
++
+ struct wg_parser_stream_enable_params
+ {
+     struct wg_parser_stream *stream;
+     const struct wg_format *format;
++    uint32_t flags;
+ };
+ 
+ struct wg_parser_stream_get_buffer_params
+diff --git a/dlls/winegstreamer/wg_parser.c b/dlls/winegstreamer/wg_parser.c
+index 3cb4ae828a0..ea51fe33b13 100644
+--- a/dlls/winegstreamer/wg_parser.c
++++ b/dlls/winegstreamer/wg_parser.c
+@@ -219,31 +219,34 @@ static NTSTATUS wg_parser_stream_enable(void *args)
+ 
+     if (format->major_type == WG_MAJOR_TYPE_VIDEO)
+     {
+-        bool flip = (format->u.video.height < 0);
+-
+-        switch (format->u.video.format)
++        if (params->flags & STREAM_ENABLE_FLAG_FLIP_RGB)
+         {
+-            case WG_VIDEO_FORMAT_BGRA:
+-            case WG_VIDEO_FORMAT_BGRx:
+-            case WG_VIDEO_FORMAT_BGR:
+-            case WG_VIDEO_FORMAT_RGB15:
+-            case WG_VIDEO_FORMAT_RGB16:
+-                flip = !flip;
+-                break;
++            bool flip = (format->u.video.height < 0);
+ 
+-            case WG_VIDEO_FORMAT_AYUV:
+-            case WG_VIDEO_FORMAT_I420:
+-            case WG_VIDEO_FORMAT_NV12:
+-            case WG_VIDEO_FORMAT_UYVY:
+-            case WG_VIDEO_FORMAT_YUY2:
+-            case WG_VIDEO_FORMAT_YV12:
+-            case WG_VIDEO_FORMAT_YVYU:
+-            case WG_VIDEO_FORMAT_UNKNOWN:
+-            case WG_VIDEO_FORMAT_CINEPAK:
+-                break;
+-        }
++            switch (format->u.video.format)
++            {
++                case WG_VIDEO_FORMAT_BGRA:
++                case WG_VIDEO_FORMAT_BGRx:
++                case WG_VIDEO_FORMAT_BGR:
++                case WG_VIDEO_FORMAT_RGB15:
++                case WG_VIDEO_FORMAT_RGB16:
++                    flip = !flip;
++                    break;
+ 
+-        gst_util_set_object_arg(G_OBJECT(stream->flip), "method", flip ? "vertical-flip" : "none");
++                case WG_VIDEO_FORMAT_AYUV:
++                case WG_VIDEO_FORMAT_I420:
++                case WG_VIDEO_FORMAT_NV12:
++                case WG_VIDEO_FORMAT_UYVY:
++                case WG_VIDEO_FORMAT_YUY2:
++                case WG_VIDEO_FORMAT_YV12:
++                case WG_VIDEO_FORMAT_YVYU:
++                case WG_VIDEO_FORMAT_UNKNOWN:
++                case WG_VIDEO_FORMAT_CINEPAK:
++                    break;
++            }
++
++            gst_util_set_object_arg(G_OBJECT(stream->flip), "method", flip ? "vertical-flip" : "none");
++        }
+     }
+ 
+     gst_pad_push_event(stream->my_sink, gst_event_new_reconfigure());
+diff --git a/dlls/winegstreamer/wm_reader.c b/dlls/winegstreamer/wm_reader.c
+index 169a3b19fdc..389bb3a915a 100644
+--- a/dlls/winegstreamer/wm_reader.c
++++ b/dlls/winegstreamer/wm_reader.c
+@@ -1520,7 +1520,7 @@ static HRESULT init_stream(struct wm_reader *reader, QWORD file_size)
+                     stream->format.u.video.format = WG_VIDEO_FORMAT_BGRx;
+             }
+         }
+-        wg_parser_stream_enable(stream->wg_stream, &stream->format);
++        wg_parser_stream_enable(stream->wg_stream, &stream->format, STREAM_ENABLE_FLAG_FLIP_RGB);
+     }
+ 
+     /* We probably discarded events because streams weren't enabled yet.
+@@ -1798,7 +1798,7 @@ HRESULT wm_reader_set_output_props(struct wm_reader *reader, DWORD output,
+     }
+ 
+     stream->format = format;
+-    wg_parser_stream_enable(stream->wg_stream, &format);
++    wg_parser_stream_enable(stream->wg_stream, &format, STREAM_ENABLE_FLAG_FLIP_RGB);
+ 
+     /* Re-decode any buffers that might have been generated with the old format.
+      *
+@@ -2069,7 +2069,7 @@ HRESULT wm_reader_set_streams_selected(struct wm_reader *reader, WORD count,
+                 FIXME("Ignoring selection %#x for stream %u; treating as enabled.\n",
+                         selections[i], stream_numbers[i]);
+             TRACE("Enabling stream %u.\n", stream_numbers[i]);
+-            wg_parser_stream_enable(stream->wg_stream, &stream->format);
++            wg_parser_stream_enable(stream->wg_stream, &stream->format, STREAM_ENABLE_FLAG_FLIP_RGB);
+         }
+     }
+ 
+-- 
+2.37.1
+
+From 4d84e993d6dd5c51d7db3e74de5e617e1df6067f Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Thu, 14 Apr 2022 17:01:36 -0400
+Subject: [PATCH 2/5] include: Define MFVideoFormat_ABGR32.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ include/mfapi.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/mfapi.h b/include/mfapi.h
+index 6926bd2cd2d..5edb99ab24f 100644
+--- a/include/mfapi.h
++++ b/include/mfapi.h
+@@ -72,6 +72,7 @@ DEFINE_MEDIATYPE_GUID(MFVideoFormat_RGB565,        D3DFMT_R5G6B5);
+ DEFINE_MEDIATYPE_GUID(MFVideoFormat_RGB24,         D3DFMT_R8G8B8);
+ DEFINE_MEDIATYPE_GUID(MFVideoFormat_RGB32,         D3DFMT_X8R8G8B8);
+ DEFINE_MEDIATYPE_GUID(MFVideoFormat_ARGB32,        D3DFMT_A8R8G8B8);
++DEFINE_MEDIATYPE_GUID(MFVideoFormat_ABGR32,        32);
+ DEFINE_MEDIATYPE_GUID(MFVideoFormat_A2R10G10B10,   D3DFMT_A2B10G10R10);
+ DEFINE_MEDIATYPE_GUID(MFVideoFormat_A16B16G16R16F, D3DFMT_A16B16G16R16F);
+ DEFINE_MEDIATYPE_GUID(MFVideoFormat_L8,            D3DFMT_L8);
+-- 
+2.37.1
+
+From 0cff02f20f0211263b70be137432829f5426bf29 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Thu, 14 Apr 2022 16:58:33 -0400
+Subject: [PATCH 3/5] mfplat: Add MFVideoFormat_ABGR32 format information.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/mfplat/mediatype.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/dlls/mfplat/mediatype.c b/dlls/mfplat/mediatype.c
+index 984120c5414..2f9594a52b8 100644
+--- a/dlls/mfplat/mediatype.c
++++ b/dlls/mfplat/mediatype.c
+@@ -2633,6 +2633,7 @@ static const struct uncompressed_video_format video_formats[] =
+     { &MFVideoFormat_RGB565,        2, 3, 1, 0 },
+     { &MFVideoFormat_RGB555,        2, 3, 1, 0 },
+     { &MFVideoFormat_A2R10G10B10,   4, 3, 1, 0 },
++    { &MFVideoFormat_ABGR32,        4, 3, 1, 0 },
+     { &MFVideoFormat_RGB8,          1, 3, 1, 0 },
+     { &MFVideoFormat_L8,            1, 3, 1, 0 },
+     { &MFVideoFormat_AYUV,          4, 3, 0, 1 },
+@@ -3441,6 +3442,8 @@ DXGI_FORMAT WINAPI MFMapDX9FormatToDXGIFormat(DWORD format)
+             return DXGI_FORMAT_P8;
+         case D3DFMT_A8P8:
+             return DXGI_FORMAT_A8P8;
++        case D3DFMT_A8B8G8R8:
++            return DXGI_FORMAT_R8G8B8A8_UNORM;
+         default:
+             return DXGI_FORMAT_UNKNOWN;
+     }
+-- 
+2.37.1
+
+From 0c96f3b8cdf4262337d50b8d002af2a95196565a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Fri, 24 Jun 2022 19:37:39 +0200
+Subject: [PATCH 4/5] winegstreamer: Add WG_VIDEO_FORMAT_RGBA format support.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/winegstreamer/mfplat.c        | 1 +
+ dlls/winegstreamer/quartz_parser.c | 1 +
+ dlls/winegstreamer/unixlib.h       | 1 +
+ dlls/winegstreamer/wg_format.c     | 3 +++
+ dlls/winegstreamer/wg_parser.c     | 1 +
+ 5 files changed, 7 insertions(+)
+
+diff --git a/dlls/winegstreamer/mfplat.c b/dlls/winegstreamer/mfplat.c
+index 2916dfb3320..e4ed511ef4d 100644
+--- a/dlls/winegstreamer/mfplat.c
++++ b/dlls/winegstreamer/mfplat.c
+@@ -691,6 +691,7 @@ video_formats[] =
+     {&MFVideoFormat_RGB24,  WG_VIDEO_FORMAT_BGR},
+     {&MFVideoFormat_RGB555, WG_VIDEO_FORMAT_RGB15},
+     {&MFVideoFormat_RGB565, WG_VIDEO_FORMAT_RGB16},
++    {&MFVideoFormat_ABGR32, WG_VIDEO_FORMAT_RGBA},
+     {&MFVideoFormat_AYUV,   WG_VIDEO_FORMAT_AYUV},
+     {&MFVideoFormat_I420,   WG_VIDEO_FORMAT_I420},
+     {&MFVideoFormat_IYUV,   WG_VIDEO_FORMAT_I420},
+diff --git a/dlls/winegstreamer/quartz_parser.c b/dlls/winegstreamer/quartz_parser.c
+index 23ec764df16..0703e6045f7 100644
+--- a/dlls/winegstreamer/quartz_parser.c
++++ b/dlls/winegstreamer/quartz_parser.c
+@@ -262,6 +262,7 @@ unsigned int wg_format_get_max_size(const struct wg_format *format)
+ 
+             switch (format->u.video.format)
+             {
++                case WG_VIDEO_FORMAT_RGBA:
+                 case WG_VIDEO_FORMAT_BGRA:
+                 case WG_VIDEO_FORMAT_BGRx:
+                 case WG_VIDEO_FORMAT_AYUV:
+diff --git a/dlls/winegstreamer/unixlib.h b/dlls/winegstreamer/unixlib.h
+index 1e5d61e3356..99364618f9a 100644
+--- a/dlls/winegstreamer/unixlib.h
++++ b/dlls/winegstreamer/unixlib.h
+@@ -56,6 +56,7 @@ struct wg_format
+                 WG_VIDEO_FORMAT_BGR,
+                 WG_VIDEO_FORMAT_RGB15,
+                 WG_VIDEO_FORMAT_RGB16,
++                WG_VIDEO_FORMAT_RGBA,
+ 
+                 WG_VIDEO_FORMAT_AYUV,
+                 WG_VIDEO_FORMAT_I420,
+diff --git a/dlls/winegstreamer/wg_format.c b/dlls/winegstreamer/wg_format.c
+index 032b39bb799..862b4bd4378 100644
+--- a/dlls/winegstreamer/wg_format.c
++++ b/dlls/winegstreamer/wg_format.c
+@@ -138,6 +138,8 @@ static enum wg_video_format wg_video_format_from_gst(GstVideoFormat format)
+ {
+     switch (format)
+     {
++        case GST_VIDEO_FORMAT_RGBA:
++            return WG_VIDEO_FORMAT_RGBA;
+         case GST_VIDEO_FORMAT_BGRA:
+             return WG_VIDEO_FORMAT_BGRA;
+         case GST_VIDEO_FORMAT_BGRx:
+@@ -370,6 +372,7 @@ static GstVideoFormat wg_video_format_to_gst(enum wg_video_format format)
+         case WG_VIDEO_FORMAT_BGR:   return GST_VIDEO_FORMAT_BGR;
+         case WG_VIDEO_FORMAT_RGB15: return GST_VIDEO_FORMAT_RGB15;
+         case WG_VIDEO_FORMAT_RGB16: return GST_VIDEO_FORMAT_RGB16;
++        case WG_VIDEO_FORMAT_RGBA:  return GST_VIDEO_FORMAT_RGBA;
+         case WG_VIDEO_FORMAT_AYUV:  return GST_VIDEO_FORMAT_AYUV;
+         case WG_VIDEO_FORMAT_I420:  return GST_VIDEO_FORMAT_I420;
+         case WG_VIDEO_FORMAT_NV12:  return GST_VIDEO_FORMAT_NV12;
+diff --git a/dlls/winegstreamer/wg_parser.c b/dlls/winegstreamer/wg_parser.c
+index ea51fe33b13..a9bb29faf30 100644
+--- a/dlls/winegstreamer/wg_parser.c
++++ b/dlls/winegstreamer/wg_parser.c
+@@ -225,6 +225,7 @@ static NTSTATUS wg_parser_stream_enable(void *args)
+ 
+             switch (format->u.video.format)
+             {
++                case WG_VIDEO_FORMAT_RGBA:
+                 case WG_VIDEO_FORMAT_BGRA:
+                 case WG_VIDEO_FORMAT_BGRx:
+                 case WG_VIDEO_FORMAT_BGR:
+-- 
+2.37.1
+
+From 3b1192cfbe01f057db2acd23a5d7e622fb5c8e4d Mon Sep 17 00:00:00 2001
+From: Nikolay Sivov <nsivov@codeweavers.com>
+Date: Wed, 12 Jan 2022 22:48:35 +0300
+Subject: [PATCH] winegstreamer: Add MFVideoFormat_ARGB32 output for the
+ source.
+
+(cherry picked from commit 9812591f0003c5c611faa59ab9b3cb73a85be637)
+
+CW-Bug-Id: #19975
+---
+ dlls/winegstreamer/media_source.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winegstreamer/media_source.c b/dlls/winegstreamer/media_source.c
+index 8994616bbdb..7d28fb26636 100644
+--- a/dlls/winegstreamer/media_source.c
++++ b/dlls/winegstreamer/media_source.c
+@@ -872,7 +872,7 @@ static HRESULT new_media_stream(struct media_source *source,
+ static HRESULT media_stream_init_desc(struct media_stream *stream)
+ {
+     IMFMediaTypeHandler *type_handler = NULL;
+-    IMFMediaType *stream_types[6];
++    IMFMediaType *stream_types[7];
+     struct wg_format format;
+     DWORD type_count = 0;
+     unsigned int i;
+@@ -891,6 +891,7 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
+             &MFVideoFormat_YUY2,
+             &MFVideoFormat_IYUV,
+             &MFVideoFormat_I420,
++            &MFVideoFormat_ARGB32,
+         };
+ 
+         IMFMediaType *base_type = mf_media_type_from_wg_format(&format);
+From 223ed2e0af0a380106876137972c21e5e88c7e35 Mon Sep 17 00:00:00 2001
+From: Andrew Eikum <aeikum@codeweavers.com>
+Date: Tue, 25 Jan 2022 10:21:28 -0600
+Subject: [PATCH] winegstreamer: Add MFVideoFormat_RGB32 output for the source.
+
+CW-Bug-Id: #19516
+CW-Bug-Id: #19859
+---
+ dlls/winegstreamer/media_source.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winegstreamer/media_source.c b/dlls/winegstreamer/media_source.c
+index 7d28fb26636..ddb58ea0a3f 100644
+--- a/dlls/winegstreamer/media_source.c
++++ b/dlls/winegstreamer/media_source.c
+@@ -872,7 +872,7 @@ static HRESULT new_media_stream(struct media_source *source,
+ static HRESULT media_stream_init_desc(struct media_stream *stream)
+ {
+     IMFMediaTypeHandler *type_handler = NULL;
+-    IMFMediaType *stream_types[7];
++    IMFMediaType *stream_types[8];
+     struct wg_format format;
+     DWORD type_count = 0;
+     unsigned int i;
+@@ -892,6 +892,7 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
+             &MFVideoFormat_IYUV,
+             &MFVideoFormat_I420,
+             &MFVideoFormat_ARGB32,
++            &MFVideoFormat_RGB32,
+         };
+ 
+         IMFMediaType *base_type = mf_media_type_from_wg_format(&format);
+From b97f2ba066494ef86d7b45ec32ee897101e7592e Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Thu, 14 Apr 2022 17:02:03 -0400
+Subject: [PATCH 5/5] winegstreamer: Add MFVideoFormat_ABGR32 media type to
+ media source video stream descriptor.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/winegstreamer/media_source.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winegstreamer/media_source.c b/dlls/winegstreamer/media_source.c
+index 68912f4235b..2191cfb0ded 100644
+--- a/dlls/winegstreamer/media_source.c
++++ b/dlls/winegstreamer/media_source.c
+@@ -855,7 +855,7 @@ static HRESULT new_media_stream(struct media_source *source,
+ static HRESULT media_stream_init_desc(struct media_stream *stream)
+ {
+     IMFMediaTypeHandler *type_handler = NULL;
+-    IMFMediaType *stream_types[8];
++    IMFMediaType *stream_types[9];
+     struct wg_format format;
+     DWORD type_count = 0;
+     unsigned int i;
+@@ -876,6 +876,7 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
+             &MFVideoFormat_I420,
+             &MFVideoFormat_ARGB32,
+             &MFVideoFormat_RGB32,
++            &MFVideoFormat_ABGR32,
+         };
+ 
+         IMFMediaType *base_type = mf_media_type_from_wg_format(&format);
+-- 
+2.37.1
+
+From a2efaf1d8b8a848dfe60d5c45238d48a6a653b68 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 13 Jul 2022 13:08:41 -0400
+Subject: [PATCH 02/14] ntoskrnl, server: Support referencing section objects.
+
+Needed for the shared resource manager to track the shared memory object for shared fences.
+---
+ dlls/ntoskrnl.exe/ntoskrnl.c | 12 +++++++++++-
+ server/mapping.c             | 14 +++++++++++++-
+ 2 files changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/ntoskrnl.exe/ntoskrnl.c b/dlls/ntoskrnl.exe/ntoskrnl.c
+index 38a25bc5092..1802d483bbf 100644
+--- a/dlls/ntoskrnl.exe/ntoskrnl.c
++++ b/dlls/ntoskrnl.exe/ntoskrnl.c
+@@ -260,6 +260,15 @@ POBJECT_TYPE WINAPI ObGetObjectType( void *object )
+     return header->type;
+ }
+ 
++static const WCHAR section_type_name[] = {'S','e','c','t','i','o','n',0};
++
++static struct _OBJECT_TYPE section_type =
++{
++    section_type_name
++};
++
++static POBJECT_TYPE p_section_type = &section_type;
++
+ static const POBJECT_TYPE *known_types[] =
+ {
+     &ExEventObjectType,
+@@ -269,7 +278,8 @@ static const POBJECT_TYPE *known_types[] =
+     &IoFileObjectType,
+     &PsProcessType,
+     &PsThreadType,
+-    &SeTokenObjectType
++    &SeTokenObjectType,
++    &p_section_type,
+ };
+ 
+ DECLARE_CRITICAL_SECTION(handle_map_cs);
+diff --git a/server/mapping.c b/server/mapping.c
+index 4c90673a5c5..67896165048 100644
+--- a/server/mapping.c
++++ b/server/mapping.c
+@@ -160,6 +160,7 @@ struct type_descr mapping_type =
+ struct mapping
+ {
+     struct object   obj;             /* object header */
++    struct list     kernel_object;   /* list of kernel object pointers */
+     mem_size_t      size;            /* mapping size */
+     unsigned int    flags;           /* SEC_* flags */
+     struct fd      *fd;              /* fd for mapped file */
+@@ -171,6 +172,7 @@ struct mapping
+ 
+ static void mapping_dump( struct object *obj, int verbose );
+ static struct fd *mapping_get_fd( struct object *obj );
++static struct list *mapping_get_kernel_obj_list( struct object *obj );
+ static void mapping_destroy( struct object *obj );
+ static enum server_fd_type mapping_get_fd_type( struct fd *fd );
+ 
+@@ -195,7 +197,7 @@ static const struct object_ops mapping_ops =
+     directory_link_name,         /* link_name */
+     default_unlink_name,         /* unlink_name */
+     no_open_file,                /* open_file */
+-    no_kernel_obj_list,          /* get_kernel_obj_list */
++    mapping_get_kernel_obj_list, /* get_kernel_obj_list */
+     no_close_handle,             /* close_handle */
+     mapping_destroy              /* destroy */
+ };
+@@ -903,6 +905,8 @@ static struct mapping *create_mapping( struct object *root, const struct unicode
+     if (get_error() == STATUS_OBJECT_NAME_EXISTS)
+         return mapping;  /* Nothing else to do */
+ 
++    list_init( &mapping->kernel_object );
++
+     mapping->size        = size;
+     mapping->fd          = NULL;
+     mapping->shared      = NULL;
+@@ -995,6 +999,8 @@ struct mapping *create_fd_mapping( struct object *root, const struct unicode_str
+     if (!(mapping = create_named_object( root, &mapping_ops, name, attr, sd ))) return NULL;
+     if (get_error() == STATUS_OBJECT_NAME_EXISTS) return mapping;  /* Nothing else to do */
+ 
++    list_init( &mapping->kernel_object );
++
+     mapping->shared    = NULL;
+     mapping->committed = NULL;
+     mapping->flags     = SEC_FILE;
+@@ -1101,6 +1107,12 @@ static struct fd *mapping_get_fd( struct object *obj )
+     return (struct fd *)grab_object( mapping->fd );
+ }
+ 
++static struct list *mapping_get_kernel_obj_list( struct object *obj )
++{
++    struct mapping *mapping = (struct mapping *)obj;
++    return &mapping->kernel_object;
++}
++
+ static void mapping_destroy( struct object *obj )
+ {
+     struct mapping *mapping = (struct mapping *)obj;
+-- 
+2.37.1
+
+From 730fd8b7cb22b630b82be1e12104bdfe5946a027 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 13 Jul 2022 13:11:22 -0400
+Subject: [PATCH 03/14] sharedgpures.sys: Keep index into resource pool in
+ FsContext instead of direct pointer to resource.
+
+This fixes the errors due to the pointers in FsContext becoming invalid when the resource pool was expanded.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/sharedgpures.sys/shared_resource.c | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/dlls/sharedgpures.sys/shared_resource.c b/dlls/sharedgpures.sys/shared_resource.c
+index b0a2aebdb01..0cd30c4a256 100644
+--- a/dlls/sharedgpures.sys/shared_resource.c
++++ b/dlls/sharedgpures.sys/shared_resource.c
+@@ -285,7 +285,7 @@ static NTSTATUS WINAPI dispatch_create(DEVICE_OBJECT *device, IRP *irp)
+ static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
+ {
+     IO_STACK_LOCATION *stack = IoGetCurrentIrpStackLocation(irp);
+-    struct shared_resource *res = stack->FileObject->FsContext;
++    struct shared_resource *res = &resource_pool[ (UINT_PTR) stack->FileObject->FsContext ];
+ 
+     TRACE("Freeing shared resouce %p.\n", res);
+ 
+@@ -316,7 +316,7 @@ static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
+ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
+ {
+     IO_STACK_LOCATION *stack = IoGetCurrentIrpStackLocation( irp );
+-    struct shared_resource **res = (struct shared_resource **) &stack->FileObject->FsContext;
++    struct shared_resource *res = &resource_pool[ (UINT_PTR) stack->FileObject->FsContext ];
+     NTSTATUS status;
+ 
+     TRACE( "ioctl %lx insize %lu outsize %lu\n",
+@@ -327,37 +327,37 @@ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
+     switch (stack->Parameters.DeviceIoControl.IoControlCode)
+     {
+         case IOCTL_SHARED_GPU_RESOURCE_CREATE:
+-            status = shared_resource_create( res,
++            status = shared_resource_create( &res,
+                                       irp->AssociatedIrp.SystemBuffer,
+                                       stack->Parameters.DeviceIoControl.InputBufferLength,
+                                       &irp->IoStatus );
+             break;
+         case IOCTL_SHARED_GPU_RESOURCE_OPEN:
+-            status = shared_resource_open( res,
++            status = shared_resource_open( &res,
+                                       irp->AssociatedIrp.SystemBuffer,
+                                       stack->Parameters.DeviceIoControl.InputBufferLength,
+                                       &irp->IoStatus );
+             break;
+         case IOCTL_SHARED_GPU_RESOURCE_GETKMT:
+-            status = shared_resource_getkmt( *res,
++            status = shared_resource_getkmt( res,
+                                       irp->AssociatedIrp.SystemBuffer,
+                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
+                                       &irp->IoStatus );
+             break;
+         case IOCTL_SHARED_GPU_RESOURCE_GET_UNIX_RESOURCE:
+-            status = shared_resource_get_unix_resource( *res,
++            status = shared_resource_get_unix_resource( res,
+                                       irp->AssociatedIrp.SystemBuffer,
+                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
+                                       &irp->IoStatus );
+             break;
+         case IOCTL_SHARED_GPU_RESOURCE_SET_METADATA:
+-            status = shared_resource_set_metadata( *res,
++            status = shared_resource_set_metadata( res,
+                                       irp->AssociatedIrp.SystemBuffer,
+                                       stack->Parameters.DeviceIoControl.InputBufferLength,
+                                       &irp->IoStatus );
+             break;
+         case IOCTL_SHARED_GPU_RESOURCE_GET_METADATA:
+-            status = shared_resource_get_metadata( *res,
++            status = shared_resource_get_metadata( res,
+                                       irp->AssociatedIrp.SystemBuffer,
+                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
+                                       &irp->IoStatus );
+@@ -368,6 +368,9 @@ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
+         break;
+     }
+ 
++    if (!status)
++        stack->FileObject->FsContext = (UINT_PTR)(res - resource_pool);
++
+     irp->IoStatus.u.Status = status;
+     IoCompleteRequest( irp, IO_NO_INCREMENT );
+     return status;
+-- 
+2.37.1
+
+From c2e10847a3a9921c9d611dc4118dcb8c0bee0d4e Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Wed, 13 Jul 2022 13:14:04 -0400
+Subject: [PATCH 04/14] sharedgpures.sys: Add support for associating
+ additional NT objects with shared resources.
+
+This is then used to share a shared memory section for shared fences
+---
+ dlls/sharedgpures.sys/shared_resource.c | 91 +++++++++++++++++++++++++
+ 1 file changed, 91 insertions(+)
+
+diff --git a/dlls/sharedgpures.sys/shared_resource.c b/dlls/sharedgpures.sys/shared_resource.c
+index 0cd30c4a256..ce0e778166f 100644
+--- a/dlls/sharedgpures.sys/shared_resource.c
++++ b/dlls/sharedgpures.sys/shared_resource.c
+@@ -25,6 +25,8 @@ struct shared_resource
+     WCHAR *name;
+     void *metadata;
+     SIZE_T metadata_size;
++    void **object_pool;
++    unsigned int object_pool_count;
+ };
+ 
+ static struct shared_resource *resource_pool;
+@@ -275,6 +277,70 @@ static NTSTATUS shared_resource_get_metadata(struct shared_resource *res, void *
+     return STATUS_SUCCESS;
+ }
+ 
++#define IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_WRITE_ACCESS)
++
++struct shared_resource_set_object
++{
++    unsigned int index;
++    obj_handle_t handle;
++};
++
++static NTSTATUS shared_resource_set_object(struct shared_resource *res, void *buff, SIZE_T insize, IO_STATUS_BLOCK *iosb)
++{
++    struct shared_resource_set_object *params = buff;
++    void *object;
++
++    if (insize < sizeof(*params))
++        return STATUS_INFO_LENGTH_MISMATCH;
++
++    if (!(object = reference_client_handle(params->handle)))
++        return STATUS_INVALID_HANDLE;
++
++    if (params->index >= res->object_pool_count)
++    {
++        void **expanded_pool = ExAllocatePoolWithTag(NonPagedPool, (params->index + 1) * sizeof(void *), 0);
++
++        if (res->object_pool)
++        {
++            memcpy(expanded_pool, res->object_pool, res->object_pool_count * sizeof(void *));
++            ExFreePoolWithTag(res->object_pool, 0);
++        }
++
++        memset(&expanded_pool[res->object_pool_count], 0, (params->index + 1 - res->object_pool_count) * sizeof (void *));
++
++        res->object_pool = expanded_pool;
++        res->object_pool_count = params->index + 1;
++    }
++
++    if (res->object_pool[params->index])
++        ObDereferenceObject(res->object_pool[params->index]);
++
++    res->object_pool[params->index] = object;
++
++    iosb->Information = 0;
++    return STATUS_SUCCESS;
++}
++
++#define IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_READ_ACCESS)
++
++static NTSTATUS shared_resource_get_object(struct shared_resource *res, void *buff, SIZE_T insize, SIZE_T outsize, IO_STATUS_BLOCK *iosb)
++{
++    unsigned int index;
++
++    if (insize < sizeof(unsigned int) || outsize < sizeof(obj_handle_t))
++        return STATUS_INFO_LENGTH_MISMATCH;
++
++    index = *(unsigned int *)buff;
++
++    if (index >= res->object_pool_count || !res->object_pool[index])
++        return STATUS_INVALID_PARAMETER;
++
++    *((obj_handle_t *)buff) = open_client_handle(res->object_pool[index]);
++
++    iosb->Information = sizeof(obj_handle_t);
++    return STATUS_SUCCESS;
++}
++
+ static NTSTATUS WINAPI dispatch_create(DEVICE_OBJECT *device, IRP *irp)
+ {
+     irp->IoStatus.u.Status = STATUS_SUCCESS;
+@@ -305,6 +371,18 @@ static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
+                 ExFreePoolWithTag(res->metadata, 0);
+                 res->metadata = NULL;
+             }
++            if (res->object_pool)
++            {
++                unsigned int i;
++                for (i = 0; i < res->object_pool_count; i++)
++                {
++                    if (res->object_pool[i])
++                        ObDereferenceObject(res->object_pool[i]);
++                }
++                ExFreePoolWithTag(res->object_pool, 0);
++                res->object_pool = NULL;
++                res->object_pool_count = 0;
++            }
+         }
+     }
+ 
+@@ -362,6 +440,19 @@ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
+                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
+                                       &irp->IoStatus );
+             break;
++        case IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT:
++            status = shared_resource_set_object( res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.InputBufferLength,
++                                      &irp->IoStatus );
++            break;
++        case IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT:
++            status = shared_resource_get_object( res,
++                                      irp->AssociatedIrp.SystemBuffer,
++                                      stack->Parameters.DeviceIoControl.InputBufferLength,
++                                      stack->Parameters.DeviceIoControl.OutputBufferLength,
++                                      &irp->IoStatus);
++            break;
+     default:
+         FIXME( "ioctl %lx not supported\n", stack->Parameters.DeviceIoControl.IoControlCode );
+         status = STATUS_NOT_SUPPORTED;
+-- 
+2.37.1
+
+From 3e193e81d02fbe57d538eb05733baddbe57158b7 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Thu, 14 Jul 2022 15:44:46 -0400
+Subject: [PATCH 05/14] winevulkan: NULL check optional parameters when
+ accessing host object.
+
+---
+ dlls/winevulkan/make_vulkan | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index b81a9a1faea..a9cf215031a 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -1514,7 +1514,7 @@ class VkMember(object):
+ class VkParam(object):
+     """ Helper class which describes a parameter to a function call. """
+ 
+-    def __init__(self, type_info, const=None, pointer=None, name=None, array_len=None, dyn_array_len=None, object_type=None):
++    def __init__(self, type_info, const=None, pointer=None, name=None, array_len=None, dyn_array_len=None, object_type=None, optional=False):
+         self.const = const
+         self.name = name
+         self.array_len = array_len
+@@ -1522,6 +1522,7 @@ class VkParam(object):
+         self.pointer = pointer
+         self.object_type = object_type
+         self.type_info = type_info
++        self.optional = optional
+         self.type = type_info["name"] # For convenience
+         self.handle = type_info["data"] if type_info["category"] == "handle" else None
+         self.struct = type_info["data"] if type_info["category"] == "struct" else None
+@@ -1561,12 +1562,14 @@ class VkParam(object):
+         # Some uint64_t are actually handles with a separate type param
+         object_type = param.get("objecttype", None)
+ 
++        optional = param.get("optional", False)
++
+         # Since we have parsed all types before hand, this should not happen.
+         type_info = types.get(type_elem.text, None)
+         if type_info is None:
+             LOGGER.err("type info not found for: {0}".format(type_elem.text))
+ 
+-        return VkParam(type_info, const=const, pointer=pointer, name=name, array_len=array_len, dyn_array_len=dyn_array_len, object_type=object_type)
++        return VkParam(type_info, const=const, pointer=pointer, name=name, array_len=array_len, dyn_array_len=dyn_array_len, object_type=object_type, optional=optional)
+ 
+     def _set_conversions(self):
+         """ Internal helper function to configure any needed conversion functions. """
+@@ -1903,7 +1906,10 @@ class VkParam(object):
+             # the wine driver's handle to calls which are wrapped by the driver.
+             p = "{0}{1}".format(params_prefix, self.name)
+             driver_handle = self.handle.driver_handle(p) if self.is_handle() else None
+-            return driver_handle if driver_handle else p
++            if driver_handle and self.optional:
++                return "{0} ? {1} : VK_NULL_HANDLE".format(p, driver_handle)
++            else:
++                return driver_handle if driver_handle else p
+ 
+ 
+ class VkStruct(Sequence):
+-- 
+2.37.1
+
+From ef1dedf4c9e1b8f415593a6bcf669f7f7d0ed168 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Fri, 15 Jul 2022 15:12:52 -0400
+Subject: [PATCH 11/14] winegstreamer: Add MF_MT_VIDEO_NOMINAL_RANGE attribute
+ to base video output type.
+
+---
+ dlls/winegstreamer/media_source.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/dlls/winegstreamer/media_source.c b/dlls/winegstreamer/media_source.c
+index eab85c29bed..63e61e84f44 100644
+--- a/dlls/winegstreamer/media_source.c
++++ b/dlls/winegstreamer/media_source.c
+@@ -882,6 +882,8 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
+         IMFMediaType *base_type = mf_media_type_from_wg_format(&format);
+         GUID base_subtype;
+ 
++        IMFMediaType_SetUINT32(base_type, &MF_MT_VIDEO_NOMINAL_RANGE, MFNominalRange_Normal);
++
+         IMFMediaType_GetGUID(base_type, &MF_MT_SUBTYPE, &base_subtype);
+ 
+         stream_types[0] = base_type;
+-- 
+2.37.1
+
+From 65e8ff36eff59d827c4beedaf75a3f0418f05e16 Mon Sep 17 00:00:00 2001
+From: Derek Lesho <dlesho@codeweavers.com>
+Date: Fri, 22 Apr 2022 11:53:02 -0400
+Subject: [PATCH 01/14] winevulkan: Implement VK_KHR_external_semaphore_win32
+ for OPAQUE_WIN32 handleType.
+
+---
+ dlls/winevulkan/make_vulkan |  14 ++-
+ dlls/winevulkan/vulkan.c    | 188 ++++++++++++++++++++++++++++++++++--
+ 2 files changed, 191 insertions(+), 11 deletions(-)
+
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 89b2e7ee1e2..b81a9a1faea 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -98,7 +98,6 @@ UNSUPPORTED_EXTENSIONS = [
+     "VK_EXT_hdr_metadata", # Needs WSI work.
+     "VK_GOOGLE_display_timing",
+     "VK_KHR_external_fence_win32",
+-    "VK_KHR_external_semaphore_win32",
+     # Relates to external_semaphore and needs type conversions in bitflags.
+     "VK_KHR_shared_presentable_image", # Needs WSI work.
+     "VK_KHR_win32_keyed_mutex",
+@@ -111,7 +110,6 @@ UNSUPPORTED_EXTENSIONS = [
+     "VK_EXT_physical_device_drm",
+     "VK_GOOGLE_surfaceless_query",
+     "VK_KHR_external_fence_fd",
+-    "VK_KHR_external_semaphore_fd",
+     "VK_SEC_amigo_profiling", # Angle specific.
+
+     # Extensions which require callback handling
+@@ -126,6 +124,7 @@ UNSUPPORTED_EXTENSIONS = [
+ # but not expose to applications (useful for test commits)
+ UNEXPOSED_EXTENSIONS = {
+     "VK_KHR_external_memory_fd",
++    "VK_KHR_external_semaphore_fd",
+ }
+ 
+ # The Vulkan loader provides entry-points for core functionality and important
+@@ -192,7 +191,7 @@ FUNCTION_OVERRIDES = {
+     "vkEnumeratePhysicalDevices" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetPhysicalDeviceExternalBufferProperties" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetPhysicalDeviceExternalFenceProperties" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetPhysicalDeviceExternalSemaphoreProperties" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetPhysicalDeviceExternalSemaphoreProperties" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetPhysicalDeviceImageFormatProperties2" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+     "vkGetPhysicalDeviceProperties2" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PUBLIC, "loader_thunk" : ThunkType.PRIVATE},
+     "vkGetPhysicalDeviceProperties2KHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PUBLIC, "loader_thunk" : ThunkType.PRIVATE},
+@@ -205,6 +204,7 @@ FUNCTION_OVERRIDES = {
+     "vkCreateComputePipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+     "vkCreateGraphicsPipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+     "vkCreateImage" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkCreateSemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkDestroyCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkDestroyDevice" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkFreeCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+@@ -244,7 +244,7 @@ FUNCTION_OVERRIDES = {
+     "vkGetPhysicalDeviceImageFormatProperties2KHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+ 
+     # VK_KHR_external_semaphore_capabilities
+-    "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+ 
+     # VK_KHR_device_group_creation
+     "vkEnumeratePhysicalDeviceGroupsKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+@@ -274,6 +274,10 @@ FUNCTION_OVERRIDES = {
+     # VK_KHR_external_memory_win32
+     "vkGetMemoryWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetMemoryWin32HandlePropertiesKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++
++    # VK_KHR_external_semaphore_win32
++    "vkGetSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkImportSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+ }
+ 
+ STRUCT_CHAIN_CONVERSIONS = {
+@@ -286,6 +290,7 @@ STRUCT_CHAIN_CONVERSIONS = {
+     "VkImageCreateInfo": [],
+     "VkMemoryAllocateInfo": ["VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"],
+     "VkPhysicalDeviceImageFormatInfo2": [],
++    "VkSemaphoreCreateInfo": ["VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"],
+ }
+ 
+ 
+diff --git a/dlls/winevulkan/vulkan.c b/dlls/winevulkan/vulkan.c
+index ce2c464c462..70ab0dddf0f 100644
+--- a/dlls/winevulkan/vulkan.c
++++ b/dlls/winevulkan/vulkan.c
+@@ -285,6 +285,15 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
+             host_properties[i].specVersion = VK_KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION;
+         }
+ 
++        if (!strcmp(host_properties[i].extensionName, "VK_KHR_external_semaphore_fd"))
++        {
++            TRACE("Substituting VK_KHR_external_semaphore_fd for VK_KHR_external_semaphore_win32\n");
++
++            snprintf(host_properties[i].extensionName, sizeof(host_properties[i].extensionName),
++                    VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
++            host_properties[i].specVersion = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_SPEC_VERSION;
++        }
++
+         if (wine_vk_device_extension_supported(host_properties[i].extensionName))
+         {
+             TRACE("Enabling extension '%s' for physical device %p\n", host_properties[i].extensionName, object);
+@@ -408,7 +417,7 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
+ 
+     for (i = 0; i < src->enabledExtensionCount; i++)
+     {
+-        if (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
++        if (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32") || !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
+         {
+             replace_win32 = 1;
+             break;
+@@ -426,6 +435,8 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
+         {
+             if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
+                 new_extensions_list[o] = strdup("VK_KHR_external_memory_fd");
++            else if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
++                new_extensions_list[o] = strdup("VK_KHR_external_semaphore_fd");
+             else
+                 new_extensions_list[o] = strdup(dst->ppEnabledExtensionNames[i]);
+             ++o;
+@@ -1627,6 +1638,51 @@ NTSTATUS wine_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(void *args)
+     return res;
+ }
+ 
++static inline void wine_vk_normalize_semaphore_handle_types_win(VkExternalSemaphoreHandleTypeFlags *types)
++{
++    *types &=
++        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT |
++        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT |
++        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
++}
++
++static inline void wine_vk_normalize_semaphore_handle_types_host(VkExternalSemaphoreHandleTypeFlags *types)
++{
++    *types &=
++        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT |
++        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
++}
++
++static void wine_vk_get_physical_device_external_semaphore_properties(VkPhysicalDevice phys_dev,
++    void (*p_vkGetPhysicalDeviceExternalSemaphoreProperties)(VkPhysicalDevice, const VkPhysicalDeviceExternalSemaphoreInfo *, VkExternalSemaphoreProperties *),
++    const VkPhysicalDeviceExternalSemaphoreInfo *semaphore_info, VkExternalSemaphoreProperties *properties)
++{
++    VkPhysicalDeviceExternalSemaphoreInfo semaphore_info_dup = *semaphore_info;
++
++    wine_vk_normalize_semaphore_handle_types_win(&semaphore_info_dup.handleType);
++    if (semaphore_info_dup.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++        semaphore_info_dup.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++    wine_vk_normalize_semaphore_handle_types_host(&semaphore_info_dup.handleType);
++
++    if (semaphore_info->handleType && !semaphore_info_dup.handleType)
++    {
++        properties->exportFromImportedHandleTypes = 0;
++        properties->compatibleHandleTypes = 0;
++        properties->externalSemaphoreFeatures = 0;
++        return;
++    }
++
++    p_vkGetPhysicalDeviceExternalSemaphoreProperties(phys_dev->phys_dev, &semaphore_info_dup, properties);
++
++    if (properties->exportFromImportedHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
++        properties->exportFromImportedHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++    wine_vk_normalize_semaphore_handle_types_win(&properties->exportFromImportedHandleTypes);
++
++    if (properties->compatibleHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
++        properties->compatibleHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++    wine_vk_normalize_semaphore_handle_types_win(&properties->compatibleHandleTypes);
++}
++
+ NTSTATUS wine_vkGetPhysicalDeviceExternalSemaphoreProperties(void *args)
+ {
+     struct vkGetPhysicalDeviceExternalSemaphoreProperties_params *params = args;
+@@ -1635,9 +1691,8 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalSemaphoreProperties(void *args)
+     VkExternalSemaphoreProperties *properties = params->pExternalSemaphoreProperties;
+ 
+     TRACE("%p, %p, %p\n", phys_dev, semaphore_info, properties);
+-    properties->exportFromImportedHandleTypes = 0;
+-    properties->compatibleHandleTypes = 0;
+-    properties->externalSemaphoreFeatures = 0;
++    wine_vk_get_physical_device_external_semaphore_properties(phys_dev, phys_dev->instance->funcs.p_vkGetPhysicalDeviceExternalSemaphoreProperties, semaphore_info, properties);
++
+     return STATUS_SUCCESS;
+ }
+ 
+@@ -1649,9 +1704,8 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(void *args)
+     VkExternalSemaphoreProperties *properties = params->pExternalSemaphoreProperties;
+ 
+     TRACE("%p, %p, %p\n", phys_dev, semaphore_info, properties);
+-    properties->exportFromImportedHandleTypes = 0;
+-    properties->compatibleHandleTypes = 0;
+-    properties->externalSemaphoreFeatures = 0;
++    wine_vk_get_physical_device_external_semaphore_properties(phys_dev, phys_dev->instance->funcs.p_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, semaphore_info, properties);
++
+     return STATUS_SUCCESS;
+ }
+ 
+@@ -2008,6 +2062,10 @@ BOOL WINAPI wine_vk_is_available_device_function(VkDevice device, const char *na
+ {
+     if (!strcmp(name, "vkGetMemoryWin32HandleKHR") || !strcmp(name, "vkGetMemoryWin32HandlePropertiesKHR"))
+         name = "vkGetMemoryFdKHR";
++    if (!strcmp(name, "vkGetSemaphoreWin32HandleKHR"))
++        name = "vkGetSemaphoreFdKHR";
++    if (!strcmp(name, "vkImportSemaphoreWin32HandleKHR"))
++        name = "vkImportSemaphoreFdKHR";
+     return !!vk_funcs->p_vkGetDeviceProcAddr(device->device, name);
+ }
+ 
+@@ -2480,3 +2538,119 @@ NTSTATUS wine_vkCreateImage(void *args)
+ 
+     return res;
+ }
++
++NTSTATUS wine_vkCreateSemaphore(void *args)
++{
++    struct vkCreateSemaphore_params *params = args;
++    VkDevice device = params->device;
++    const VkSemaphoreCreateInfo *create_info = params->pCreateInfo;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++    VkSemaphore *semaphore = params->pSemaphore;
++
++    VkSemaphoreCreateInfo create_info_host = *create_info;
++    VkExportSemaphoreCreateInfo *export_semaphore_info;
++    VkResult res;
++
++    TRACE("%p %p %p %p", device, create_info, allocator, semaphore);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if ((res = convert_VkSemaphoreCreateInfo_struct_chain(create_info->pNext, &create_info_host)))
++    {
++        WARN("Failed to convert VkSemaphoreCreateInfo pNext chain, res=%d.\n", res);
++        return res;
++    }
++
++    if ((export_semaphore_info = wine_vk_find_struct(&create_info_host, EXPORT_SEMAPHORE_CREATE_INFO)))
++    {
++        if (export_semaphore_info->handleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++            export_semaphore_info->handleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++        wine_vk_normalize_semaphore_handle_types_host(&export_semaphore_info->handleTypes);
++    }
++
++    if (wine_vk_find_struct(&create_info_host,  EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR))
++        FIXME("VkExportSemaphoreWin32HandleInfoKHR unhandled.\n");
++
++    res = device->funcs.p_vkCreateSemaphore(device->device, &create_info_host, NULL, semaphore);
++
++    free_VkSemaphoreCreateInfo_struct_chain(&create_info_host);
++
++    return res;
++}
++
++NTSTATUS wine_vkGetSemaphoreWin32HandleKHR(void *args)
++{
++    struct vkGetSemaphoreWin32HandleKHR_params *params = args;
++    VkDevice device = params->device;
++    const VkSemaphoreGetWin32HandleInfoKHR *handle_info = params->pGetWin32HandleInfo;
++    HANDLE *handle = params->pHandle;
++
++    VkSemaphoreGetFdInfoKHR_host fd_info;
++    VkResult res;
++    int fd;
++
++    fd_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
++    fd_info.pNext = handle_info->pNext;
++    fd_info.semaphore = handle_info->semaphore;
++    fd_info.handleType = handle_info->handleType;
++    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
++
++    res = device->funcs.p_vkGetSemaphoreFdKHR(device->device, &fd_info, &fd);
++
++    if (res != VK_SUCCESS)
++        return res;
++
++    if (wine_server_fd_to_handle(fd, GENERIC_ALL, 0, handle) != STATUS_SUCCESS)
++    {
++        close(fd);
++        return VK_ERROR_OUT_OF_HOST_MEMORY;
++    }
++
++    return VK_SUCCESS;
++}
++
++NTSTATUS wine_vkImportSemaphoreWin32HandleKHR(void *args)
++{
++    struct vkImportSemaphoreWin32HandleKHR_params *params = args;
++    VkDevice device = params->device;
++    const VkImportSemaphoreWin32HandleInfoKHR *handle_info = params->pImportSemaphoreWin32HandleInfo;
++
++    VkImportSemaphoreFdInfoKHR_host fd_info;
++    VkResult res;
++    int fd;
++
++    fd_info.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
++    fd_info.pNext = handle_info->pNext;
++    fd_info.semaphore = handle_info->semaphore;
++    fd_info.flags = handle_info->flags;
++    fd_info.handleType = handle_info->handleType;
++
++    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++    {
++        if (handle_info->name)
++        {
++            FIXME("Importing win32 semaphore by name not supported.\n");
++            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++        }
++
++        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++        if (wine_server_handle_to_fd(handle_info->handle, GENERIC_ALL, &fd, NULL) != STATUS_SUCCESS)
++            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++    }
++    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
++
++    if (!fd_info.handleType)
++    {
++        FIXME("Importing win32 semaphore with handle type %#x not supported.\n", handle_info->handleType);
++        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++    }
++
++    /* importing FDs transfers ownership, importing NT handles does not  */
++    if ((res = device->funcs.p_vkImportSemaphoreFdKHR(device->device, &fd_info)) != VK_SUCCESS)
++        close(fd);
++
++    return res;
++}
+-- 
+2.37.1
+
+From 56fec27f2c26681bdd850ec6319d9b663e9c77e1 Mon Sep 17 00:00:00 2001
+From: Dmitry Skvortsov <lvb.crd@protonmail.com>
+Date: Thu, 11 Aug 2022 22:32:22 +0300
+Subject: [PATCH] megacommit
+
+dd5f79790d01f4dbddcaa7970cbc2af10fa8c193 Derek Lesho winevulkan: Add initial support for D3D12-Fence compatible timeline semaphores.
+e8992e62caafe2ca81f587050c077ada5a65ef85 Derek Lesho winevulkan: Implement vkWaitForFences and vkSignalSemaphore for D3D12-Fence compatible timeline semaphores.
+e2bbca036deb6f86a8cdf8a1c9e24656bceb2a8b Derek Lesho winevulkan: Copy VkSubmitInfo structs so that they don't contain pointers to the source object.
+86d9e6efd9a9cab8bd551fa1652af845ba38bee7 Derek Lesho winevulkan: Support waiting for and signalling D3D12-Fence style timeline semaphores in Vulkan Queues.
+d27f6727eb2dba67e0a9e176a32db88f21ec0b82 Derek Lesho winevulkan: Add support for signalling VkFence from virtualized VkQueues.
+6d5ad56d49af8a355476dc37b89681b9a2b7b44b Derek Lesho winevulkan: Flush virtual queue before providing native handle.
+22118a4146aa2ccbb6829c4c9ea8c9b4d521f9e0 Derek Lesho winevulkan: Allowing importing D3D11 Texture handles as Vulkan memory objects.
+c68248d2dd50bd11ed8deab7c483d9ddd6a06377 Derek Lesho winevulkan: Expose VK_EXT_memory_priority and VK_KHR_win32_keyed_mutex for Crysis: Remastered.
+
+Signed-off-by: Derek Lesho <dlesho@codeweavers.com>
+---
+ dlls/winevulkan/make_vulkan      |   51 +-
+ dlls/winevulkan/vulkan.c         | 2218 ++++++++++++++++++++++++++++--
+ dlls/winevulkan/vulkan_loader.h  |    2 +
+ dlls/winevulkan/vulkan_private.h |  108 ++
+ 4 files changed, 2259 insertions(+), 120 deletions(-)
+
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 6cb45569d8a..04a02522506 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -100,7 +100,6 @@ UNSUPPORTED_EXTENSIONS = [
+     "VK_KHR_external_fence_win32",
+     # Relates to external_semaphore and needs type conversions in bitflags.
+     "VK_KHR_shared_presentable_image", # Needs WSI work.
+-    "VK_KHR_win32_keyed_mutex",
+     "VK_NV_external_memory_rdma", # Needs shared resources work.
+ 
+     # Extensions for other platforms
+@@ -202,16 +201,28 @@ FUNCTION_OVERRIDES = {
+     "vkCreateBuffer" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkCreateCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkCreateComputePipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
++    "vkCreateFence" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkCreateGraphicsPipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+     "vkCreateImage" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkCreateSemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkDestroyCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkDestroyDevice" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkDestroyFence" : {"dispatch" : True, "driver" : False, "thunk": ThunkType.NONE},
++    "vkDestroySemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkFreeCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkFreeMemory" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetDeviceProcAddr" : {"dispatch" : False, "driver" : True, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.NONE},
+     "vkGetDeviceQueue" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkGetDeviceQueue2" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetSemaphoreCounterValue" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkResetFences" : {"dispatch" : True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkSignalSemaphore" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkWaitForFences" : {"dispatch": True, "driver": False, "thunk": ThunkType.PRIVATE},
++    "vkWaitSemaphores" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkQueueBindSparse" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkQueueSubmit" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkQueueSubmit2" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkQueueWaitIdle" : {"dispatch": True, "driver": False, "thunk" : ThunkType.NONE},
+ 
+     # VK_KHR_surface
+     "vkDestroySurfaceKHR" : {"dispatch" : True, "driver" : True, "thunk" : ThunkType.NONE},
+@@ -234,7 +245,7 @@ FUNCTION_OVERRIDES = {
+     "vkCreateSwapchainKHR" : {"dispatch" : True, "driver" : True, "thunk" : ThunkType.PUBLIC},
+     "vkDestroySwapchainKHR" : {"dispatch" : True, "driver" : True, "thunk" : ThunkType.PUBLIC},
+     "vkGetSwapchainImagesKHR": {"dispatch" : True, "driver" : True, "thunk" : ThunkType.PUBLIC},
+-    "vkQueuePresentKHR": {"dispatch" : True, "driver" : True, "thunk" : ThunkType.PUBLIC},
++    "vkQueuePresentKHR": {"dispatch" : True, "driver" : True, "thunk" : ThunkType.PRIVATE},
+ 
+     # VK_KHR_external_fence_capabilities
+     "vkGetPhysicalDeviceExternalFencePropertiesKHR" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
+@@ -278,6 +289,14 @@ FUNCTION_OVERRIDES = {
+     # VK_KHR_external_semaphore_win32
+     "vkGetSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+     "vkImportSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++
++    # VK_KHR_timeline_semaphore
++    "vkGetSemaphoreCounterValueKHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkSignalSemaphoreKHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++    "vkWaitSemaphoresKHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
++
++    # VK_KHR_synchronization2
++    "vkQueueSubmit2KHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+ }
+ 
+ STRUCT_CHAIN_CONVERSIONS = {
+@@ -290,7 +309,10 @@ STRUCT_CHAIN_CONVERSIONS = {
+     "VkImageCreateInfo": [],
+     "VkMemoryAllocateInfo": ["VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"],
+     "VkPhysicalDeviceImageFormatInfo2": [],
++    "VkPhysicalDeviceExternalSemaphoreInfo": [],
+     "VkSemaphoreCreateInfo": ["VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"],
++    "VkSubmitInfo": ["VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR", "VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR"],
++    "VkSubmitInfo2" : ["VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR"],
+ }
+ 
+ 
+@@ -1116,6 +1138,10 @@ class VkHandle(object):
+             return "wine_surface_from_handle({0})->surface".format(name)
+         if self.name == "VkDeviceMemory":
+             return "wine_dev_mem_from_handle({0})->dev_mem".format(name)
++        if self.name == "VkSemaphore":
++            return "wine_semaphore_host_handle( wine_semaphore_from_handle({0}) )".format(name)
++        if self.name == "VkFence":
++            return "wine_fence_from_handle({0})->fence".format(name)
+ 
+         native_handle_name = None
+ 
+@@ -1250,9 +1276,10 @@ class VkMember(object):
+         return VkMember(const=const, struct_fwd_decl=struct_fwd_decl, _type=member_type, pointer=pointer, name=name_elem.text,
+                 array_len=array_len, dyn_array_len=dyn_array_len, optional=optional, values=values, object_type=object_type, bit_width=bit_width)
+ 
+-    def copy(self, input, output, direction, conv):
++    def copy(self, input, output, direction, conv, deep_copy=False):
+         """ Helper method for use by conversion logic to generate a C-code statement to copy this member.
+-            - `conv` indicates whether the statement is in a struct alignment conversion path. """
++            - `conv` indicates whether the statement is in a struct alignment conversion path.
++            - `deep_copy` indicates whether a pointers members need to have their data copied. """
+ 
+         if (conv and self.needs_conversion()) or self.needs_unwrapping():
+             if self.is_dynamic_array():
+@@ -1290,6 +1317,9 @@ class VkMember(object):
+         elif self.is_static_array():
+             bytes_count = "{0} * sizeof({1})".format(self.array_len, self.type)
+             return "memcpy({0}{1}, {2}{1}, {3});\n".format(output, self.name, input, bytes_count)
++        elif deep_copy and self.is_dynamic_array():
++            count = self.dyn_array_len if isinstance(self.dyn_array_len, int) else "{0}{1}".format(input, self.dyn_array_len)
++            return "{0}{1} = memdup({2}{1}, {3}, sizeof({0}{1}[0]));\n".format(output, self.name, input, count)
+         else:
+             return "{0}{1} = {2}{1};\n".format(output, self.name, input)
+ 
+@@ -1768,9 +1798,6 @@ class VkParam(object):
+         # 'parent' param requiring conversion.
+         if self.is_struct():
+             for m in self.struct:
+-                if not m.is_struct():
+-                    continue
+-
+                 if not m.needs_conversion() and not m.needs_unwrapping():
+                     continue
+ 
+@@ -2542,10 +2569,11 @@ class FreeFunction(object):
+ 
+ 
+ class StructChainConversionFunction(object):
+-    def __init__(self, direction, struct, ignores):
++    def __init__(self, direction, struct, ignores, deep_copy):
+         self.direction = direction
+         self.struct = struct
+         self.ignores = ignores
++        self.deep_copy = deep_copy
+         self.type = struct.name
+ 
+         self.name = "convert_{0}_struct_chain".format(self.type)
+@@ -2595,8 +2623,8 @@ class StructChainConversionFunction(object):
+                 if m.name == "pNext":
+                     body += "            out->pNext = NULL;\n"
+                 else:
+-                    convert = m.copy("in->", "out->", self.direction, conv=True)
+-                    unwrap = m.copy("in->", "out->", self.direction, conv=False)
++                    convert = m.copy("in->", "out->", self.direction, conv=True, deep_copy=self.deep_copy)
++                    unwrap = m.copy("in->", "out->", self.direction, conv=False, deep_copy=self.deep_copy)
+                     if unwrap == convert:
+                         body += "            " + unwrap
+                     else:
+@@ -2732,7 +2760,8 @@ class VkGenerator(object):
+ 
+         for struct in self.registry.structs:
+             if struct.name in STRUCT_CHAIN_CONVERSIONS:
+-                self.struct_chain_conversions.append(StructChainConversionFunction(Direction.INPUT, struct, STRUCT_CHAIN_CONVERSIONS[struct.name]))
++                self.struct_chain_conversions.append(StructChainConversionFunction(Direction.INPUT, struct, STRUCT_CHAIN_CONVERSIONS[struct.name],
++                                                                                   struct.name == "VkSubmitInfo" or struct.name == "VkSubmitInfo2"))
+                 self.struct_chain_conversions.append(FreeStructChainFunction(struct))
+                 # Once we decide to support pNext chains conversion everywhere, move this under get_conversions
+                 for e in struct.struct_extensions:
+diff --git a/dlls/winevulkan/vulkan.c b/dlls/winevulkan/vulkan.c
+index 70ab0dddf0f..542c9a459ab 100644
+--- a/dlls/winevulkan/vulkan.c
++++ b/dlls/winevulkan/vulkan.c
+@@ -25,6 +25,12 @@
+ #include <time.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <stdbool.h>
++#include <stdio.h>
++#include <assert.h>
++#include <errno.h>
++#include <poll.h>
++#include <sys/eventfd.h>
+ 
+ #include "ntstatus.h"
+ #define WIN32_NO_STATUS
+@@ -32,6 +38,7 @@
+ #include "winnt.h"
+ #include "winioctl.h"
+ #include "wine/server.h"
++#include "wine/list.h"
+ 
+ #include "vulkan_private.h"
+ #include "wine/vulkan_driver.h"
+@@ -236,8 +243,14 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
+     struct VkPhysicalDevice_T *object;
+     uint32_t num_host_properties, num_properties = 0;
+     VkExtensionProperties *host_properties = NULL;
++#if defined(USE_STRUCT_CONVERSION)
++    VkPhysicalDeviceProperties_host physdev_properties;
++#else
++    VkPhysicalDeviceProperties physdev_properties;
++#endif
+     VkResult res;
+     unsigned int i, j;
++    bool has_memory_priority = false;
+ 
+     if (!(object = calloc(1, sizeof(*object))))
+         return NULL;
+@@ -246,6 +259,9 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
+     object->instance = instance;
+     object->phys_dev = phys_dev;
+ 
++    instance->funcs.p_vkGetPhysicalDeviceProperties(phys_dev, &physdev_properties);
++    object->api_version = physdev_properties.apiVersion;
++
+     WINE_VK_ADD_DISPATCHABLE_MAPPING(instance, object, phys_dev);
+ 
+     res = instance->funcs.p_vkEnumerateDeviceExtensionProperties(phys_dev,
+@@ -293,6 +309,10 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
+                     VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
+             host_properties[i].specVersion = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_SPEC_VERSION;
+         }
++        if (!strcmp(host_properties[i].extensionName, "VK_EXT_memory_priority"))
++        {
++            has_memory_priority = true;
++        }
+ 
+         if (wine_vk_device_extension_supported(host_properties[i].extensionName))
+         {
+@@ -305,6 +325,12 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
+         }
+     }
+ 
++    if (instance->quirks & WINEVULKAN_QUIRK_EXPOSE_KEYED_MUTEX)
++        num_properties++;
++
++    if (!has_memory_priority && (instance->quirks & WINEVULKAN_QUIRK_EXPOSE_MEM_PRIORITY))
++        num_properties++;
++
+     TRACE("Host supported extensions %u, Wine supported extensions %u\n", num_host_properties, num_properties);
+ 
+     if (!(object->extensions = calloc(num_properties, sizeof(*object->extensions))))
+@@ -321,6 +347,27 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
+             j++;
+         }
+     }
++
++    if (instance->quirks & WINEVULKAN_QUIRK_EXPOSE_KEYED_MUTEX)
++    {
++        TRACE("Faking VK_KHR_win32_keyed_mutex extension.\n");
++        snprintf(object->extensions[j].extensionName, sizeof(object->extensions[j].extensionName),
++                VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME);
++        object->extensions[j].specVersion = VK_KHR_WIN32_KEYED_MUTEX_SPEC_VERSION;
++        j++;
++    }
++
++    if (!has_memory_priority && (instance->quirks & WINEVULKAN_QUIRK_EXPOSE_MEM_PRIORITY))
++    {
++        TRACE("Faking VK_EXT_memory_priority extension.\n");
++        snprintf(object->extensions[j].extensionName, sizeof(object->extensions[j].extensionName),
++                VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME);
++        object->extensions[j].specVersion = VK_EXT_MEMORY_PRIORITY_SPEC_VERSION;
++        j++;
++
++        object->fake_memory_priority = true;
++    }
++
+     object->extension_count = num_properties;
+ 
+     free(host_properties);
+@@ -366,6 +413,14 @@ static void wine_vk_device_get_queues(struct VkDevice_T *device,
+         queue->queue_index = i;
+         queue->flags = flags;
+ 
++        pthread_mutex_init(&queue->submissions_mutex, NULL);
++        pthread_cond_init(&queue->submissions_cond, NULL);
++        list_init(&queue->submissions);
++
++        pthread_mutex_init(&queue->signaller_mutex, NULL);
++        pthread_cond_init(&queue->signaller_cond, NULL);
++        list_init(&queue->signal_ops);
++
+         /* The Vulkan spec says:
+          *
+          * "vkGetDeviceQueue must only be used to get queues that were created
+@@ -397,10 +452,10 @@ static void wine_vk_device_free_create_info(VkDeviceCreateInfo *create_info)
+         free((void *)create_info->ppEnabledExtensionNames);
+ }
+ 
+-static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src,
++static VkResult wine_vk_device_convert_create_info(VkPhysicalDevice phys_dev, const VkDeviceCreateInfo *src,
+         VkDeviceCreateInfo *dst)
+ {
+-    unsigned int i, replace_win32 = 0;
++    unsigned int i, replace_win32 = 0, timeline_enabled = 0, drop_extension = 0, wine_extension_count;
+     VkResult res;
+ 
+     *dst = *src;
+@@ -411,32 +466,74 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
+         return res;
+     }
+ 
++    if (phys_dev->fake_memory_priority)
++    {
++        VkBaseOutStructure *header;
++
++        for (header = (void *) dst; header; header = header->pNext)
++        {
++            if (header->pNext && header->pNext->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT)
++            {
++                VkBaseOutStructure *memory_priority = header->pNext;
++
++                header->pNext = memory_priority->pNext;
++                free(memory_priority);
++                break;
++            }
++        }
++    }
++
+     /* Should be filtered out by loader as ICDs don't support layers. */
+     dst->enabledLayerCount = 0;
+     dst->ppEnabledLayerNames = NULL;
+ 
+-    for (i = 0; i < src->enabledExtensionCount; i++)
++    for (i = 0; i < dst->enabledExtensionCount; i++)
+     {
+-        if (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32") || !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
+-        {
++        const char *extension_name = dst->ppEnabledExtensionNames[i];
++        if (!strcmp(extension_name, "VK_KHR_external_memory_win32") || !strcmp(extension_name, "VK_KHR_external_semaphore_win32"))
+             replace_win32 = 1;
+-            break;
+-        }
++        else if (!strcmp(extension_name, "VK_KHR_win32_keyed_mutex") || (phys_dev->fake_memory_priority && !strcmp(extension_name, "VK_EXT_memory_priority")))
++            drop_extension = 1;
++        else if (!strcmp(extension_name, "VK_KHR_timeline_semaphore"))
++            timeline_enabled = 1;
+     }
+ 
+-    if (replace_win32)
++    if (replace_win32 || drop_extension)
+     {
+-        unsigned int o = 0;
++        unsigned int o = 0, j;
+         char **new_extensions_list;
+- 
+-        new_extensions_list = malloc(sizeof(char *) * (dst->enabledExtensionCount));
++
++        new_extensions_list = malloc(sizeof(char *) * (dst->enabledExtensionCount + replace_win32));
+ 
+         for (i = 0; i < dst->enabledExtensionCount; i++)
+         {
++            if (drop_extension && (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_win32_keyed_mutex") ||
++                (phys_dev->fake_memory_priority && !strcmp(src->ppEnabledExtensionNames[i], "VK_EXT_memory_priority"))))
++            {
++                TRACE("Ignoring active extension %s.\n", src->ppEnabledExtensionNames[i]);
++                continue;
++            }
++
+             if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
+                 new_extensions_list[o] = strdup("VK_KHR_external_memory_fd");
+             else if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
++            {
+                 new_extensions_list[o] = strdup("VK_KHR_external_semaphore_fd");
++
++                /* D3D12-Fence interoperable semaphores are implemented using timeline semaphores */
++                if (!timeline_enabled && (phys_dev->api_version < VK_API_VERSION_1_2 || phys_dev->instance->api_version < VK_API_VERSION_1_2))
++                {
++                    for (j = 0; j < phys_dev->extension_count; j++)
++                    {
++                        if (!strcmp(phys_dev->extensions[j].extensionName, "VK_KHR_timeline_semaphore"))
++                        {
++                            new_extensions_list[++o] = strdup("VK_KHR_timeline_semaphore");
++                            break;
++                        }
++                    }
++                }
++
++            }
+             else
+                 new_extensions_list[o] = strdup(dst->ppEnabledExtensionNames[i]);
+             ++o;
+@@ -444,10 +541,13 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
+ 
+         dst->enabledExtensionCount = o;
+         dst->ppEnabledExtensionNames = (const char * const *)new_extensions_list;
++
+     }
+ 
++    wine_extension_count = dst->enabledExtensionCount;
++
+     TRACE("Enabled %u extensions.\n", dst->enabledExtensionCount);
+-    for (i = 0; i < dst->enabledExtensionCount; i++)
++    for (i = 0; i < wine_extension_count; i++)
+     {
+         TRACE("Extension %u: %s.\n", i, debugstr_a(dst->ppEnabledExtensionNames[i]));
+     }
+@@ -455,6 +555,11 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
+     return VK_SUCCESS;
+ }
+ 
++static bool is_virtual_queue(struct VkQueue_T *queue)
++{
++    return __atomic_load_n(&queue->virtual_queue, __ATOMIC_ACQUIRE);
++}
++
+ /* Helper function used for freeing a device structure. This function supports full
+  * and partial object cleanups and can thus be used for vkCreateDevice failures.
+  */
+@@ -471,6 +576,28 @@ static void wine_vk_device_free(struct VkDevice_T *device)
+         for (i = 0; i < device->queue_count; i++)
+         {
+             queue = &device->queues[i];
++
++            if (is_virtual_queue(queue))
++            {
++                pthread_mutex_lock(&queue->submissions_mutex);
++                pthread_mutex_lock(&queue->signaller_mutex);
++                queue->stop = 1;
++                pthread_mutex_unlock(&queue->submissions_mutex);
++                pthread_mutex_unlock(&queue->signaller_mutex);
++
++                pthread_cond_signal(&queue->submissions_cond);
++                pthread_cond_signal(&queue->signaller_cond);
++
++                pthread_join(queue->virtual_queue_thread, NULL);
++                pthread_join(queue->signal_thread, NULL);
++            }
++
++            pthread_mutex_destroy(&queue->submissions_mutex);
++            pthread_mutex_destroy(&queue->signaller_mutex);
++
++            pthread_cond_destroy(&queue->submissions_cond);
++            pthread_cond_destroy(&queue->signaller_cond);
++
+             if (queue && queue->queue)
+                 WINE_VK_REMOVE_HANDLE_MAPPING(device->phys_dev->instance, queue);
+         }
+@@ -496,7 +623,6 @@ NTSTATUS init_vulkan(void *args)
+         return STATUS_UNSUCCESSFUL;
+     }
+ 
+-
+     *(const struct unix_funcs **)args = &loader_funcs;
+     return STATUS_SUCCESS;
+ }
+@@ -781,7 +907,7 @@ NTSTATUS wine_vkCreateDevice(void *args)
+     object->base.base.loader_magic = VULKAN_ICD_MAGIC_VALUE;
+     object->phys_dev = phys_dev;
+ 
+-    res = wine_vk_device_convert_create_info(create_info, &create_info_host);
++    res = wine_vk_device_convert_create_info(phys_dev, create_info, &create_info_host);
+     if (res != VK_SUCCESS)
+         goto fail;
+ 
+@@ -894,6 +1020,23 @@ NTSTATUS wine_vkCreateInstance(void *args)
+     ALL_VK_INSTANCE_FUNCS()
+ #undef USE_VK_FUNC
+ 
++    if ((app_info = create_info->pApplicationInfo))
++    {
++        TRACE("Application name %s, application version %#x.\n",
++                debugstr_a(app_info->pApplicationName), app_info->applicationVersion);
++        TRACE("Engine name %s, engine version %#x.\n", debugstr_a(app_info->pEngineName),
++                app_info->engineVersion);
++        TRACE("API version %#x.\n", app_info->apiVersion);
++
++        object->api_version = app_info->apiVersion;
++
++        if (app_info->pEngineName && !strcmp(app_info->pEngineName, "idTech"))
++            object->quirks |= WINEVULKAN_QUIRK_GET_DEVICE_PROC_ADDR;
++
++        if (app_info->pEngineName && !strcmp(app_info->pEngineName, "nvpro-sample"))
++            object->quirks |= (WINEVULKAN_QUIRK_EXPOSE_MEM_PRIORITY | WINEVULKAN_QUIRK_EXPOSE_KEYED_MUTEX);
++    }
++
+     /* Cache physical devices for vkEnumeratePhysicalDevices within the instance as
+      * each vkPhysicalDevice is a dispatchable object, which means we need to wrap
+      * the native physical devices and present those to the application.
+@@ -907,18 +1050,6 @@ NTSTATUS wine_vkCreateInstance(void *args)
+         return res;
+     }
+ 
+-    if ((app_info = create_info->pApplicationInfo))
+-    {
+-        TRACE("Application name %s, application version %#x.\n",
+-                debugstr_a(app_info->pApplicationName), app_info->applicationVersion);
+-        TRACE("Engine name %s, engine version %#x.\n", debugstr_a(app_info->pEngineName),
+-                app_info->engineVersion);
+-        TRACE("API version %#x.\n", app_info->apiVersion);
+-
+-        if (app_info->pEngineName && !strcmp(app_info->pEngineName, "idTech"))
+-            object->quirks |= WINEVULKAN_QUIRK_GET_DEVICE_PROC_ADDR;
+-    }
+-
+     object->quirks |= WINEVULKAN_QUIRK_ADJUST_MAX_IMAGE_COUNT;
+ 
+     *instance = object;
+@@ -1350,7 +1481,9 @@ static inline void wine_vk_normalize_handle_types_host(VkExternalMemoryHandleTyp
+ 
+ static const VkExternalMemoryHandleTypeFlagBits wine_vk_handle_over_fd_types =
+                 VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT |
+-                VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
++                VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT |
++                VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT |
++                VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT;
+ 
+ static void wine_vk_get_physical_device_external_buffer_properties(VkPhysicalDevice phys_dev,
+         void (*p_vkGetPhysicalDeviceExternalBufferProperties)(VkPhysicalDevice, const VkPhysicalDeviceExternalBufferInfo *, VkExternalBufferProperties *),
+@@ -1657,29 +1790,90 @@ static void wine_vk_get_physical_device_external_semaphore_properties(VkPhysical
+     void (*p_vkGetPhysicalDeviceExternalSemaphoreProperties)(VkPhysicalDevice, const VkPhysicalDeviceExternalSemaphoreInfo *, VkExternalSemaphoreProperties *),
+     const VkPhysicalDeviceExternalSemaphoreInfo *semaphore_info, VkExternalSemaphoreProperties *properties)
+ {
+-    VkPhysicalDeviceExternalSemaphoreInfo semaphore_info_dup = *semaphore_info;
++    VkPhysicalDeviceExternalSemaphoreInfo semaphore_info_dup = *semaphore_info, semaphore_info_host;
++    VkSemaphoreTypeCreateInfo semaphore_type_info, *p_semaphore_type_info;
++    unsigned int i;
++    VkResult res;
++
++    if ((res = convert_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(semaphore_info->pNext, &semaphore_info_dup)) < 0)
++    {
++        WARN("Failed to convert VkPhysicalDeviceExternalSemaphoreInfo pNext chain, res=%d.\n", res);
++
++        properties->exportFromImportedHandleTypes = 0;
++        properties->compatibleHandleTypes = 0;
++        properties->externalSemaphoreFeatures = 0;
++        return;
++    }
++
++    semaphore_info_host = semaphore_info_dup;
++
++    switch(semaphore_info->handleType)
++    {
++        case VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT:
++            semaphore_info_host.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++            break;
++        case VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT:
++        {
++            if (phys_dev->api_version < VK_API_VERSION_1_2 ||
++                phys_dev->instance->api_version < VK_API_VERSION_1_2)
++            {
++                for (i = 0; i < phys_dev->extension_count; i++)
++                {
++                    if (!strcmp(phys_dev->extensions[i].extensionName, "VK_KHR_timeline_semaphore"))
++                        break;
++                }
++                if (i == phys_dev->extension_count)
++                {
++                    free_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(&semaphore_info_dup);
++                    properties->exportFromImportedHandleTypes = 0;
++                    properties->compatibleHandleTypes = 0;
++                    properties->externalSemaphoreFeatures = 0;
++                    return;
++                }
++            }
++
++            if ((p_semaphore_type_info = wine_vk_find_struct(&semaphore_info_host, SEMAPHORE_TYPE_CREATE_INFO)))
++            {
++                p_semaphore_type_info->semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
++                p_semaphore_type_info->initialValue = 0;
++            }
++            else
++            {
++                semaphore_type_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
++                semaphore_type_info.pNext = semaphore_info_host.pNext;
++                semaphore_type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
++                semaphore_type_info.initialValue = 0;
+ 
+-    wine_vk_normalize_semaphore_handle_types_win(&semaphore_info_dup.handleType);
+-    if (semaphore_info_dup.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+-        semaphore_info_dup.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+-    wine_vk_normalize_semaphore_handle_types_host(&semaphore_info_dup.handleType);
++                semaphore_info_host.pNext = &semaphore_type_info;
++            }
++
++            semaphore_info_host.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++            break;
++        }
++        default:
++            semaphore_info_host.handleType = 0;
++    }
+ 
+-    if (semaphore_info->handleType && !semaphore_info_dup.handleType)
++    if (semaphore_info->handleType && !semaphore_info_host.handleType)
+     {
++        free_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(&semaphore_info_dup);
++
+         properties->exportFromImportedHandleTypes = 0;
+         properties->compatibleHandleTypes = 0;
+         properties->externalSemaphoreFeatures = 0;
+         return;
+     }
+ 
+-    p_vkGetPhysicalDeviceExternalSemaphoreProperties(phys_dev->phys_dev, &semaphore_info_dup, properties);
++    p_vkGetPhysicalDeviceExternalSemaphoreProperties(phys_dev->phys_dev, &semaphore_info_host, properties);
++
++    free_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(&semaphore_info_dup);
+ 
+     if (properties->exportFromImportedHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
+-        properties->exportFromImportedHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++        properties->exportFromImportedHandleTypes = semaphore_info->handleType;
+     wine_vk_normalize_semaphore_handle_types_win(&properties->exportFromImportedHandleTypes);
+ 
+     if (properties->compatibleHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
+-        properties->compatibleHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
++        properties->compatibleHandleTypes = semaphore_info->handleType;
+     wine_vk_normalize_semaphore_handle_types_win(&properties->compatibleHandleTypes);
+ }
+ 
+@@ -2255,6 +2449,23 @@ NTSTATUS wine_vkAllocateMemory(void *args)
+         return res;
+     }
+ 
++    if (device->phys_dev->fake_memory_priority)
++    {
++        VkBaseOutStructure *header;
++
++        for (header = (void *) &allocate_info_dup; header; header = header->pNext)
++        {
++            if (header->pNext && header->pNext->sType == VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT)
++            {
++                VkBaseOutStructure *memory_priority = header->pNext;
++
++                header->pNext = memory_priority->pNext;
++                free(memory_priority);
++                break;
++            }
++        }
++    }
++
+     if (!(object = calloc(1, sizeof(*object))))
+     {
+         free_VkMemoryAllocateInfo_struct_chain(&allocate_info_dup);
+@@ -2290,12 +2501,14 @@ NTSTATUS wine_vkAllocateMemory(void *args)
+         switch (handle_import_info->handleType)
+         {
+             case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT:
++            case VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT:
+                 if (handle_import_info->handle)
+                     NtDuplicateObject( NtCurrentProcess(), handle_import_info->handle, NtCurrentProcess(), &object->handle, 0, 0, DUPLICATE_SAME_ACCESS );
+                 else if (handle_import_info->name)
+                     object->handle = open_shared_resource( 0, handle_import_info->name );
+                 break;
+             case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT:
++            case VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT:
+                 /* FIXME: the spec says that device memory imported from a KMT handle doesn't keep a reference to the underyling payload.
+                    This means that in cases where on windows an application leaks VkDeviceMemory objects, we leak the full payload.  To
+                    fix this, we would need wine_dev_mem objects to store no reference to the payload, that means no host VkDeviceMemory
+@@ -2397,9 +2610,11 @@ NTSTATUS wine_vkGetMemoryWin32HandleKHR(void *args)
+     switch(handle_info->handleType)
+     {
+         case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT:
++        case VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT:
+             return !NtDuplicateObject( NtCurrentProcess(), dev_mem->handle, NtCurrentProcess(), handle, dev_mem->access, dev_mem->inherit ? OBJ_INHERIT : 0, 0) ?
+                 VK_SUCCESS : VK_ERROR_OUT_OF_HOST_MEMORY;
+         case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT:
++        case VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT:
+         {
+             if ((ret = get_shared_resource_kmt_handle(dev_mem->handle)) == INVALID_HANDLE_VALUE)
+                 return VK_ERROR_OUT_OF_HOST_MEMORY;
+@@ -2539,118 +2754,1903 @@ NTSTATUS wine_vkCreateImage(void *args)
+     return res;
+ }
+ 
+-NTSTATUS wine_vkCreateSemaphore(void *args)
++#define IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_WRITE_ACCESS)
++
++static bool set_shared_resource_object(HANDLE shared_resource, unsigned int index, HANDLE handle)
+ {
+-    struct vkCreateSemaphore_params *params = args;
+-    VkDevice device = params->device;
+-    const VkSemaphoreCreateInfo *create_info = params->pCreateInfo;
+-    const VkAllocationCallbacks *allocator = params->pAllocator;
+-    VkSemaphore *semaphore = params->pSemaphore;
++    IO_STATUS_BLOCK iosb;
++    struct shared_resource_set_object
++    {
++        unsigned int index;
++        obj_handle_t handle;
++    } params;
+ 
+-    VkSemaphoreCreateInfo create_info_host = *create_info;
+-    VkExportSemaphoreCreateInfo *export_semaphore_info;
+-    VkResult res;
++    params.index = index;
++    params.handle = wine_server_obj_handle(handle);
+ 
+-    TRACE("%p %p %p %p", device, create_info, allocator, semaphore);
++    return NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT,
++            &params, sizeof(params), NULL, 0) == STATUS_SUCCESS;
++}
+ 
+-    if (allocator)
+-        FIXME("Support for allocation callbacks not implemented yet\n");
++#define IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_READ_ACCESS)
++
++static HANDLE get_shared_resource_object(HANDLE shared_resource, unsigned int index)
++{
++    IO_STATUS_BLOCK iosb;
++    obj_handle_t handle;
++
++    if (NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT,
++            &index, sizeof(index), &handle, sizeof(handle)))
++        return NULL;
++
++    return wine_server_ptr_handle(handle);
++}
++
++static void d3d12_semaphore_lock(struct wine_semaphore *semaphore)
++{
++    assert( semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT );
++    pthread_mutex_lock(&semaphore->d3d12_fence_shm->mutex);
++}
++
++static void d3d12_semaphore_unlock(struct wine_semaphore *semaphore)
++{
++    assert( semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT );
++    pthread_mutex_unlock(&semaphore->d3d12_fence_shm->mutex);
++}
++
++/* returns -1 when there is no queued update that would satisfy the wait */
++static uint64_t d3d12_semaphore_try_get_wait_value_locked(struct wine_semaphore *semaphore, uint64_t virtual_value,
++        struct VkQueue_T *waiting_queue)
++{
++    struct pending_update *update;
++    uint64_t ret = -1;
++    unsigned int i;
++
++    if (semaphore->d3d12_fence_shm->virtual_value >= virtual_value)
++        return 0;
+ 
+-    if ((res = convert_VkSemaphoreCreateInfo_struct_chain(create_info->pNext, &create_info_host)))
++    for (i = 0; i < semaphore->d3d12_fence_shm->pending_updates_count; i++)
+     {
+-        WARN("Failed to convert VkSemaphoreCreateInfo pNext chain, res=%d.\n", res);
+-        return res;
++        update = &semaphore->d3d12_fence_shm->pending_updates[i];
++
++        if (update->virtual_value < virtual_value)
++            continue;
++
++        if (update->signalling_pid == getpid() && waiting_queue && update->signalling_queue == waiting_queue)
++            return 0;
++
++        ret = min(ret, update->physical_value);
+     }
+ 
+-    if ((export_semaphore_info = wine_vk_find_struct(&create_info_host, EXPORT_SEMAPHORE_CREATE_INFO)))
++    return ret;
++}
++
++static struct pending_wait *d3d12_semaphore_push_wait_locked(struct wine_semaphore *semaphore, uint64_t virtual_value)
++{
++    struct pending_wait *wait;
++    unsigned int i;
++
++    for (i = 0; i < ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_waits); i++)
+     {
+-        if (export_semaphore_info->handleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+-            export_semaphore_info->handleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+-        wine_vk_normalize_semaphore_handle_types_host(&export_semaphore_info->handleTypes);
++        wait = &semaphore->d3d12_fence_shm->pending_waits[i];
++        if (!wait->present)
++            break;
+     }
+ 
+-    if (wine_vk_find_struct(&create_info_host,  EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR))
+-        FIXME("VkExportSemaphoreWin32HandleInfoKHR unhandled.\n");
++    if (i == ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_waits))
++    {
++        FIXME("Failed to wait on semaphore %p, maximum waits exceeded.\n", semaphore);
++        return NULL;
++    }
++
++    wait->present = true;
++    wait->satisfied = false;
++    wait->virtual_value = virtual_value;
++    wait->physical_value = 0;
+ 
+-    res = device->funcs.p_vkCreateSemaphore(device->device, &create_info_host, NULL, semaphore);
++    return wait;
++}
+ 
+-    free_VkSemaphoreCreateInfo_struct_chain(&create_info_host);
++static uint64_t d3d12_semaphore_pop_wait_locked(struct wine_semaphore *semaphore, struct pending_wait *wait)
++{
++    wait->satisfied = false;
++    wait->present = false;
+ 
+-    return res;
++    return wait->physical_value;
+ }
+ 
+-NTSTATUS wine_vkGetSemaphoreWin32HandleKHR(void *args)
++static void d3d12_semaphore_satisfy_waits_locked(struct wine_semaphore *semaphore, uint64_t virtual_value,
++        uint64_t physical_value)
+ {
+-    struct vkGetSemaphoreWin32HandleKHR_params *params = args;
+-    VkDevice device = params->device;
+-    const VkSemaphoreGetWin32HandleInfoKHR *handle_info = params->pGetWin32HandleInfo;
+-    HANDLE *handle = params->pHandle;
++    struct pending_wait *wait;
++    unsigned int i;
+ 
+-    VkSemaphoreGetFdInfoKHR_host fd_info;
+-    VkResult res;
+-    int fd;
++    for (i = 0; i < ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_waits); i++)
++    {
++        wait = &semaphore->d3d12_fence_shm->pending_waits[i];
+ 
+-    fd_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
+-    fd_info.pNext = handle_info->pNext;
+-    fd_info.semaphore = handle_info->semaphore;
+-    fd_info.handleType = handle_info->handleType;
+-    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+-        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+-    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
++        if (wait->present && !wait->satisfied && wait->virtual_value <= virtual_value)
++        {
++            wait->satisfied = true;
++            wait->physical_value = physical_value;
++            pthread_cond_signal(&wait->cond);
++        }
++    }
++}
+ 
+-    res = device->funcs.p_vkGetSemaphoreFdKHR(device->device, &fd_info, &fd);
++static uint64_t d3d12_semaphore_add_pending_signal_locked(struct wine_semaphore *semaphore, uint64_t virtual_value,
++        struct VkQueue_T *signalling_queue)
++{
++    struct pending_update *update;
+ 
+-    if (res != VK_SUCCESS)
+-        return res;
++    if (semaphore->d3d12_fence_shm->pending_updates_count == ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_updates))
++    {
++        FIXME("Failed to queue signal on d3d12 semaphore, maximum concurrent signals exceeded.\n");
++        return 0;
++    }
++
++    update = &semaphore->d3d12_fence_shm->pending_updates[
++        semaphore->d3d12_fence_shm->pending_updates_count++];
++
++    update->virtual_value = virtual_value;
++    update->physical_value = ++semaphore->d3d12_fence_shm->counter;
++    update->signalling_pid = getpid();
++    update->signalling_queue = signalling_queue;
++
++    return update->physical_value;
++}
++
++static struct pending_update d3d12_semaphore_peek_added_signal_locked(struct wine_semaphore *semaphore)
++{
++    return semaphore->d3d12_fence_shm->pending_updates[semaphore->d3d12_fence_shm->pending_updates_count - 1];
++}
++
++static bool d3d12_semaphore_pop_pending_signal_locked(struct wine_semaphore *semaphore, uint64_t phys_val, struct pending_update *ret)
++{
++    struct pending_update *update;
++    unsigned int i;
+ 
+-    if (wine_server_fd_to_handle(fd, GENERIC_ALL, 0, handle) != STATUS_SUCCESS)
++    for (i = 0; i < semaphore->d3d12_fence_shm->pending_updates_count; i++)
+     {
+-        close(fd);
+-        return VK_ERROR_OUT_OF_HOST_MEMORY;
++        if (semaphore->d3d12_fence_shm->pending_updates[i].physical_value == phys_val)
++        {
++            update = &semaphore->d3d12_fence_shm->pending_updates[i];
++            if (ret)
++                *ret = *update;
++            *update = semaphore->d3d12_fence_shm->pending_updates[--semaphore->d3d12_fence_shm->pending_updates_count];
++            return true;
++        }
+     }
+ 
+-    return VK_SUCCESS;
++    return false;
+ }
+ 
+-NTSTATUS wine_vkImportSemaphoreWin32HandleKHR(void *args)
++static void d3d12_semaphore_update_phys_val_locked(struct wine_semaphore *sem, uint64_t phys_val)
+ {
+-    struct vkImportSemaphoreWin32HandleKHR_params *params = args;
++    struct pending_update pending;
++
++    /* Based off linked VKD3D-Proton implementation, but we don't signal CPU waits here.
++        * https://github.com/HansKristian-Work/vkd3d-proton/blob/829ac72e3d381006a843c183e613e8ee77e0b292/libs/vkd3d/command.c#L758 */
++    while (sem->d3d12_fence_shm->physical_value < phys_val)
++    {
++        sem->d3d12_fence_shm->physical_value++;
++
++        if (d3d12_semaphore_pop_pending_signal_locked(sem, sem->d3d12_fence_shm->physical_value, &pending))
++            sem->d3d12_fence_shm->virtual_value = pending.virtual_value;
++    }
++}
++
++NTSTATUS wine_vkCreateSemaphore(void *args)
++{
++    struct vkCreateSemaphore_params *params = args;
+     VkDevice device = params->device;
+-    const VkImportSemaphoreWin32HandleInfoKHR *handle_info = params->pImportSemaphoreWin32HandleInfo;
++    const VkSemaphoreCreateInfo *create_info = params->pCreateInfo;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++    VkSemaphore *semaphore = params->pSemaphore;
+ 
+-    VkImportSemaphoreFdInfoKHR_host fd_info;
++    VkExportSemaphoreWin32HandleInfoKHR *export_handle_info = wine_vk_find_struct(create_info, EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR);
++    VkExportSemaphoreCreateInfo *export_semaphore_info, timeline_export_info;
++    VkSemaphoreCreateInfo create_info_dup = *create_info, create_info_host;
++    VkSemaphoreTypeCreateInfo *found_type_info, type_info;
++    VkSemaphoreGetFdInfoKHR_host fd_info;
++    pthread_mutexattr_t mutex_attr;
++    struct wine_semaphore *object;
++    pthread_condattr_t cond_attr;
++    OBJECT_ATTRIBUTES attr;
++    HANDLE section_handle;
++    LARGE_INTEGER li;
++    unsigned int i;
+     VkResult res;
++    SIZE_T size;
+     int fd;
+ 
+-    fd_info.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+-    fd_info.pNext = handle_info->pNext;
+-    fd_info.semaphore = handle_info->semaphore;
+-    fd_info.flags = handle_info->flags;
+-    fd_info.handleType = handle_info->handleType;
++    TRACE("(%p, %p, %p, %p)\n", device, create_info, allocator, semaphore);
+ 
+-    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+-    {
+-        if (handle_info->name)
+-        {
+-            FIXME("Importing win32 semaphore by name not supported.\n");
+-            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+-        }
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
+ 
+-        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+-        if (wine_server_handle_to_fd(handle_info->handle, GENERIC_ALL, &fd, NULL) != STATUS_SUCCESS)
+-            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++    if ((res = convert_VkSemaphoreCreateInfo_struct_chain(create_info->pNext, &create_info_dup)))
++    {
++        WARN("Failed to convert VkSemaphoreCreateInfo pNext chain, res=%d.\n", res);
++        return res;
+     }
+-    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
+ 
+-    if (!fd_info.handleType)
++    if (!(object = calloc(1, sizeof(*object))))
+     {
+-        FIXME("Importing win32 semaphore with handle type %#x not supported.\n", handle_info->handleType);
+-        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++        free_VkSemaphoreCreateInfo_struct_chain(&create_info_dup);
++        return VK_ERROR_OUT_OF_HOST_MEMORY;
+     }
++    object->handle = INVALID_HANDLE_VALUE;
+ 
+-    /* importing FDs transfers ownership, importing NT handles does not  */
+-    if ((res = device->funcs.p_vkImportSemaphoreFdKHR(device->device, &fd_info)) != VK_SUCCESS)
+-        close(fd);
++    create_info_host = create_info_dup;
+ 
+-    return res;
++    if ((export_semaphore_info = wine_vk_find_struct(&create_info_host, EXPORT_SEMAPHORE_CREATE_INFO)))
++    {
++        object->export_types = export_semaphore_info->handleTypes;
++        if (export_semaphore_info->handleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
++            export_semaphore_info->handleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++        wine_vk_normalize_semaphore_handle_types_host(&export_semaphore_info->handleTypes);
++    }
++
++    if ((res = device->funcs.p_vkCreateSemaphore(device->device, &create_info_host, NULL, &object->semaphore)) != VK_SUCCESS)
++        goto done;
++
++    if (export_semaphore_info && export_semaphore_info->handleTypes == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
++    {
++        fd_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
++        fd_info.pNext = NULL;
++        fd_info.semaphore = object->semaphore;
++        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++
++        if ((res = device->funcs.p_vkGetSemaphoreFdKHR(device->device, &fd_info, &fd)) == VK_SUCCESS)
++        {
++            object->handle = create_gpu_resource(fd, export_handle_info ? export_handle_info->name : NULL);
++            close(fd);
++        }
++
++        if (object->handle == INVALID_HANDLE_VALUE)
++        {
++            res = VK_ERROR_OUT_OF_HOST_MEMORY;
++            goto done;
++        }
++    }
++    else if (object->export_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++    {
++        /* compatibleHandleTypes doesn't include any other types */
++        assert(object->export_types == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT);
++        object->handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
++
++        timeline_export_info.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
++        timeline_export_info.pNext = NULL;
++        timeline_export_info.handleTypes = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++
++        type_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
++        type_info.pNext = &timeline_export_info;
++        type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
++        type_info.initialValue = 0;
++
++        create_info_host.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
++        create_info_host.pNext = &type_info;
++        create_info_host.flags = 0;
++
++        if ((res = device->funcs.p_vkCreateSemaphore(device->device, &create_info_host, NULL, &object->fence_timeline_semaphore)) != VK_SUCCESS)
++            goto done;
++
++        fd_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
++        fd_info.pNext = NULL;
++        fd_info.semaphore = object->fence_timeline_semaphore;
++        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++
++        if ((res = device->funcs.p_vkGetSemaphoreFdKHR(device->device, &fd_info, &fd)) == VK_SUCCESS)
++        {
++            object->handle = create_gpu_resource(fd, export_handle_info ? export_handle_info->name : NULL);
++            close(fd);
++        }
++
++        if (object->handle == INVALID_HANDLE_VALUE)
++        {
++            res = VK_ERROR_OUT_OF_HOST_MEMORY;
++            goto done;
++        }
++
++        /* Shared Fence Memory */
++        InitializeObjectAttributes(&attr, NULL, 0, NULL, NULL);
++        size = li.QuadPart = sizeof(*object->d3d12_fence_shm);
++        if (NtCreateSection(&section_handle, STANDARD_RIGHTS_REQUIRED | SECTION_QUERY | SECTION_MAP_READ | SECTION_MAP_WRITE, &attr, &li, PAGE_READWRITE, SEC_COMMIT, NULL))
++        {
++            res = VK_ERROR_OUT_OF_HOST_MEMORY;
++            goto done;
++        }
++
++        if (!set_shared_resource_object(object->handle, 0, section_handle))
++        {
++            NtClose(section_handle);
++            res = VK_ERROR_OUT_OF_HOST_MEMORY;
++            goto done;
++        }
++
++        if (NtMapViewOfSection(section_handle, GetCurrentProcess(), (void**) &object->d3d12_fence_shm, 0, 0, NULL, &size, ViewShare, 0, PAGE_READWRITE))
++        {
++            NtClose(section_handle);
++            res = VK_ERROR_OUT_OF_HOST_MEMORY;
++            goto done;
++        }
++
++        NtClose(section_handle);
++
++        if ((found_type_info = wine_vk_find_struct(create_info, SEMAPHORE_TYPE_CREATE_INFO)))
++            object->d3d12_fence_shm->virtual_value = found_type_info->initialValue;
++
++        pthread_mutexattr_init(&mutex_attr);
++        pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
++        if (pthread_mutex_init(&object->d3d12_fence_shm->mutex, &mutex_attr))
++        {
++            pthread_mutexattr_destroy(&mutex_attr);
++            res = VK_ERROR_OUT_OF_HOST_MEMORY;
++            goto done;
++        }
++        pthread_mutexattr_destroy(&mutex_attr);
++
++        for (i = 0; i < ARRAY_SIZE(object->d3d12_fence_shm->pending_waits); i++)
++        {
++            pthread_condattr_init(&cond_attr);
++            pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
++            pthread_cond_init(&object->d3d12_fence_shm->pending_waits[i].cond, &cond_attr);
++            pthread_condattr_destroy(&cond_attr);
++        }
++
++        WINE_VK_ADD_NON_DISPATCHABLE_MAPPING(device->phys_dev->instance, object, object->fence_timeline_semaphore);
++    }
++
++    WINE_VK_ADD_NON_DISPATCHABLE_MAPPING(device->phys_dev->instance, object, object->semaphore);
++    *semaphore = wine_semaphore_to_handle(object);
++
++    done:
++
++    if (res != VK_SUCCESS)
++    {
++        pthread_mutex_destroy(&object->d3d12_fence_shm->mutex);
++        if (object->d3d12_fence_shm)
++            NtUnmapViewOfSection(GetCurrentProcess(), object->d3d12_fence_shm);
++        if (object->handle != INVALID_HANDLE_VALUE)
++            NtClose(object->handle);
++        if (object->semaphore != VK_NULL_HANDLE)
++            device->funcs.p_vkDestroySemaphore(device->device, object->semaphore, NULL);
++        if (object->fence_timeline_semaphore != VK_NULL_HANDLE)
++            device->funcs.p_vkDestroySemaphore(device->device, object->fence_timeline_semaphore, NULL);
++        free(object);
++    }
++
++    free_VkSemaphoreCreateInfo_struct_chain(&create_info_dup);
++
++    return res;
++}
++
++NTSTATUS wine_vkGetSemaphoreWin32HandleKHR(void *args)
++{
++    struct vkGetSemaphoreWin32HandleKHR_params *params = args;
++    const VkSemaphoreGetWin32HandleInfoKHR *handle_info = params->pGetWin32HandleInfo;
++    HANDLE *handle = params->pHandle;
++
++    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle_info->semaphore);
++
++    if (!(semaphore->export_types & handle_info->handleType))
++        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++
++    if (NtDuplicateObject( NtCurrentProcess(), semaphore->handle, NtCurrentProcess(), handle, 0, 0, DUPLICATE_SAME_ACCESS ))
++        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++
++    return VK_SUCCESS;
++}
++
++NTSTATUS wine_vkDestroySemaphore(void *args)
++{
++    struct vkDestroySemaphore_params *params = args;
++    VkDevice device = params->device;
++    VkSemaphore handle = params->semaphore;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++
++    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle);
++
++    TRACE("%p 0x%s, %p\n", device, wine_dbgstr_longlong(handle), allocator);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if (!handle)
++        return VK_SUCCESS;
++
++    if (semaphore->handle != INVALID_HANDLE_VALUE)
++        NtClose(semaphore->handle);
++
++    if (semaphore->d3d12_fence_shm)
++        NtUnmapViewOfSection(GetCurrentProcess(), semaphore->d3d12_fence_shm);
++
++    WINE_VK_REMOVE_HANDLE_MAPPING(device->phys_dev->instance, semaphore);
++    device->funcs.p_vkDestroySemaphore(device->device, semaphore->semaphore, NULL);
++
++    if (semaphore->fence_timeline_semaphore)
++        device->funcs.p_vkDestroySemaphore(device->device, semaphore->fence_timeline_semaphore, NULL);
++
++    free(semaphore);
++    return VK_SUCCESS;
++}
++
++NTSTATUS wine_vkImportSemaphoreWin32HandleKHR(void *args)
++{
++    struct vkImportSemaphoreWin32HandleKHR_params *params = args;
++    VkDevice device = params->device;
++    const VkImportSemaphoreWin32HandleInfoKHR *handle_info = params->pImportSemaphoreWin32HandleInfo;
++
++    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle_info->semaphore);
++    VkImportSemaphoreFdInfoKHR_host fd_info;
++    struct wine_semaphore output_semaphore;
++    VkSemaphoreTypeCreateInfo type_info;
++    VkSemaphoreCreateInfo create_info;
++    HANDLE d3d12_fence_shm;
++    NTSTATUS stat;
++    VkResult res;
++    SIZE_T size;
++
++    TRACE("(%p, %p). semaphore = %p handle = %p\n", device, handle_info, handle_info->semaphore, handle_info->handle);
++
++    if (handle_info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT && !semaphore->fence_timeline_semaphore)
++    {
++        type_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
++        type_info.pNext = NULL;
++        type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
++        type_info.initialValue = 0;
++
++        create_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
++        create_info.pNext = &type_info;
++        create_info.flags = 0;
++
++        if ((res = device->funcs.p_vkCreateSemaphore(device->device, &create_info, NULL, &semaphore->fence_timeline_semaphore)) != VK_SUCCESS)
++        {
++            ERR("Failed to create timeline semaphore backing D3D12 semaphore. vr %d.\n", res);
++            return res;
++        };
++
++        WINE_VK_ADD_NON_DISPATCHABLE_MAPPING(device->phys_dev->instance, semaphore, semaphore->fence_timeline_semaphore);
++    }
++
++    output_semaphore = *semaphore;
++    output_semaphore.handle = NULL;
++    output_semaphore.handle_type = handle_info->handleType;
++    output_semaphore.d3d12_fence_shm = NULL;
++
++    fd_info.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
++    fd_info.pNext = handle_info->pNext;
++    fd_info.semaphore = wine_semaphore_host_handle(&output_semaphore);
++    fd_info.flags = handle_info->flags;
++    fd_info.handleType = handle_info->handleType;
++
++    if (handle_info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT ||
++        handle_info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++    {
++        if (handle_info->name)
++        {
++            FIXME("Importing win32 semaphore by name not supported.\n");
++            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++        }
++
++        if (NtDuplicateObject( NtCurrentProcess(), handle_info->handle, NtCurrentProcess(), &output_semaphore.handle, 0, 0, DUPLICATE_SAME_ACCESS ))
++            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++
++        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
++        if ((fd_info.fd = get_shared_resource_fd(output_semaphore.handle)) == -1)
++        {
++            WARN("Invalid handle %p.\n", handle_info->handle);
++            NtClose(output_semaphore.handle);
++            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++        }
++
++        if (handle_info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++        {
++            if (handle_info->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT)
++            {
++                FIXME("Temporarily importing d3d12 fences unsupported.\n");
++                close(fd_info.fd);
++                NtClose(output_semaphore.handle);
++                return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++            }
++
++            if (!(d3d12_fence_shm = get_shared_resource_object(output_semaphore.handle, 0)))
++            {
++                ERR("Failed to get D3D12 semaphore memory.\n");
++                close(fd_info.fd);
++                NtClose(output_semaphore.handle);
++                return VK_ERROR_OUT_OF_HOST_MEMORY;
++            }
++
++            size = sizeof(*output_semaphore.d3d12_fence_shm);
++            if ((stat = NtMapViewOfSection(d3d12_fence_shm, GetCurrentProcess(), (void**) &output_semaphore.d3d12_fence_shm, 0, 0, NULL, &size, ViewShare, 0, PAGE_READWRITE)))
++            {
++                ERR("Failed to map D3D12 semaphore memory. stat %#x.\n", stat);
++                close(fd_info.fd);
++                NtClose(d3d12_fence_shm);
++                NtClose(output_semaphore.handle);
++                return VK_ERROR_OUT_OF_HOST_MEMORY;
++            }
++
++            NtClose(d3d12_fence_shm);
++        }
++    }
++
++    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
++
++    if (!fd_info.handleType)
++    {
++        FIXME("Importing win32 semaphore with handle type %#x not supported.\n", handle_info->handleType);
++        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
++    }
++
++    if ((res = device->funcs.p_vkImportSemaphoreFdKHR(device->device, &fd_info)) == VK_SUCCESS)
++    {
++        if (semaphore->handle)
++            NtClose(semaphore->handle);
++        if (semaphore->d3d12_fence_shm)
++            NtUnmapViewOfSection(GetCurrentProcess(), semaphore->d3d12_fence_shm);
++
++        *semaphore = output_semaphore;
++    }
++    else
++    {
++        if (output_semaphore.handle)
++            NtClose(output_semaphore.handle);
++        if (output_semaphore.d3d12_fence_shm)
++            NtUnmapViewOfSection(GetCurrentProcess(), output_semaphore.d3d12_fence_shm);
++
++        /* importing FDs transfers ownership, importing NT handles does not  */
++        close(fd_info.fd);
++    }
++
++    return res;
++}
++
++
++static NTSTATUS vk_get_semaphore_counter_value(VkDevice device, VkSemaphore semaphore, uint64_t *value, bool khr);
++static NTSTATUS wine_vk_get_semaphore_counter_value(VkDevice device, VkSemaphore handle, uint64_t *value, bool khr)
++{
++    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle);
++
++    if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++    {
++        d3d12_semaphore_lock(semaphore);
++        *value = semaphore->d3d12_fence_shm->virtual_value;
++        d3d12_semaphore_unlock(semaphore);
++        return VK_SUCCESS;
++    }
++
++    return vk_get_semaphore_counter_value(device, handle, value, khr);
++}
++
++static NTSTATUS vk_get_semaphore_counter_value(VkDevice device, VkSemaphore semaphore, uint64_t *value, bool khr)
++{
++    if (khr)
++        return thunk_vkGetSemaphoreCounterValueKHR(device, semaphore, value);
++    else
++        return thunk_vkGetSemaphoreCounterValue(device, semaphore, value);
++}
++
++NTSTATUS wine_vkGetSemaphoreCounterValue(void *args)
++{
++    struct vkGetSemaphoreCounterValue_params *params = args;
++    VkDevice device = params->device;
++    VkSemaphore semaphore = params->semaphore;
++    uint64_t *value = params->pValue;
++
++    return wine_vk_get_semaphore_counter_value(device, semaphore, value, false);
++}
++
++NTSTATUS wine_vkGetSemaphoreCounterValueKHR(void *args)
++{
++    struct vkGetSemaphoreCounterValue_params *params = args;
++    VkDevice device = params->device;
++    VkSemaphore semaphore = params->semaphore;
++    uint64_t *value = params->pValue;
++
++    return wine_vk_get_semaphore_counter_value(device, semaphore, value, true);
++}
++
++static NTSTATUS vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr);
++static NTSTATUS wine_vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr)
++{
++    uint64_t phys_val;
++    VkResult vr;
++
++    struct wine_semaphore *semaphore = wine_semaphore_from_handle(signal_info->semaphore);
++
++    TRACE("(%p, %p)\n", device, signal_info);
++
++    if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++    {
++        d3d12_semaphore_lock(semaphore);
++
++        /* vkWaitSemaphore w/ WAIT_ANY wakes on every physical value increment to check if the wait is satisfied, so
++           if there are no scheduled signals, step the physical value */
++        if ((vr = vk_get_semaphore_counter_value(device, signal_info->semaphore, &phys_val, khr)) != VK_SUCCESS)
++        {
++            d3d12_semaphore_unlock(semaphore);
++            return vr;
++        }
++
++        d3d12_semaphore_update_phys_val_locked(semaphore, phys_val);
++
++        if (!semaphore->d3d12_fence_shm->pending_updates_count)
++        {
++            VkSemaphoreSignalInfo step_signal_info;
++
++            assert(semaphore->d3d12_fence_shm->counter == phys_val);
++            phys_val++;
++
++            semaphore->d3d12_fence_shm->counter = semaphore->d3d12_fence_shm->physical_value = phys_val;
++
++            step_signal_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
++            step_signal_info.pNext = NULL;
++            step_signal_info.semaphore = signal_info->semaphore;
++            step_signal_info.value = phys_val;
++
++            vr = vk_signal_semaphore(device, &step_signal_info, khr);
++            if (vr != VK_SUCCESS)
++            {
++                d3d12_semaphore_unlock(semaphore);
++                return vr;
++            }
++        }
++
++        /* If a queue is already waiting on the pending physical value of a previous submit, this won't wake it up. */
++        d3d12_semaphore_satisfy_waits_locked(semaphore, signal_info->value, 0);
++        semaphore->d3d12_fence_shm->virtual_value = signal_info->value;
++
++        d3d12_semaphore_unlock(semaphore);
++        return VK_SUCCESS;
++    }
++
++    return vk_signal_semaphore(device, signal_info, khr);
++}
++
++static NTSTATUS vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr)
++{
++    if (khr)
++        return thunk_vkSignalSemaphoreKHR(device, signal_info);
++    else
++        return thunk_vkSignalSemaphore(device, signal_info);
++}
++
++NTSTATUS wine_vkSignalSemaphore(void *args)
++{
++    struct vkSignalSemaphore_params *params = args;
++    VkDevice device = params->device;
++    const VkSemaphoreSignalInfo *signal_info = params->pSignalInfo;
++
++    return wine_vk_signal_semaphore(device, signal_info, false);
++}
++
++NTSTATUS wine_vkSignalSemaphoreKHR(void *args)
++{
++    struct vkSignalSemaphore_params *params = args;
++    VkDevice device = params->device;
++    const VkSemaphoreSignalInfo *signal_info = params->pSignalInfo;
++
++    return wine_vk_signal_semaphore(device, signal_info, true);
++}
++
++static NTSTATUS vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr);
++static NTSTATUS wine_vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr)
++{
++    VkSemaphoreWaitInfo wait_info_dup = *wait_info;
++    struct timespec abs_timeout, start_time;
++    struct pending_wait **pending_waits;
++    struct pending_wait *pending_wait;
++    unsigned int i, remaining_waits;
++    VkSemaphore* semaphores_dup;
++    uint64_t *values_dup;
++    uint64_t phys_val;
++    int wait_stat;
++    VkResult res;
++
++    TRACE("(%p, %p, 0x%s)\n", device, wait_info, wine_dbgstr_longlong(timeout));
++
++    if (timeout)
++    {
++        clock_gettime(CLOCK_REALTIME, &start_time);
++
++        abs_timeout.tv_sec = start_time.tv_sec + (timeout / NANOSECONDS_IN_A_SECOND);
++        abs_timeout.tv_nsec = start_time.tv_nsec + (timeout % NANOSECONDS_IN_A_SECOND);
++        if (abs_timeout.tv_nsec >= NANOSECONDS_IN_A_SECOND)
++        {
++            abs_timeout.tv_sec++;
++            abs_timeout.tv_nsec-=NANOSECONDS_IN_A_SECOND;
++        }
++    }
++
++    wait_info_dup.pSemaphores = semaphores_dup = calloc(wait_info->semaphoreCount, sizeof(VkSemaphore));
++    wait_info_dup.pValues = values_dup = calloc(wait_info->semaphoreCount, sizeof(uint64_t));
++    pending_waits = calloc(wait_info->semaphoreCount, sizeof(struct pending_wait *));
++
++    for (i = 0; i < wait_info->semaphoreCount; i++)
++    {
++        struct wine_semaphore *semaphore = wine_semaphore_from_handle(wait_info->pSemaphores[i]);
++
++        semaphores_dup[i] = wait_info->pSemaphores[i];
++        values_dup[i] = wait_info->pValues[i];
++
++        if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++        {
++            d3d12_semaphore_lock(semaphore);
++            if ((values_dup[i] = d3d12_semaphore_try_get_wait_value_locked(semaphore, wait_info->pValues[i], NULL)) == -1)
++            {
++                if (!timeout)
++                {
++                    d3d12_semaphore_unlock(semaphore);
++                    continue;
++                }
++
++                pending_wait = d3d12_semaphore_push_wait_locked(semaphore, wait_info->pValues[i]);
++
++                if (wait_info->flags & VK_SEMAPHORE_WAIT_ANY_BIT)
++                {
++                    /* Keep scheduling a wait of current physical_value+1 until the desired virtual value is signaled */
++                    values_dup[i] = semaphore->d3d12_fence_shm->physical_value + 1;
++                    pending_waits[i] = pending_wait;
++                }
++                else
++                {
++                    while (!pending_wait->satisfied && wait_stat != ETIMEDOUT)
++                        wait_stat = pthread_cond_timedwait(&pending_wait->cond, &semaphore->d3d12_fence_shm->mutex, &abs_timeout);
++
++                    values_dup[i] = d3d12_semaphore_pop_wait_locked(semaphore, pending_wait);
++
++                    if (wait_stat == ETIMEDOUT)
++                    {
++                        d3d12_semaphore_unlock(semaphore);
++                        free(semaphores_dup);
++                        free(values_dup);
++                        free(pending_waits);
++                        return VK_TIMEOUT;
++                    }
++                }
++            }
++            d3d12_semaphore_unlock(semaphore);
++        }
++    }
++
++    do
++    {
++        if (timeout)
++        {
++            clock_gettime(CLOCK_REALTIME, &start_time);
++
++            if (start_time.tv_sec > abs_timeout.tv_sec ||
++                    (start_time.tv_sec == abs_timeout.tv_sec && start_time.tv_nsec >= abs_timeout.tv_nsec))
++                timeout = 0;
++            else
++                timeout = ((abs_timeout.tv_sec - start_time.tv_sec) * NANOSECONDS_IN_A_SECOND) +
++                    (abs_timeout.tv_nsec - start_time.tv_nsec);
++        }
++
++        remaining_waits = 0;
++        res = vk_wait_semaphores(device, &wait_info_dup, timeout, khr);
++
++        for (i = 0; i < wait_info->semaphoreCount; i++)
++        {
++            struct wine_semaphore * semaphore = wine_semaphore_from_handle(wait_info->pSemaphores[i]);
++
++            if (pending_waits[i])
++            {
++                remaining_waits++;
++
++                d3d12_semaphore_lock(semaphore);
++                if (res != VK_SUCCESS || pending_waits[i]->satisfied)
++                {
++                    values_dup[i] = pending_waits[i]->physical_value;
++                    d3d12_semaphore_pop_wait_locked(semaphore, pending_waits[i]);
++                    pending_waits[i] = NULL;
++                }
++                d3d12_semaphore_unlock(semaphore);
++            }
++        }
++    }
++    while (res == VK_SUCCESS && remaining_waits);
++
++    /* Make sure the physical value we waited on is processed before returning */
++    for (i = 0; i < wait_info_dup.semaphoreCount; i++)
++    {
++        struct wine_semaphore *semaphore = wine_semaphore_from_handle(wait_info_dup.pSemaphores[i]);
++
++        if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++        {
++            d3d12_semaphore_lock(semaphore);
++            if (wait_info->flags & VK_SEMAPHORE_WAIT_ANY_BIT)
++            {
++                if (!vk_get_semaphore_counter_value(device, semaphores_dup[i], &phys_val, khr))
++                    d3d12_semaphore_update_phys_val_locked(semaphore, phys_val);
++            }
++            else
++                d3d12_semaphore_update_phys_val_locked(semaphore, values_dup[i]);
++            d3d12_semaphore_unlock(semaphore);
++        }
++    }
++
++    free(semaphores_dup);
++    free(values_dup);
++    free(pending_waits);
++    return res;
++}
++
++static NTSTATUS vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr)
++{
++    if (khr)
++        return thunk_vkWaitSemaphoresKHR(device, wait_info, timeout);
++    else
++        return thunk_vkWaitSemaphores(device, wait_info, timeout);
++}
++
++NTSTATUS wine_vkWaitSemaphores(void *args)
++{
++    struct vkWaitSemaphores_params *params = args;
++    VkDevice device = params->device;
++    const VkSemaphoreWaitInfo *wait_info = params->pWaitInfo;
++    uint64_t timeout = params->timeout;
++
++    return wine_vk_wait_semaphores(device, wait_info, timeout, false);
++}
++
++NTSTATUS wine_vkWaitSemaphoresKHR(void *args)
++{
++    struct vkWaitSemaphores_params *params = args;
++    VkDevice device = params->device;
++    const VkSemaphoreWaitInfo *wait_info = params->pWaitInfo;
++    uint64_t timeout = params->timeout;
++
++    return wine_vk_wait_semaphores(device, wait_info, timeout, true);
++}
++
++struct signal_op
++{
++    enum
++    {
++        SIGNAL_TYPE_SEMAPHORE,
++        SIGNAL_TYPE_FENCE,
++    } signal_type;
++
++    union
++    {
++        struct
++        {
++            struct wine_semaphore *obj;
++            uint64_t phys_val;
++
++            bool khr;
++        } semaphore;
++
++        struct wine_fence *fence;
++    };
++
++    struct list entry;
++};
++
++static void *queue_signaller_worker(void *arg)
++{
++    struct VkQueue_T *queue = (struct VkQueue_T *)arg;
++    VkSemaphoreWaitInfo wait_info;
++    struct signal_op *signal_op;
++    VkSemaphore sem_handle;
++    bool device_lost;
++    VkFence fence;
++    uint64_t buf;
++    VkResult vr;
++
++    for (;;)
++    {
++        pthread_mutex_lock(&queue->signaller_mutex);
++
++        while (!queue->stop && list_empty(&queue->signal_ops))
++            pthread_cond_wait(&queue->signaller_cond, &queue->signaller_mutex);
++
++        if (queue->stop)
++        {
++            assert( list_empty(&queue->signal_ops) );
++            pthread_mutex_unlock(&queue->signaller_mutex);
++            return NULL;
++        }
++
++        signal_op = LIST_ENTRY(list_head(&queue->signal_ops), struct signal_op, entry);
++        list_remove(&signal_op->entry);
++
++        device_lost = queue->device_lost;
++
++        pthread_mutex_unlock(&queue->signaller_mutex);
++
++        if (signal_op->signal_type == SIGNAL_TYPE_SEMAPHORE)
++        {
++            wait_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
++            wait_info.pNext = NULL;
++            wait_info.flags = 0;
++            wait_info.semaphoreCount = 1;
++            sem_handle = wine_semaphore_to_handle(signal_op->semaphore.obj);
++            wait_info.pSemaphores = &sem_handle;
++            wait_info.pValues = &signal_op->semaphore.phys_val;
++            if (!device_lost && (vr = vk_wait_semaphores(queue->device, &wait_info, -1, signal_op->semaphore.khr)) < 0)
++            {
++                /* likely GPU hang */
++                fprintf(stderr, "winevulkan/queue_signaller_worker: Semaphore wait failed, vr %d.\n", vr);
++                continue;
++            }
++
++            d3d12_semaphore_lock(signal_op->semaphore.obj);
++            d3d12_semaphore_update_phys_val_locked(signal_op->semaphore.obj, signal_op->semaphore.phys_val);
++            d3d12_semaphore_unlock(signal_op->semaphore.obj);
++        }
++        else
++        {
++            fence = wine_fence_to_handle(signal_op->fence);
++
++            if (!device_lost && (vr = thunk_vkWaitForFences(queue->device, 1, &fence, VK_TRUE, -1)) < 0)
++            {
++                /* likely GPU hang */
++                fprintf(stderr, "winevulkan/queue_signaller_worker: Fence wait failed, vr %d.\n", vr);
++                continue;
++            }
++
++            buf = 1;
++            assert( write(signal_op->fence->eventfd, &buf, sizeof(buf)) != -1 );
++        }
++
++        free(signal_op);
++    }
++
++    return NULL;
++}
++
++static VkSubmitInfo *copy_VkSubmitInfo(const VkSubmitInfo *in, uint32_t submit_count)
++{
++    VkSubmitInfo *out = malloc(sizeof(*out) * submit_count);
++    unsigned int i;
++
++    for (i = 0; i < submit_count; i++)
++    {
++        out[i].sType = in[i].sType;
++        out[i].waitSemaphoreCount = in[i].waitSemaphoreCount;
++        out[i].pWaitSemaphores = memdup(in[i].pWaitSemaphores, in[i].waitSemaphoreCount, sizeof(out[i].pWaitSemaphores[0]));
++        out[i].pWaitDstStageMask = memdup(in[i].pWaitDstStageMask, in[i].waitSemaphoreCount, sizeof(out[i].pWaitDstStageMask[0]));
++        out[i].commandBufferCount = in[i].commandBufferCount;
++        out[i].pCommandBuffers = memdup(in[i].pCommandBuffers, in[i].commandBufferCount, sizeof(out[i].pCommandBuffers[0]));
++        out[i].signalSemaphoreCount = in[i].signalSemaphoreCount;
++        out[i].pSignalSemaphores = memdup(in[i].pSignalSemaphores, in[i].signalSemaphoreCount, sizeof(out[i].pSignalSemaphores[0]));
++
++        convert_VkSubmitInfo_struct_chain(in[i].pNext, &out[i]);
++    }
++
++    return out;
++}
++
++static void free_copied_VkSubmitInfo(VkSubmitInfo *info, uint32_t submit_count)
++{
++    unsigned int i;
++
++    for (i = 0; i < submit_count; i++)
++    {
++        free_VkSubmitInfo_struct_chain(&info[i]);
++
++        free((VkSemaphore *)         info[i].pWaitSemaphores);
++        free((VkPipelineStageFlags*) info[i].pWaitDstStageMask);
++        free((VkCommandBuffer*)      info[i].pCommandBuffers);
++        free((VkSemaphore*)          info[i].pSignalSemaphores);
++    }
++
++    free(info);
++}
++
++static VkSubmitInfo2 *copy_VkSubmitInfo2(const VkSubmitInfo2 *in, uint32_t submit_count)
++{
++    VkSubmitInfo2 *out = malloc(sizeof(*out) * submit_count);
++    VkCommandBufferSubmitInfo *cmdbuf_submit_info;
++    VkSemaphoreSubmitInfo *sem_submit_info;
++    unsigned int i, k;
++
++    for (i = 0; i < submit_count; i++)
++    {
++        out[i].sType = in[i].sType;
++        out[i].flags = in[i].flags;
++
++        out[i].waitSemaphoreInfoCount = in[i].waitSemaphoreInfoCount;
++        out[i].pWaitSemaphoreInfos = sem_submit_info = memdup(in[i].pWaitSemaphoreInfos,
++                                            in[i].waitSemaphoreInfoCount,
++                                            sizeof(out[i].pWaitSemaphoreInfos[0]));
++        for (k = 0; k < out[i].waitSemaphoreInfoCount; k++)
++        {
++            if (sem_submit_info[k].pNext)
++            {
++                FIXME("pNext chain conversion for VkSemaphoreSubmitInfo not supported.\n");
++                sem_submit_info[k].pNext = NULL;
++            }
++        }
++
++        out[i].commandBufferInfoCount = in[i].commandBufferInfoCount;
++        out[i].pCommandBufferInfos = cmdbuf_submit_info = memdup(in[i].pCommandBufferInfos,
++                                            in[i].commandBufferInfoCount,
++                                            sizeof(out[i].pCommandBufferInfos[0]));
++        for (k = 0; k < out[i].commandBufferInfoCount; k++)
++        {
++            if (cmdbuf_submit_info[k].pNext)
++            {
++                FIXME("pNext chain conversion for VkCommandBufferSubmitInfo not supported.\n");
++                cmdbuf_submit_info[k].pNext = NULL;
++            }
++        }
++
++        out[i].signalSemaphoreInfoCount = in[i].signalSemaphoreInfoCount;
++        out[i].pSignalSemaphoreInfos = sem_submit_info =memdup(in[i].pSignalSemaphoreInfos,
++                                              in[i].signalSemaphoreInfoCount,
++                                              sizeof(out[i].pSignalSemaphoreInfos[0]));
++        for (k = 0; k < out[i].signalSemaphoreInfoCount; k++)
++        {
++            if (sem_submit_info[k].pNext)
++            {
++                FIXME("pNext chain conversion for VkSemaphoreSubmitInfo not supported.\n");
++                sem_submit_info[k].pNext = NULL;
++            }
++        }
++
++        convert_VkSubmitInfo2_struct_chain(in[i].pNext, &out[i]);
++    }
++
++    return out;
++}
++
++static void free_copied_VkSubmitInfo2(VkSubmitInfo2 *info, uint32_t submit_count)
++{
++    unsigned int i;
++
++    for (i = 0; i < submit_count; i++)
++    {
++        free_VkSubmitInfo2_struct_chain(&info[i]);
++
++        free((VkSemaphoreSubmitInfo  *)    info[i].pWaitSemaphoreInfos);
++        free((VkCommandBufferSubmitInfo *) info[i].pCommandBufferInfos);
++        free((VkSemaphoreSubmitInfo *)     info[i].pSignalSemaphoreInfos);
++    }
++
++    free(info);
++}
++
++struct queue_submit_unit
++{
++    uint32_t submit_count;
++    VkSubmitInfo *submits;
++    VkSubmitInfo2 *submits2;
++    VkFence fence;
++    bool khr;
++
++    struct pending_wait **waits;
++
++    struct list entry;
++};
++
++/* Abstracts away the differences between VkSubmitInfo and VkSubmitInfo2. */
++static bool for_each_d3d12_semaphore(struct queue_submit_unit *unit, bool signal,
++                                     struct wine_semaphore **semaphore_out, uint64_t **value_out, uint32_t counter)
++{
++    VkTimelineSemaphoreSubmitInfo *timeline_values;
++    struct wine_semaphore *semaphore;
++    unsigned int i, j, k;
++    uint32_t sem_count;
++
++    for (i = 0, k = 0; i < unit->submit_count; i++)
++    {
++        if (unit->submits)
++        {
++            timeline_values = wine_vk_find_struct(&unit->submits[i], TIMELINE_SEMAPHORE_SUBMIT_INFO);
++
++            if (signal)
++                sem_count = unit->submits[i].signalSemaphoreCount;
++            else
++                sem_count = unit->submits[i].waitSemaphoreCount;
++
++            for (j = 0; j < sem_count; j++)
++            {
++                if (signal)
++                    semaphore = wine_semaphore_from_handle(unit->submits[i].pSignalSemaphores[j]);
++                else
++                    semaphore = wine_semaphore_from_handle(unit->submits[i].pWaitSemaphores[j]);
++
++                if (semaphore->handle_type != VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                    continue;
++
++                if (k++ == counter)
++                {
++                    *semaphore_out = semaphore;
++                    if (signal)
++                        *value_out = (uint64_t *) &timeline_values->pSignalSemaphoreValues[j];
++                    else
++                        *value_out = (uint64_t *) &timeline_values->pWaitSemaphoreValues[j];
++                    return true;
++                }
++            }
++        }
++        else
++        {
++            if (signal)
++                sem_count = unit->submits2[i].signalSemaphoreInfoCount;
++            else
++                sem_count = unit->submits2[i].waitSemaphoreInfoCount;
++
++            for (j = 0; j < sem_count; j++)
++            {
++                if (signal)
++                    semaphore = wine_semaphore_from_handle(unit->submits2[i].pSignalSemaphoreInfos[j].semaphore);
++                else
++                    semaphore = wine_semaphore_from_handle(unit->submits2[i].pWaitSemaphoreInfos[j].semaphore);
++
++                if (semaphore->handle_type != VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                    continue;
++
++                if (k++ == counter)
++                {
++                    *semaphore_out = semaphore;
++                    if (signal)
++                        *value_out = (uint64_t *) &unit->submits2[i].pSignalSemaphoreInfos[j].value;
++                    else
++                        *value_out = (uint64_t *) &unit->submits2[i].pWaitSemaphoreInfos[j].value;
++                    return true;
++                }
++            }
++        }
++    }
++
++    return false;
++}
++
++static void *virtual_queue_worker(void *arg)
++{
++    struct VkQueue_T *queue = (struct VkQueue_T *)arg;
++    struct queue_submit_unit *submit_unit;
++    struct signal_op *signal_op;
++    struct wine_semaphore *sem;
++    struct pending_wait *wait;
++    struct wine_fence *fence;
++    bool device_lost = false;
++    uint64_t *timeline_value;
++    unsigned int i;
++    VkResult vr;
++
++    for (;;)
++    {
++        pthread_mutex_lock(&queue->submissions_mutex);
++
++        while (!queue->stop && list_empty(&queue->submissions))
++            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
++
++        if (queue->stop)
++        {
++            assert( list_empty(&queue->submissions) );
++            pthread_mutex_unlock(&queue->submissions_mutex);
++            return NULL;
++        }
++
++        submit_unit = LIST_ENTRY(list_head(&queue->submissions), struct queue_submit_unit, entry);
++        list_remove(&submit_unit->entry);
++
++        pthread_mutex_unlock(&queue->submissions_mutex);
++
++        if (device_lost)
++            goto free_submit_unit;
++
++        /* Wait for all fences to have a pending signal */
++        for (i = 0; for_each_d3d12_semaphore(submit_unit, false, &sem, &timeline_value, i); i++)
++        {
++            if ((wait = submit_unit->waits[i++]))
++            {
++                assert(wait);
++                d3d12_semaphore_lock(sem);
++
++                while (!wait->satisfied)
++                    pthread_cond_wait(&wait->cond, &sem->d3d12_fence_shm->mutex);
++
++                *timeline_value = d3d12_semaphore_pop_wait_locked(sem, wait);
++
++                d3d12_semaphore_unlock(sem);
++            }
++        }
++
++        for (i = 0; for_each_d3d12_semaphore(submit_unit, true, &sem, &timeline_value, i); i++)
++        {
++            d3d12_semaphore_lock(sem);
++
++            *timeline_value = d3d12_semaphore_add_pending_signal_locked(sem, *timeline_value, queue);
++        }
++
++        if (submit_unit->submits)
++            vr = thunk_vkQueueSubmit(queue, submit_unit->submit_count, submit_unit->submits, submit_unit->fence);
++        else
++        {
++            if (submit_unit->khr)
++                vr = thunk_vkQueueSubmit2KHR(queue, submit_unit->submit_count, submit_unit->submits2, submit_unit->fence);
++            else
++                vr = thunk_vkQueueSubmit2(queue, submit_unit->submit_count, submit_unit->submits2, submit_unit->fence);
++        }
++
++        pthread_mutex_lock(&queue->signaller_mutex);
++
++        for (i = 0; for_each_d3d12_semaphore(submit_unit, true, &sem, &timeline_value, i); i++)
++        {
++            if (vr == VK_SUCCESS)
++            {
++                struct pending_update added_signal = d3d12_semaphore_peek_added_signal_locked(sem);
++                d3d12_semaphore_satisfy_waits_locked(sem, added_signal.virtual_value, added_signal.physical_value);
++
++                signal_op = malloc(sizeof(*signal_op));
++                signal_op->signal_type = SIGNAL_TYPE_SEMAPHORE;
++                signal_op->semaphore.obj = sem;
++                signal_op->semaphore.phys_val = added_signal.physical_value;
++                signal_op->semaphore.khr = submit_unit->khr;
++
++                list_add_tail(&queue->signal_ops, &signal_op->entry);
++            }
++            else
++            {
++                d3d12_semaphore_pop_pending_signal_locked(sem, *timeline_value, NULL);
++            }
++
++            d3d12_semaphore_unlock(sem);
++        }
++
++        if (vr == VK_SUCCESS && (fence = wine_fence_from_handle(submit_unit->fence)))
++        {
++            signal_op = malloc(sizeof(*signal_op));
++            signal_op->signal_type = SIGNAL_TYPE_FENCE;
++            signal_op->fence = fence;
++
++            list_add_tail(&queue->signal_ops, &signal_op->entry);
++        }
++
++        pthread_cond_signal(&queue->signaller_cond);
++        pthread_mutex_unlock(&queue->signaller_mutex);
++
++        if (vr != VK_SUCCESS)
++        {
++            fprintf(stderr, "winevulkan/virtual_queue_worker: queue submission failed with %d, treating as DEVICE_LOST.\n", vr);
++            pthread_mutex_lock(&queue->submissions_mutex);
++            queue->device_lost = device_lost = true;
++            pthread_mutex_unlock(&queue->submissions_mutex);
++
++            if ((fence = wine_fence_from_handle(submit_unit->fence)))
++            {
++                uint64_t buf = 1;
++                assert( write(fence->eventfd, &buf, sizeof(buf)) != -1 );
++            }
++        }
++
++free_submit_unit:
++        if (submit_unit->submits)
++            free_copied_VkSubmitInfo(submit_unit->submits, submit_unit->submit_count);
++        else
++            free_copied_VkSubmitInfo2(submit_unit->submits2, submit_unit->submit_count);
++        free(submit_unit->waits);
++        free(submit_unit);
++
++        pthread_mutex_lock(&queue->submissions_mutex);
++        if (list_empty(&queue->submissions))
++        {
++            queue->processing = false;
++        }
++        pthread_cond_signal(&queue->submissions_cond);
++        pthread_mutex_unlock(&queue->submissions_mutex);
++    }
++
++    return NULL;
++}
++
++static void init_virtual_queue(struct VkQueue_T *queue)
++{
++    if (is_virtual_queue(queue))
++        return;
++
++    pthread_mutex_lock(&queue->submissions_mutex);
++
++    if (queue->virtual_queue)
++    {
++        pthread_mutex_unlock(&queue->submissions_mutex);
++        return;
++    }
++
++    __atomic_store_n(&queue->virtual_queue, 1, __ATOMIC_RELEASE);
++
++    pthread_create(&queue->virtual_queue_thread, NULL, virtual_queue_worker, queue);
++    pthread_create(&queue->signal_thread, NULL, queue_signaller_worker, queue);
++
++    queue->virtual_queue = true;
++
++    pthread_mutex_unlock(&queue->submissions_mutex);
++}
++
++static NTSTATUS virtual_queue_submit(struct VkQueue_T *queue, uint32_t submit_count, const VkSubmitInfo *submits, VkFence fence)
++{
++    VkTimelineSemaphoreSubmitInfo *timeline_submit_info, *host_timeline_values;
++    VkD3D12FenceSubmitInfoKHR *d3d12_submit_info;
++    struct queue_submit_unit *submit_unit;
++    struct wine_semaphore *sem;
++    unsigned int i, j, k;
++    uint64_t wait_value;
++    bool device_lost;
++
++    init_virtual_queue(queue);
++
++    pthread_mutex_lock(&queue->submissions_mutex);
++    device_lost = queue->device_lost;
++    pthread_mutex_unlock(&queue->submissions_mutex);
++    if (device_lost)
++        return VK_ERROR_DEVICE_LOST;
++
++    submit_unit = malloc(sizeof(*submit_unit));
++    submit_unit->submit_count = submit_count;
++    submit_unit->submits = copy_VkSubmitInfo(submits, submit_count);
++    submit_unit->submits2 = NULL;
++    submit_unit->fence = fence;
++    submit_unit->waits = NULL;
++    submit_unit->khr = queue->device->phys_dev->api_version < VK_API_VERSION_1_2 ||
++                       queue->device->phys_dev->instance->api_version < VK_API_VERSION_1_2;
++
++    /* As D3D12 fences are rewindable, we add the wait synchronously as not to miss a temporarily signalled value
++     between vkQueueSubmit and processing the submit unit*/
++    for (i = 0, k = 0; i < submit_count; i++)
++    {
++        timeline_submit_info = wine_vk_find_struct(&submits[i], TIMELINE_SEMAPHORE_SUBMIT_INFO);
++        d3d12_submit_info = wine_vk_find_struct(&submits[i], D3D12_FENCE_SUBMIT_INFO_KHR);
++
++        host_timeline_values = wine_vk_find_struct(&submit_unit->submits[i], TIMELINE_SEMAPHORE_SUBMIT_INFO);
++
++        if (d3d12_submit_info && !host_timeline_values)
++        {
++            host_timeline_values = malloc(sizeof(*host_timeline_values));
++
++            host_timeline_values->sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
++            host_timeline_values->pNext = submit_unit->submits[i].pNext;
++            host_timeline_values->waitSemaphoreValueCount = d3d12_submit_info->waitSemaphoreValuesCount;
++            host_timeline_values->pWaitSemaphoreValues =
++                    memdup(d3d12_submit_info->pWaitSemaphoreValues, d3d12_submit_info->waitSemaphoreValuesCount,
++                        sizeof(host_timeline_values->pWaitSemaphoreValues[0]));
++            host_timeline_values->signalSemaphoreValueCount = d3d12_submit_info->signalSemaphoreValuesCount;
++            host_timeline_values->pSignalSemaphoreValues =
++                    memdup(d3d12_submit_info->pSignalSemaphoreValues, d3d12_submit_info->signalSemaphoreValuesCount,
++                        sizeof(host_timeline_values->pSignalSemaphoreValues[0]));
++
++            submit_unit->submits[i].pNext = host_timeline_values;
++        }
++
++        for (j = 0; j < submits[i].waitSemaphoreCount; j++)
++        {
++            sem = wine_semaphore_from_handle(submits[i].pWaitSemaphores[j]);
++
++            if (sem->handle_type != VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                continue;
++
++            if (timeline_submit_info)
++                wait_value = timeline_submit_info->pWaitSemaphoreValues[j];
++            else
++                wait_value = d3d12_submit_info->pWaitSemaphoreValues[j];
++
++            submit_unit->waits = realloc(submit_unit->waits, (k + 1) * sizeof(*submit_unit->waits));
++            submit_unit->waits[k] = NULL;
++
++            d3d12_semaphore_lock(sem);
++
++            if ((((uint64_t*)host_timeline_values->pWaitSemaphoreValues)[j] =
++                                d3d12_semaphore_try_get_wait_value_locked(sem, wait_value, queue)) == -1)
++                submit_unit->waits[k] = d3d12_semaphore_push_wait_locked(sem, wait_value);
++
++            d3d12_semaphore_unlock(sem);
++            k++;
++        }
++    }
++
++    pthread_mutex_lock(&queue->submissions_mutex);
++    queue->processing = true;
++    if (fence)
++    {
++        wine_fence_from_handle(fence)->queue = queue;
++        wine_fence_from_handle(fence)->wait_assist = true;
++    }
++    list_add_tail(&queue->submissions, &submit_unit->entry);
++    pthread_cond_signal(&queue->submissions_cond);
++    pthread_mutex_unlock(&queue->submissions_mutex);
++
++    return VK_SUCCESS;
++}
++
++NTSTATUS wine_vkQueueSubmit(void *args)
++{
++    struct vkQueueSubmit_params *params = args;
++    VkQueue queue = params->queue;
++    uint32_t submit_count = params->submitCount;
++    const VkSubmitInfo *submits = params->pSubmits;
++    VkFence fence = params->fence;
++
++    unsigned int i, k;
++
++    TRACE("(%p %u %p 0x%s)\n", queue, submit_count, submits, wine_dbgstr_longlong(fence));
++
++    if (is_virtual_queue(queue))
++        return virtual_queue_submit(queue, submit_count, submits, fence);
++
++    for (i = 0; i < submit_count; i++)
++    {
++        if (wine_vk_find_struct(&submits[i], WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR))
++            FIXME("VkWin32KeyedMutexAcquireReleaseInfoKHR structure unhandled.\n");
++
++        for (k = 0; k < submits[i].waitSemaphoreCount; k++)
++        {
++            if (wine_semaphore_from_handle(submits[i].pWaitSemaphores[k])->handle_type ==
++                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                return virtual_queue_submit(queue, submit_count, submits, fence);
++        }
++
++        for (k = 0; k < submits[i].signalSemaphoreCount; k++)
++        {
++            if (wine_semaphore_from_handle(submits[i].pSignalSemaphores[k])->handle_type ==
++                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                return virtual_queue_submit(queue, submit_count, submits, fence);
++        }
++    }
++
++    if (fence)
++        wine_fence_from_handle(fence)->queue = queue;
++
++    return thunk_vkQueueSubmit(queue, submit_count, submits, fence);
++}
++
++static NTSTATUS virtual_queue_submit2(struct VkQueue_T *queue, uint32_t submit_count, const VkSubmitInfo2 *submits, VkFence fence, bool khr)
++{
++    VkSemaphoreSubmitInfo *sem_submit_info;
++    struct queue_submit_unit *submit_unit;
++    VkSubmitInfo2 *queue_submit;
++    struct wine_semaphore *sem;
++    unsigned int i, j, k;
++    uint64_t wait_value;
++    bool device_lost;
++
++    init_virtual_queue(queue);
++
++    pthread_mutex_lock(&queue->submissions_mutex);
++    device_lost = queue->device_lost;
++    pthread_mutex_unlock(&queue->submissions_mutex);
++    if (device_lost)
++        return VK_ERROR_DEVICE_LOST;
++
++    submit_unit = malloc(sizeof(*submit_unit));
++    submit_unit->submit_count = submit_count;
++    submit_unit->submits = NULL;
++    submit_unit->submits2 = copy_VkSubmitInfo2(submits, submit_count);
++    submit_unit->fence = fence;
++    submit_unit->waits = NULL;
++    submit_unit->khr = khr;
++
++    /* As D3D12 fences are rewindable, we add the wait synchronously as not to miss a temporarily signalled value
++     between vkQueueSubmit and processing the submit unit */
++    for (i = 0, k = 0; i < submit_count; i++)
++    {
++        queue_submit = &submit_unit->submits2[i];
++
++        for (j = 0; j < queue_submit->waitSemaphoreInfoCount; j++)
++        {
++            sem_submit_info = (VkSemaphoreSubmitInfo *) &queue_submit->pWaitSemaphoreInfos[j];
++            sem = wine_semaphore_from_handle(sem_submit_info->semaphore);
++
++            if (sem->handle_type != VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                continue;
++
++            wait_value = sem_submit_info->value;
++
++            submit_unit->waits = realloc(submit_unit->waits, (k + 1) * sizeof(*submit_unit->waits));
++            submit_unit->waits[k] = NULL;
++
++            d3d12_semaphore_lock(sem);
++
++            if ((sem_submit_info->value =
++                                d3d12_semaphore_try_get_wait_value_locked(sem, wait_value, queue)) == -1)
++                submit_unit->waits[k] = d3d12_semaphore_push_wait_locked(sem, wait_value);
++
++            d3d12_semaphore_unlock(sem);
++            k++;
++        }
++    }
++
++    pthread_mutex_lock(&queue->submissions_mutex);
++    queue->processing = true;
++    if (fence)
++    {
++        wine_fence_from_handle(fence)->queue = queue;
++        wine_fence_from_handle(fence)->wait_assist = true;
++    }
++    list_add_tail(&queue->submissions, &submit_unit->entry);
++    pthread_cond_signal(&queue->submissions_cond);
++    pthread_mutex_unlock(&queue->submissions_mutex);
++
++    return VK_SUCCESS;
++}
++
++static NTSTATUS vk_queue_submit_2(VkQueue queue, uint32_t submit_count, const VkSubmitInfo2 *submits, VkFence fence, bool khr)
++{
++    unsigned int i, k;
++
++    TRACE("(%p, %u, %p, %s)\n", queue, submit_count, submits, wine_dbgstr_longlong(fence));
++
++    if (is_virtual_queue(queue))
++        return virtual_queue_submit2(queue, submit_count, submits, fence, khr);
++
++    for (i = 0; i < submit_count; i++)
++    {
++        if (wine_vk_find_struct(&submits[i], WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR))
++            FIXME("VkWin32KeyedMutexAcquireReleaseInfoKHR structure unhandled.\n");
++
++        for (k = 0; k < submits[i].waitSemaphoreInfoCount; k++)
++        {
++            if (wine_semaphore_from_handle(submits[i].pWaitSemaphoreInfos[k].semaphore)->handle_type ==
++                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                return virtual_queue_submit2(queue, submit_count, submits, fence, khr);
++        }
++
++        for (k = 0; k < submits[i].signalSemaphoreInfoCount; k++)
++        {
++            if (wine_semaphore_from_handle(submits[i].pSignalSemaphoreInfos[k].semaphore)->handle_type ==
++                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++                return virtual_queue_submit2(queue, submit_count, submits, fence, khr);
++        }
++    }
++
++    if (fence)
++        wine_fence_from_handle(fence)->queue = queue;
++
++    if (khr)
++        return thunk_vkQueueSubmit2KHR(queue, submit_count, submits, fence);
++    else
++        return thunk_vkQueueSubmit2(queue, submit_count, submits, fence);
++}
++
++NTSTATUS wine_vkQueueSubmit2(void *args)
++{
++    struct vkQueueSubmit2_params *params = args;
++    VkQueue queue = params->queue;
++    uint32_t submit_count = params->submitCount;
++    const VkSubmitInfo2 *submits = params->pSubmits;
++    VkFence fence = params->fence;
++
++    return vk_queue_submit_2(queue, submit_count, submits, fence, false);
++}
++
++NTSTATUS wine_vkQueueSubmit2KHR(void *args)
++{
++    struct vkQueueSubmit2_params *params = args;
++    VkQueue queue = params->queue;
++    uint32_t submit_count = params->submitCount;
++    const VkSubmitInfo2 *submits = params->pSubmits;
++    VkFence fence = params->fence;
++
++    return vk_queue_submit_2(queue, submit_count, submits, fence, true);
++}
++
++static inline VkSemaphore *convert_VkSemaphore_array_win_to_host(const VkSemaphore *in, uint32_t count)
++{
++    VkSemaphore *out;
++    unsigned int i;
++
++    if (!in || !count) return NULL;
++
++    out = malloc(count * sizeof(*out));
++    for (i = 0; i < count; i++)
++    {
++        out[i] = in[i] ? wine_semaphore_from_handle(in[i])->semaphore : VK_NULL_HANDLE;
++    }
++
++    return out;
++}
++
++static inline void free_VkSemaphore_array(VkSemaphore *in, uint32_t count)
++{
++    if (!in) return;
++
++    free(in);
++}
++
++NTSTATUS wine_vkQueuePresentKHR(void *args)
++{
++    struct vkQueuePresentKHR_params *params = args;
++    VkQueue queue = params->queue;
++    const VkPresentInfoKHR *present_info = params->pPresentInfo;
++
++    VkPresentInfoKHR host_present_info = *present_info;
++    struct wine_semaphore *semaphore;
++    VkSemaphore *host_semaphores;
++    unsigned int i;
++    VkResult vr;
++
++    TRACE("%p %p\n", queue, present_info);
++
++    for (i = 0; i < present_info->waitSemaphoreCount; i++)
++    {
++        semaphore = wine_semaphore_from_handle(present_info->pWaitSemaphores[i]);
++
++        if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++        {
++            FIXME("Waiting on D3D12-Fence compatible timeline semaphore not supported.\n");
++            return VK_ERROR_OUT_OF_HOST_MEMORY;
++        }
++    }
++
++    if (is_virtual_queue(queue))
++    {
++        pthread_mutex_lock(&queue->submissions_mutex);
++        while (queue->processing)
++            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
++        pthread_mutex_unlock(&queue->submissions_mutex);
++    }
++
++    vr = thunk_vkQueuePresentKHR(queue, &host_present_info);
++    free_VkSemaphore_array(host_semaphores, present_info->waitSemaphoreCount);
++    return vr;
++}
++
++NTSTATUS wine_vkQueueBindSparse(void *args)
++{
++    struct vkQueueBindSparse_params *params = args;
++    VkQueue queue = params->queue;
++    uint32_t bind_info_count = params->bindInfoCount;
++    const VkBindSparseInfo *bind_info = params->pBindInfo;
++    VkFence fence = params->fence;
++
++    struct wine_semaphore *semaphore;
++    const VkBindSparseInfo *batch;
++    unsigned int i, k;
++
++    TRACE("(%p, %u, %p, 0x%s)\n", queue, bind_info_count, bind_info, wine_dbgstr_longlong(fence));
++
++    if (is_virtual_queue(queue))
++    {
++        FIXME("Can't process sparse bind calls on virtual queue, flushing.\n");
++        pthread_mutex_lock(&queue->submissions_mutex);
++        while (queue->processing)
++            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
++        pthread_mutex_unlock(&queue->submissions_mutex);
++    }
++
++    for (i = 0; i < bind_info_count; i++)
++    {
++        batch = &bind_info[i];
++
++        for (k = 0; k < batch->waitSemaphoreCount; k++)
++        {
++            semaphore = wine_semaphore_from_handle(batch->pWaitSemaphores[k]);
++
++            if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++            {
++                FIXME("Waiting on D3D12-Fence compatible timeline semaphore not supported.\n");
++                return VK_ERROR_OUT_OF_HOST_MEMORY;
++            }
++        }
++
++        for(k = 0; k < batch->signalSemaphoreCount; k++)
++        {
++            semaphore = wine_semaphore_from_handle(batch->pSignalSemaphores[k]);
++
++            if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++            {
++                FIXME("Signalling D3D12-Fence compatible timeline semaphore not supported.\n");
++                return VK_ERROR_OUT_OF_HOST_MEMORY;
++            }
++        }
++    }
++
++    return thunk_vkQueueBindSparse(queue, bind_info_count, bind_info, fence);
++}
++
++NTSTATUS wine_vkCreateFence(void *args)
++{
++    struct vkCreateFence_params *params = args;
++    VkDevice device = params->device;
++    const VkFenceCreateInfo *create_info = params->pCreateInfo;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++    VkFence *fence = params->pFence;
++
++    struct wine_fence *object;
++    VkResult vr;
++
++    TRACE("(%p, %p, %p, %p)\n", device, create_info, allocator, fence);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if (!(object = calloc(1, sizeof(*object))))
++        return VK_ERROR_OUT_OF_HOST_MEMORY;
++
++    if ((object->eventfd = eventfd(0, EFD_CLOEXEC)) == -1)
++        ERR("Failed to create eventfd for fence.\n");
++
++    if ((vr = device->funcs.p_vkCreateFence(device->device, create_info, allocator, &object->fence)) == VK_SUCCESS)
++        *fence = wine_fence_to_handle(object);
++    else
++        free(object);
++
++    return vr;
++}
++
++NTSTATUS wine_vkDestroyFence(void *args)
++{
++    struct vkDestroyFence_params *params = args;
++    VkDevice device = params->device;
++    VkFence handle = params->fence;
++    const VkAllocationCallbacks *allocator = params->pAllocator;
++
++    struct wine_fence *fence = wine_fence_from_handle(handle);
++
++    TRACE("(%p, %p, %p)\n", device, fence, allocator);
++
++    if (allocator)
++        FIXME("Support for allocation callbacks not implemented yet\n");
++
++    if (fence->eventfd != -1)
++        close(fence->eventfd);
++
++    device->funcs.p_vkDestroyFence(device->device, fence->fence, allocator);
++    free(fence);
++
++    return STATUS_SUCCESS;
++}
++
++NTSTATUS wine_vkResetFences(void *args)
++{
++    struct vkResetFences_params *params = args;
++    VkDevice device = params->device;
++    uint32_t fence_count = params->fenceCount;
++    const VkFence *fences = params->pFences;
++
++    struct wine_fence *fence;
++    unsigned int i;
++    uint64_t buf;
++    VkResult vr;
++
++    TRACE("(%p, %u, %p)\n", device, fence_count, fences);
++
++    if ((vr = thunk_vkResetFences(device, fence_count, fences)) != VK_SUCCESS)
++        return vr;
++
++    for (i = 0; i < fence_count; i++)
++    {
++        fence = wine_fence_from_handle(fences[i]);
++
++        fence->queue = NULL;
++        fence->swapchain = NULL;
++        if (fence->wait_assist)
++        {
++            fence->wait_assist = false;
++            if (read(fence->eventfd, &buf, sizeof(buf)) == -1)
++                ERR("Failed to reset event fd.\n");
++        }
++    }
++
++    return VK_SUCCESS;
++}
++
++NTSTATUS wine_vkWaitForFences(void *args)
++{
++    struct vkWaitForFences_params *params = args;
++    VkDevice device = params->device;
++    uint32_t fence_count = params->fenceCount;
++    const VkFence *fences = params->pFences;
++    VkBool32 wait_all = params->waitAll;
++    uint64_t timeout = params->timeout;
++
++    struct signal_op *signal_op;
++    bool assisted_wait = false;
++    struct wine_fence *fence;
++    struct pollfd *wait_fds;
++    struct pollfd wait_fd;
++    unsigned int i;
++    VkResult vr;
++    int ret;
++
++    TRACE("(%p, %u, %p, %u, 0x%s)\n", device, fence_count, fences, wait_all, wine_dbgstr_longlong(timeout));
++
++    for (i = 0; i < fence_count; i++)
++    {
++        fence = wine_fence_from_handle(fences[i]);
++        if (!fence->wait_assist)
++            continue;
++
++        if (!wait_all && fence_count > 1)
++        {
++            assisted_wait = true;
++            break;
++        }
++
++        wait_fd.fd = fence->eventfd;
++        wait_fd.events = POLLIN;
++        ret = poll(&wait_fd, 1, timeout / 1000000);
++        if (ret == -1)
++        {
++            ERR("Failed to poll wait assisted fence.\n");
++            return VK_ERROR_OUT_OF_HOST_MEMORY;
++        }
++        if (!ret)
++            return VK_TIMEOUT;
++
++        if (wait_fd.revents & (POLLERR | POLLHUP | POLLNVAL))
++            ERR("Polling on fd %d returned %#x.", fence->eventfd, wait_fd.revents);
++        return VK_SUCCESS;
++    }
++
++    if (assisted_wait)
++    {
++        /* Turn all non assisted waits into assisted waits, then poll on all */
++        wait_fds = malloc( sizeof(wait_fds[0]) * fence_count );
++
++        for (i = 0; i < fence_count; i++)
++        {
++            if (!fence->wait_assist)
++            {
++                assert(fence->queue || fence->swapchain);
++
++                if (fence->queue)
++                {
++                    fence->wait_assist = true;
++
++                    /* If virtual-queue requiring work was submitted after the work signalling this mutex,
++                     * we will end up unnecessarily waiting on that work first,
++                     * but this will only happen once per queue */
++                    init_virtual_queue(fence->queue);
++
++                    signal_op = malloc(sizeof(*signal_op));
++                    signal_op->signal_type = SIGNAL_TYPE_FENCE;
++                    signal_op->fence = fence;
++
++                    pthread_mutex_lock(&fence->queue->signaller_mutex);
++                    list_add_tail(&fence->queue->signal_ops, &signal_op->entry);
++                    pthread_cond_signal(&fence->queue->signaller_cond);
++                    pthread_mutex_unlock(&fence->queue->signaller_mutex);
++                }
++                else
++                {
++                    FIXME("Wait assist for swapchain signaled fences not supported.\n");
++                    free(wait_fds);
++                    return VK_ERROR_OUT_OF_HOST_MEMORY;
++                }
++            }
++
++            wait_fds[i].fd = fence->eventfd;
++            wait_fds[i].events = POLLIN;
++        }
++
++        if (poll(wait_fds, fence_count, timeout / 1000000) == -1)
++        {
++            ERR("Failed to poll wait assisted fences.\n");
++            vr = VK_ERROR_OUT_OF_HOST_MEMORY;
++        }
++
++        free(wait_fds);
++    }
++    else
++    {
++        vr = thunk_vkWaitForFences(device, fence_count, fences, wait_all, timeout);
++    }
++
++    return vr;
++}
++
++NTSTATUS wine_vkQueueWaitIdle(void *args)
++{
++    struct vkQueueWaitIdle_params *params = args;
++    VkQueue queue = params->queue;
++
++    TRACE("(%p)\n", queue);
++
++    if (is_virtual_queue(queue))
++    {
++        pthread_mutex_lock(&queue->submissions_mutex);
++        while (queue->processing)
++            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
++        pthread_mutex_unlock(&queue->submissions_mutex);
++    }
++
++    return queue->device->funcs.p_vkQueueWaitIdle(queue->queue);
+ }
+diff --git a/dlls/winevulkan/vulkan_loader.h b/dlls/winevulkan/vulkan_loader.h
+index 3ba945dbfcc..1183cb33576 100644
+--- a/dlls/winevulkan/vulkan_loader.h
++++ b/dlls/winevulkan/vulkan_loader.h
+@@ -38,6 +38,8 @@
+ #define WINEVULKAN_QUIRK_GET_DEVICE_PROC_ADDR 0x00000001
+ #define WINEVULKAN_QUIRK_ADJUST_MAX_IMAGE_COUNT 0x00000002
+ #define WINEVULKAN_QUIRK_IGNORE_EXPLICIT_LAYERS 0x00000004
++#define WINEVULKAN_QUIRK_EXPOSE_MEM_PRIORITY 0x00000008
++#define WINEVULKAN_QUIRK_EXPOSE_KEYED_MUTEX 0x00000010
+ 
+ /* Base 'class' for our Vulkan dispatchable objects such as VkDevice and VkInstance.
+  * This structure MUST be the first element of a dispatchable object as the ICD
+diff --git a/dlls/winevulkan/vulkan_private.h b/dlls/winevulkan/vulkan_private.h
+index 16b18c67622..b8dbcd4d8c3 100644
+--- a/dlls/winevulkan/vulkan_private.h
++++ b/dlls/winevulkan/vulkan_private.h
+@@ -27,6 +27,7 @@
+ #define VK_NO_PROTOTYPES
+ 
+ #include <pthread.h>
++#include <stdbool.h>
+ 
+ #include "wine/list.h"
+ 
+@@ -86,6 +87,8 @@ struct VkInstance_T
+     struct vulkan_instance_funcs funcs;
+     VkInstance instance; /* native instance */
+ 
++    uint32_t api_version;
++
+     /* We cache devices as we need to wrap them as they are
+      * dispatchable objects.
+      */
+@@ -112,9 +115,13 @@ struct VkPhysicalDevice_T
+     struct VkInstance_T *instance; /* parent */
+     VkPhysicalDevice phys_dev; /* native physical device */
+ 
++    uint32_t api_version;
++
+     VkExtensionProperties *extensions;
+     uint32_t extension_count;
+ 
++    bool fake_memory_priority;
++
+     struct wine_vk_mapping mapping;
+ };
+ 
+@@ -128,6 +135,22 @@ struct VkQueue_T
+     uint32_t queue_index;
+     VkDeviceQueueCreateFlags flags;
+ 
++    bool virtual_queue;
++    bool processing;
++    bool device_lost;
++
++    pthread_t virtual_queue_thread;
++    pthread_mutex_t submissions_mutex;
++    pthread_cond_t submissions_cond;
++    struct list submissions;
++
++    pthread_t signal_thread;
++    pthread_mutex_t signaller_mutex;
++    pthread_cond_t signaller_cond;
++    struct list signal_ops;
++
++    bool stop;
++
+     struct wine_vk_mapping mapping;
+ };
+ 
+@@ -228,6 +251,79 @@ static inline VkDeviceMemory wine_dev_mem_to_handle(struct wine_dev_mem *dev_mem
+     return (VkDeviceMemory)(uintptr_t)dev_mem;
+ }
+ 
++struct wine_semaphore
++{
++    VkSemaphore semaphore;
++    VkSemaphore fence_timeline_semaphore;
++
++    VkExternalSemaphoreHandleTypeFlagBits export_types;
++
++    struct wine_vk_mapping mapping;
++
++    /* mutable members */
++    VkExternalSemaphoreHandleTypeFlagBits handle_type;
++    HANDLE handle;
++    struct
++    {
++        pthread_mutex_t mutex;
++        uint64_t virtual_value, physical_value, counter;
++
++        struct pending_wait
++        {
++            bool present, satisfied;
++            uint64_t virtual_value;
++            uint64_t physical_value;
++            pthread_cond_t cond;
++        } pending_waits[100];
++
++        struct pending_update
++        {
++            uint64_t virtual_value;
++            uint64_t physical_value;
++            pid_t signalling_pid;
++            struct VkQueue_T *signalling_queue;
++        } pending_updates[100];
++        uint32_t pending_updates_count;
++    } *d3d12_fence_shm;
++};
++
++static inline struct wine_semaphore *wine_semaphore_from_handle(VkSemaphore handle)
++{
++    return (struct wine_semaphore *)(uintptr_t)handle;
++}
++
++static inline VkSemaphore wine_semaphore_to_handle(struct wine_semaphore *semaphore)
++{
++    return (VkSemaphore)(uintptr_t)semaphore;
++}
++
++static inline VkSemaphore wine_semaphore_host_handle(struct wine_semaphore *semaphore)
++{
++    if (semaphore->handle_type == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
++        return semaphore->fence_timeline_semaphore;
++    return semaphore->semaphore;
++}
++
++struct wine_fence
++{
++    VkFence fence;
++
++    struct VkQueue_T *queue;
++    struct VkSwapchainKHR_T *swapchain;
++    bool wait_assist;
++    int eventfd;
++};
++
++static inline struct wine_fence *wine_fence_from_handle(VkFence handle)
++{
++    return (struct wine_fence *)(uintptr_t)handle;
++}
++
++static inline VkFence wine_fence_to_handle(struct wine_fence *fence)
++{
++    return (VkFence)(uintptr_t)fence;
++}
++
+ BOOL wine_vk_device_extension_supported(const char *name) DECLSPEC_HIDDEN;
+ BOOL wine_vk_instance_extension_supported(const char *name) DECLSPEC_HIDDEN;
+ 
+@@ -248,4 +344,16 @@ static inline void init_unicode_string( UNICODE_STRING *str, const WCHAR *data )
+     str->Buffer = (WCHAR *)data;
+ }
+ 
++static inline void *memdup(const void *in, size_t number, size_t size)
++{
++    void *out;
++
++    if (!in)
++        return NULL;
++
++    out = malloc(number * size);
++    memcpy(out, in, number * size);
++    return out;
++}
++
+ #endif /* __WINE_VULKAN_PRIVATE_H */
+-- 
+2.37.1
+

--- a/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
@@ -213,6 +213,9 @@ _re4_fix="false"
 # Child window support for vk - Fixes World of Final Fantasy and others - https://bugs.winehq.org/show_bug.cgi?id=45277
 _childwindow_fix="true"
 
+# Shared gpu resources support. Requires DXVK 1.10.3+, VKD3D-Proton 2.7+ https://github.com/doitsujin/dxvk/pull/2516 https://github.com/doitsujin/dxvk/pull/2608
+_shared_gpu_resources="false"
+
 # Fix for LoL 9.20+ crashing - Depends on _use_staging="true" - https://bugs.winehq.org/show_bug.cgi?id=47198 & https://bugs.winehq.org/show_bug.cgi?id=47915 - Requires vdso32 disabled (as root: `echo 0 > /proc/sys/abi/vsyscall32`)
 # lol depends on the following staging patches :
 # winebuild-Fake_Dlls, ntdll-RtlCreateUserThread, ntdll-NtContinue, ntdll-SystemExtendedProcessInformation, ntdll-SystemModuleInformation, ntdll-ThreadHideFromDebugger, wow64cpu-Wow64Transition, user32-InternalGetWindowIcon, ntdll-Pipe_SpecialCharacters, ntdll-NtDevicePath, ntdll-NtQueryVirtualMemory, fonts-Missing_Fonts, crypt32-CMS_Certificates, bcrypt-ECDHSecretAgreement, winex11-ime-check-thread-data

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -371,6 +371,7 @@ msg2 ''
     _mtga_fix="false"
     _protonify="false"
     _childwindow_fix="false"
+    _shared_gpu_resources="false"
     _plasma_systray_fix="false"
     _wined3d_additions="false"
     _re4_fix="false"
@@ -920,6 +921,7 @@ _prepare() {
 
     source "$_where"/wine-tkg-patches/proton/valve_proton_fullscreen_hack/valve_proton_fullscreen_hack
     source "$_where"/wine-tkg-patches/misc/childwindow/childwindow-proton
+    source "$_where"/wine-tkg-patches/proton/shared-gpu-resources/shared-gpu-resources
     source "$_where"/wine-tkg-patches/proton/proton-rawinput/proton-rawinput
     source "$_where"/wine-tkg-patches/misc/winevulkan/winevulkan
     source "$_where"/wine-tkg-patches/game-specific/overwatch-mfstub/overwatch-mfstub


### PR DESCRIPTION
"Add initial support for shared gpu resources.
Disabled by default since these patches are only in **Proton Experimental**.
Requires DXVK 1.10.3+, VKD3D-Proton 2.7+"

https://github.com/doitsujin/dxvk/pull/2516
https://github.com/doitsujin/dxvk/pull/2608

these patches are enough to make video work in `Neighbors Back From Hell` (Unity engine)
https://github.com/ValveSoftware/wine/commit/649717ad0a34e07886fd2568623b5e33b2a875f3:
```
With this and the previous two patches, some video playback bugs
are solved for some games (e.g. Trailmakers, Rustler, TOHU and
others) when using DXVK (wined3d doesn't currently support
shared resources, so there is no way to check with it).
```
but maybe other videos will need more patches from Giovanni Mascellani related to CW-Bug-Id: **#19126**

UPD. added https://github.com/Guy1524/wine/commits/crysis-remastered-fixes (thanks @Guy1524)
which contains the latest changes
```
fixes a lot of bugs and gets crysis remastered RT working
```