### PR TITLE
sharedgpures: Fix shared gpu resources patchset

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-fences-fshack.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-fences-fshack.patch
@@ -1047,7 +1047,7 @@ index e065c0bc253..1024bf04037 100644
           *
           * "vkGetDeviceQueue must only be used to get queues that were created
 @@ -397,10 +452,10 @@ static void wine_vk_device_free_create_info(VkDeviceCreateInfo *create_info)
-         free((void *)create_info->ppEnabledExtensionNames);
+     free_VkDeviceCreateInfo_struct_chain(create_info);
  }
  
 -static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src,

--- a/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-fences.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-fences.patch
@@ -1045,7 +1045,7 @@ index 70ab0dddf0f..542c9a459ab 100644
           *
           * "vkGetDeviceQueue must only be used to get queues that were created
 @@ -397,10 +452,10 @@ static void wine_vk_device_free_create_info(VkDeviceCreateInfo *create_info)
-         free((void *)create_info->ppEnabledExtensionNames);
+     free_VkDeviceCreateInfo_struct_chain(create_info);
  }
  
 -static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src,

--- a/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-texture.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/shared-gpu-resources/sharedgpures-texture.patch
@@ -173,15 +173,7 @@ index da89cdd5ba2..5b0774c32bb 100644
          if (wine_vk_device_extension_supported(host_properties[i].extensionName))
          {
              TRACE("Enabling extension '%s' for physical device %p\n", host_properties[i].extensionName, object);
-@@ -366,12 +380,15 @@ static void wine_vk_device_get_queues(struct VkDevice_T *device,
- static void wine_vk_device_free_create_info(VkDeviceCreateInfo *create_info)
- {
-     free_VkDeviceCreateInfo_struct_chain(create_info);
-+
-+    if (create_info->enabledExtensionCount)
-+        free((void *)create_info->ppEnabledExtensionNames);
- }
- 
+@@ -366,7 +380,7 @@ static void wine_vk_device_free_create_info(VkDeviceCreateInfo *create_info)
  static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src,
          VkDeviceCreateInfo *dst)
  {


### PR DESCRIPTION
This part of the old code was mistakenly taken from deprecated branch https://github.com/Guy1524/wine/tree/shared-resources and now interferes.

Fixes the launch of probably most Vulkan games. (Hades [vulkan] still broken like on current `experimental_7.0`.)