### PR TITLE
Protonify: Fix some issues and add a few additional patches mostly needed for Forza Horizon games.

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-22fa68b.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-22fa68b.patch
@@ -3046,6 +3046,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -4123,6 +4191,56 @@ index db7baff269f..12881ab9697 100644
      create_dynamic_registry_keys();
      create_environment_registry_keys();
      create_computer_name_keys();
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From bdb21c72edcccc71416c399ed432ed5eab426e26 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:24:41 +0300
@@ -4304,3 +4422,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-8dd04c7.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-8dd04c7.patch
@@ -2947,6 +2947,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3795,6 +3863,56 @@ index db7baff269f..12881ab9697 100644
      create_environment_registry_keys();
      create_computer_name_keys();
 
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From 9bf094c8a6e962b969a1832613127bc4b7cf0fb3 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:17:41 +0300
@@ -3954,3 +4072,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-dfd5f10.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-dfd5f10.patch
@@ -3046,6 +3046,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -4145,6 +4213,56 @@ index 8e2e7d93a38..5f072956087 100644
  static const SIZE_T min_kernel_stack  = 0x2000;
  static const LONG teb_offset = 0x2000;
 
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From 9bf094c8a6e962b969a1832613127bc4b7cf0fb3 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:17:41 +0300
@@ -4304,3 +4422,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-fefe108.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-fefe108.patch
@@ -1783,39 +1783,51 @@ diff --git a/loader/wine.inf.in b/loader/wine.inf.in
 index 4df88d1f386..1506a73573b 100644
 --- a/loader/wine.inf.in
 +++ b/loader/wine.inf.in
-@@ -67,6 +67,7 @@ AddReg=\
+@@ -91,10 +91,11 @@ AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -95,6 +96,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo,\
+     LicenseInformation
+@@ -117,10 +118,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntamd64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -123,6 +125,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -142,10 +144,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntarm64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -142,6 +145,7 @@ AddReg=\
-     DirectX,\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -163,6 +166,7 @@ AddReg=\
      MCI,\
      Misc,\
 +    Packages.wow64,\
      Tapi,\
      VersionInfo.ntamd64,\
-     LicenseInformation, \
-@@ -234,6 +238,7 @@ CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
+     LicenseInformation
+ 
+@@ -247,6 +251,7 @@ CurrentVersion="Software\Microsoft\Windows\CurrentVersion"
  CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
  FontSubStr="Software\Microsoft\Windows NT\CurrentVersion\FontSubstitutes"
  Control="System\CurrentControlSet\Control"
@@ -1823,7 +1835,7 @@ index 4df88d1f386..1506a73573b 100644
  
  [Classes]
  HKCR,.chm,,2,"chm.file"
-@@ -1129,6 +1134,18 @@ HKLM,System\CurrentControlSet\Control\Nls\Locale\Alternate Sorts,"00030404",,"9"
+@@ -597,6 +602,18 @@ [OLE]
  HKLM,"Software\Microsoft\OLE","EnableDCOM",,"Y"
  HKLM,"Software\Microsoft\OLE","EnableRemoteConnect",,"N"
  

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-fefe108.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/legacy/proton-tkg-fefe108.patch
@@ -2904,6 +2904,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3752,6 +3820,56 @@ index db7baff269f..12881ab9697 100644
      create_environment_registry_keys();
      create_computer_name_keys();
 
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From 9bf094c8a6e962b969a1832613127bc4b7cf0fb3 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:17:41 +0300
@@ -3911,3 +4029,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/proton-tkg.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/proton-tkg.patch
@@ -1771,39 +1771,51 @@ diff --git a/loader/wine.inf.in b/loader/wine.inf.in
 index 4df88d1f386..1506a73573b 100644
 --- a/loader/wine.inf.in
 +++ b/loader/wine.inf.in
-@@ -67,6 +67,7 @@ AddReg=\
+@@ -91,10 +91,11 @@ AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -95,6 +96,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo,\
+     LicenseInformation
+@@ -117,10 +118,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntamd64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -123,6 +125,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -142,10 +144,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntarm64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -142,6 +145,7 @@ AddReg=\
-     DirectX,\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -163,6 +166,7 @@ AddReg=\
      MCI,\
      Misc,\
 +    Packages.wow64,\
      Tapi,\
      VersionInfo.ntamd64,\
-     LicenseInformation, \
-@@ -234,6 +238,7 @@ CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
+     LicenseInformation
+ 
+@@ -247,6 +251,7 @@ CurrentVersion="Software\Microsoft\Windows\CurrentVersion"
  CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
  FontSubStr="Software\Microsoft\Windows NT\CurrentVersion\FontSubstitutes"
  Control="System\CurrentControlSet\Control"
@@ -1811,7 +1823,7 @@ index 4df88d1f386..1506a73573b 100644
  
  [Classes]
  HKCR,.chm,,2,"chm.file"
-@@ -1129,6 +1134,18 @@ HKLM,System\CurrentControlSet\Control\Nls\Locale\Alternate Sorts,"00030404",,"9"
+@@ -597,6 +602,18 @@ [OLE]
  HKLM,"Software\Microsoft\OLE","EnableDCOM",,"Y"
  HKLM,"Software\Microsoft\OLE","EnableRemoteConnect",,"N"
  

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/proton-tkg.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/proton-tkg.patch
@@ -2892,6 +2892,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3740,6 +3808,56 @@ index db7baff269f..12881ab9697 100644
      create_environment_registry_keys();
      create_computer_name_keys();
 
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From 9bf094c8a6e962b969a1832613127bc4b7cf0fb3 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:17:41 +0300
@@ -3899,3 +4017,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/proton-tkg
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/proton-tkg
@@ -423,6 +423,9 @@
 	      fi
 	    fi
 	  fi
+	  if [ "$_proton_fs_hack" != "true" ] && git merge-base --is-ancestor 3ded60bd1654dc689d24a23305f4a93acce3a6f2 HEAD; then
+	      _patchname='proton-tkg-additions.patch' && _patchmsg="Using additional Proton-tkg patches" && nonuser_patcher
+	  fi
       source "$_where"/wine-tkg-patches/proton-tkg-specific/proton-pa/proton-pa
       source "$_where"/wine-tkg-patches/proton-tkg-specific/proton-gstreamer/proton-gstreamer
       source "$_where"/wine-tkg-patches/proton-tkg-specific/proton-windows.gaming.input/proton-windows.gaming.input

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/proton-tkg-additions.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/proton-tkg-additions.patch
@@ -1,0 +1,636 @@
+From 19b86fe3d35e00c8985e0c616cd7bc2eeb5e2df7 Mon Sep 17 00:00:00 2001
+From: Andrew Eikum <aeikum@codeweavers.com>
+Date: Wed, 27 Jun 2018 10:06:48 -0500
+Subject: [PATCH] HACK: winex11.drv: Let the WM focus our windows by default.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This should fix game windows not being in focus when first started
+and when exiting, which can cause surprising keyboard behavior (e.g.
+accidentally Alt-F4ing Steam itself, which is in the background).
+
+This may break modal dialogs in some WMs (fvwm2?) which do not respect
+our responses to WM_TAKE_FOCUS. For games that show that issue, we can
+re-enable UseTakeFocus.
+
+From Zeb:
+
+"""
+The basic problem, if I understand it correctly, is that Wine uses the
+"globally active" focus model by default. This means that the window
+manager won't focus our windows unless we respond in the affirmative to
+a WM_TAKE_FOCUS event. Since the GUI thread isn't processing messages,
+this doesn't happen.
+
+Luckily, there is a very easy workaround: create the registry key
+HKCU\Software\Wine\X11 Driver and set the somewhat inaptly named value
+"UseTakeFocus" to "N" (i.e. No). This causes Wine to use the "locally
+active" model instead, which means that the window manager will focus
+our windows when it sees fit—i.e. when the user clicks on them, or when
+they are created.
+"""
+---
+ dlls/winex11.drv/x11drv_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/winex11.drv/x11drv_main.c b/dlls/winex11.drv/x11drv_main.c
+index 8c2688f2a58..6bf4a0a4211 100644
+--- a/dlls/winex11.drv/x11drv_main.c
++++ b/dlls/winex11.drv/x11drv_main.c
+@@ -68,7 +68,7 @@ BOOL usexrandr = TRUE;
+ BOOL usexcomposite = TRUE;
+ BOOL use_xfixes = FALSE;
+ BOOL use_xkb = TRUE;
+-BOOL use_take_focus = TRUE;
++BOOL use_take_focus = FALSE;
+ BOOL use_primary_selection = FALSE;
+ BOOL use_system_cursors = TRUE;
+ BOOL show_systray = TRUE;
+From 7563c241f385299b4639c3b939558c2ba430886e Mon Sep 17 00:00:00 2001
+From: Andrew Eikum <aeikum@codeweavers.com>
+Date: Tue, 18 Sep 2018 14:48:58 -0500
+Subject: [PATCH] winex11.drv: Allow the application to change window size and
+ states during PropertyNotify.
+
+On focus loss, fullscreened DDLC changes to a 1x1 pixel window and
+minimizes. On restore, it un-minimizes and changes back to fullscreen
+size. However, this restoring happens during the PropertyNotify handler,
+which means we didn't update size or the NET_WM_STATEs.
+---
+ dlls/winex11.drv/window.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 01b12f96e03..294d84bfccc 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -2615,7 +2615,7 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+     }
+ 
+     /* don't change position if we are about to minimize or maximize a managed window */
+-    if (!event_type &&
++    if ((!event_type || event_type == PropertyNotify) &&
+         !(data->managed && (swp_flags & SWP_STATECHANGED) && (new_style & (WS_MINIMIZE|WS_MAXIMIZE))))
+         sync_window_position( data, swp_flags, &old_window_rect, &old_whole_rect, &old_client_rect );
+ 
+@@ -2649,7 +2649,7 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+         else
+         {
+             if (swp_flags & (SWP_FRAMECHANGED|SWP_STATECHANGED)) set_wm_hints( data );
+-            if (!event_type) update_net_wm_states( data );
++            if (!event_type || event_type == PropertyNotify) update_net_wm_states( data );
+         }
+     }
+ 
+From 32821e17a97f4e0afb703eaf17280cadb8030a16 Mon Sep 17 00:00:00 2001
+From: Alexey Prokhin <alexey@prokhin.ru>
+Date: Wed, 17 Oct 2018 19:55:27 +0300
+Subject: [PATCH] winex11.drv: Ignore clip_reset when trying to clip the mouse
+ after the desktop has been resized.
+
+This fixes the mouse clipping when the desktop is resized multiple times in a row.
+---
+ dlls/winex11.drv/mouse.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/dlls/winex11.drv/mouse.c b/dlls/winex11.drv/mouse.c
+index d02163cbaa8..d2ff071a9f2 100644
+--- a/dlls/winex11.drv/mouse.c
++++ b/dlls/winex11.drv/mouse.c
+@@ -579,9 +579,10 @@ BOOL clip_fullscreen_window( HWND hwnd, BOOL reset )
+     release_win_data( data );
+     if (!fullscreen) return FALSE;
+     if (!(thread_data = x11drv_thread_data())) return FALSE;
+-    if (NtGetTickCount() - thread_data->clip_reset < 1000) return FALSE;
+-    if (!reset && clipping_cursor && thread_data->clip_hwnd) return FALSE;  /* already clipping */
+-
++    if (!reset) {
++        if (NtGetTickCount() - thread_data->clip_reset < 1000) return FALSE;
++        if (!reset && clipping_cursor && thread_data->clip_hwnd) return FALSE;  /* already clipping */
++    }
+     monitor = NtUserMonitorFromWindow( hwnd, MONITOR_DEFAULTTONEAREST );
+     if (!monitor) return FALSE;
+     monitor_info.cbSize = sizeof(monitor_info);
+From 36535de250f26fbfd46c6383179e4c9bfe2ce956 Mon Sep 17 00:00:00 2001
+From: Alexey Prokhin <alexey@prokhin.ru>
+Date: Sat, 20 Oct 2018 18:07:12 +0300
+Subject: [PATCH] winex11.drv: Enable fullscreen clipping even if not already
+ clipping.
+
+---
+ dlls/winex11.drv/mouse.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/dlls/winex11.drv/mouse.c b/dlls/winex11.drv/mouse.c
+index d2ff071a9f2..9635d264e14 100644
+--- a/dlls/winex11.drv/mouse.c
++++ b/dlls/winex11.drv/mouse.c
+@@ -1571,12 +1571,12 @@ BOOL CDECL X11DRV_ClipCursor( LPCRECT clip )
+         {
+             if (grab_clipping_window( clip )) return TRUE;
+         }
+-        else /* if currently clipping, check if we should switch to fullscreen clipping */
++        else /* check if we should switch to fullscreen clipping */
+         {
+             struct x11drv_thread_data *data = x11drv_thread_data();
+-            if (data && data->clip_hwnd)
++            if (data)
+             {
+-                if (EqualRect( clip, &clip_rect ) || clip_fullscreen_window( foreground, TRUE ))
++                if ((data->clip_hwnd && EqualRect( clip, &clip_rect ) && !EqualRect(&clip_rect, &virtual_rect)) || clip_fullscreen_window( foreground, TRUE ))
+                     return TRUE;
+             }
+         }
+From 24d7f2bda1e98905206476fa3664ea8fa7bd7dd1 Mon Sep 17 00:00:00 2001
+From: Andrew Eikum <aeikum@codeweavers.com>
+Date: Fri, 11 Jan 2019 11:34:03 -0600
+Subject: [PATCH] winex11.drv: Ignore ConfigureNotify messages if there is a
+ FULLSCREEN WM state pending.
+
+Into the Breach goes fullscreen by first maximizing, then setting the
+window to fullscreen in a separate call. Mutter processes the maximize
+request _after_ Wine has sent the fullscreen request. As a result, we
+get a ConfigureNotify for the size of the workspace when we expect the
+window to be fullscreened. We then notify ITB that it is no longer
+fullscreen, which begins the process over again, causing an infinite
+loop.
+
+This fixes that by setting a flag if we have a fullscreen request
+pending and ignoring ConfigureNotify requests if it is set. We unset it
+when we receive a _NET_WM_STATE PropertyNotify event that contains the
+FULLSCREEN flag.
+---
+ dlls/winex11.drv/event.c  | 35 +++++++++++++++++++++++++++++++++++
+ dlls/winex11.drv/window.c |  3 +++
+ dlls/winex11.drv/x11drv.h |  1 +
+ 3 files changed, 39 insertions(+)
+
+diff --git a/dlls/winex11.drv/event.c b/dlls/winex11.drv/event.c
+index b7f5614f222..42c66f911ce 100644
+--- a/dlls/winex11.drv/event.c
++++ b/dlls/winex11.drv/event.c
+@@ -1129,6 +1129,12 @@ static BOOL X11DRV_ConfigureNotify( HWND hwnd, XEvent *xev )
+                event->serial, data->configure_serial );
+         goto done;
+     }
++    if (data->pending_fullscreen)
++    {
++        TRACE( "win %p/%lx event %d,%d,%dx%d pending_fullscreen is pending, so ignoring\n",
++               hwnd, data->whole_window, event->x, event->y, event->width, event->height );
++        goto done;
++    }
+ 
+     /* Get geometry */
+ 
+@@ -1362,15 +1368,44 @@ static void handle_wm_state_notify( HWND hwnd, XPropertyEvent *event, BOOL updat
+ }
+ 
+ 
++static void handle__net_wm_state_notify( HWND hwnd, XPropertyEvent *event )
++{
++    struct x11drv_win_data *data = get_win_data( hwnd );
++
++    if(data->pending_fullscreen)
++    {
++        read_net_wm_states( event->display, data );
++        if(data->net_wm_state & (1 << NET_WM_STATE_FULLSCREEN)){
++            data->pending_fullscreen = FALSE;
++            TRACE("PropertyNotify _NET_WM_STATE, now 0x%x, pending_fullscreen no longer pending.\n",
++                    data->net_wm_state);
++        }else
++            TRACE("PropertyNotify _NET_WM_STATE, now 0x%x, pending_fullscreen still pending.\n",
++                    data->net_wm_state);
++    }
++
++    release_win_data( data );
++}
++
++
+ /***********************************************************************
+  *           X11DRV_PropertyNotify
+  */
+ static BOOL X11DRV_PropertyNotify( HWND hwnd, XEvent *xev )
+ {
+     XPropertyEvent *event = &xev->xproperty;
++    char *name;
+ 
+     if (!hwnd) return FALSE;
++
++    name = XGetAtomName(event->display, event->atom);
++    if(name){
++        TRACE("win %p PropertyNotify atom: %s, state: 0x%x\n", hwnd, name, event->state);
++        XFree(name);
++    }
++
+     if (event->atom == x11drv_atom(WM_STATE)) handle_wm_state_notify( hwnd, event, TRUE );
++    else if (event->atom == x11drv_atom(_NET_WM_STATE)) handle__net_wm_state_notify( hwnd, event );
+     return TRUE;
+ }
+ 
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 319a28d6fa3..1d42801291c 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -1260,6 +1260,7 @@ static void unmap_window( HWND hwnd )
+ 
+         data->mapped = FALSE;
+         data->net_wm_state = 0;
++        data->pending_fullscreen = FALSE;
+     }
+     release_win_data( data );
+ }
+@@ -1276,6 +1277,7 @@ void make_window_embedded( struct x11drv_win_data *data )
+         if (!data->managed) XUnmapWindow( data->display, data->whole_window );
+         else XWithdrawWindow( data->display, data->whole_window, data->vis.screen );
+         data->net_wm_state = 0;
++        data->pending_fullscreen = FALSE;
+     }
+     data->embedded = TRUE;
+     data->managed = TRUE;
+@@ -1759,6 +1761,7 @@ static void destroy_whole_window( struct x11drv_win_data *data, BOOL already_des
+     data->whole_colormap = 0;
+     data->wm_state = WithdrawnState;
+     data->net_wm_state = 0;
++    data->pending_fullscreen = FALSE;
+     data->mapped = FALSE;
+     if (data->xic)
+     {
+diff --git a/dlls/winex11.drv/x11drv.h b/dlls/winex11.drv/x11drv.h
+index 91cb02b902e..9767fdcf681 100644
+--- a/dlls/winex11.drv/x11drv.h
++++ b/dlls/winex11.drv/x11drv.h
+@@ -621,6 +621,7 @@ struct x11drv_win_data
+     BOOL        use_alpha : 1;  /* does window use an alpha channel? */
+     BOOL        skip_taskbar : 1; /* does window should be deleted from taskbar */
+     BOOL        add_taskbar : 1; /* does window should be added to taskbar regardless of style */
++    BOOL        pending_fullscreen : 1;
+     int         wm_state;       /* current value of the WM_STATE property */
+     DWORD       net_wm_state;   /* bit mask of active x11drv_net_wm_state values */
+     Window      embedder;       /* window id of embedder */
+From 39000841d68b3d8401bd5602113fdc146fc1ee43 Mon Sep 17 00:00:00 2001
+From: Arkadiusz Hiler <ahiler@codeweavers.com>
+Date: Tue, 8 Jun 2021 16:01:54 +0300
+Subject: [PATCH] winex11.drv: Send missed KEYUP events on KeymapNotify.
+
+Full focus lost / focus gained events on the Windows side are not
+feasible for X11's FocusIn/FocusOut events generated by keyboard grabs
+(see XGrabKeyboard()) that are used for example for Atl+Tab handling.
+Using them would degrade user's experience, especially with our full
+screen hack, by causing the window to minimize or flash multiple times
+depending on a game/window manager combo.
+
+Because of that the programs may miss on some KEYUP events that happen
+during the grab, and since there are no focus changes on the Windows
+side the state doesn't get resynced.
+
+This change attempts to improve user experience by syncing any missed
+key release events that happened while the window haven't had focus on
+the X11 side.
+
+There's no syncing of key presses as those are more problematic because
+of window manager quirks, e.g. on KDE it may end up syncing the Tab
+press portion of Alt+Tab. Luckily missing key events for keys that were
+pressed and not released while the WM had the keyboard grab is not
+nearly as confusing as stuck keys.
+
+For Warhammer: Chaosbane, theHunter: Call of the Wild, Far Cry Primal
+and many other games that end up with stuck Alt after Alt+Tabbing.
+
+CW-Bug-ID: #17046
+CW-Bug-ID: #18904
+---
+ dlls/winex11.drv/event.c    |  2 ++
+ dlls/winex11.drv/keyboard.c | 43 +++++++++++++++++++++++++++++++++++--
+ dlls/winex11.drv/mouse.c    |  2 ++
+ dlls/winex11.drv/x11drv.h   |  1 +
+ 4 files changed, 46 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/winex11.drv/event.c b/dlls/winex11.drv/event.c
+index b59d4105557..271a70940f1 100644
+--- a/dlls/winex11.drv/event.c
++++ b/dlls/winex11.drv/event.c
+@@ -821,6 +821,8 @@ static BOOL X11DRV_FocusIn( HWND hwnd, XEvent *xev )
+     if (event->detail == NotifyPointer) return FALSE;
+     if (hwnd == NtUserGetDesktopWindow()) return FALSE;
+ 
++    x11drv_thread_data()->keymapnotify_hwnd = hwnd;
++
+     switch (event->mode)
+     {
+     case NotifyGrab:
+diff --git a/dlls/winex11.drv/keyboard.c b/dlls/winex11.drv/keyboard.c
+index d04d1db9102..720b4869544 100644
+--- a/dlls/winex11.drv/keyboard.c
++++ b/dlls/winex11.drv/keyboard.c
+@@ -1209,11 +1209,19 @@ BOOL X11DRV_KeymapNotify( HWND hwnd, XEvent *event )
+     int i, j;
+     BYTE keystate[256];
+     WORD vkey;
++    DWORD flags;
++    KeyCode keycode;
++    HWND keymapnotify_hwnd;
+     BOOL changed = FALSE;
+     struct {
+         WORD vkey;
++        WORD scan;
+         WORD pressed;
+     } keys[256];
++    struct x11drv_thread_data *thread_data = x11drv_thread_data();
++
++    keymapnotify_hwnd = thread_data->keymapnotify_hwnd;
++    thread_data->keymapnotify_hwnd = NULL;
+ 
+     if (!get_async_key_state( keystate )) return FALSE;
+ 
+@@ -1228,11 +1236,17 @@ BOOL X11DRV_KeymapNotify( HWND hwnd, XEvent *event )
+     {
+         for (j = 0; j < 8; j++)
+         {
+-            vkey = keyc2vkey[(i * 8) + j];
++            keycode = (i * 8) + j;
++            vkey = keyc2vkey[keycode];
+ 
+             /* If multiple keys map to the same vkey, we want to report it as
+              * pressed iff any of them are pressed. */
+-            if (!keys[vkey & 0xff].vkey) keys[vkey & 0xff].vkey = vkey;
++            if (!keys[vkey & 0xff].vkey)
++            {
++                keys[vkey & 0xff].vkey = vkey;
++                keys[vkey & 0xff].scan = keyc2scan[keycode] & 0xff;
++            }
++
+             if (event->xkeymap.key_vector[i] & (1<<j)) keys[vkey & 0xff].pressed = TRUE;
+         }
+     }
+@@ -1244,6 +1258,31 @@ BOOL X11DRV_KeymapNotify( HWND hwnd, XEvent *event )
+             TRACE( "Adjusting state for vkey %#.2x. State before %#.2x\n",
+                    keys[vkey].vkey, keystate[vkey]);
+ 
++            /* This KeymapNotify follows a FocusIn(mode=NotifyUngrab) event,
++             * which is caused by a keyboard grab being released.
++             * See XGrabKeyboard().
++             *
++             * We might have missed some key press/release events while the
++             * keyboard was grabbed, but keyboard grab doesn't generate focus
++             * lost / focus gained events on the Windows side, so the affected
++             * program is not aware that it needs to resync the keyboard state.
++             *
++             * This, for example, may cause Alt being stuck after using Alt+Tab.
++             *
++             * To work around that problem we sync any possible key releases.
++             *
++             * Syncing key presses is not feasible as window managers differ in
++             * event sequences, e.g. KDE performs two keyboard grabs for
++             * Alt+Tab, which would sync the Tab press.
++             */
++            if (keymapnotify_hwnd && !keys[vkey].pressed)
++            {
++                TRACE( "Sending KEYUP for a modifier %#.2x\n", vkey);
++                flags = KEYEVENTF_KEYUP;
++                if (keys[vkey].vkey & 0x1000) flags |= KEYEVENTF_EXTENDEDKEY;
++                X11DRV_send_keyboard_input( keymapnotify_hwnd, vkey, keys[vkey].scan, flags, NtGetTickCount() );
++            }
++
+             update_key_state( keystate, vkey, keys[vkey].pressed );
+             changed = TRUE;
+         }
+diff --git a/dlls/winex11.drv/mouse.c b/dlls/winex11.drv/mouse.c
+index 321b631d6ca..511550a8486 100644
+--- a/dlls/winex11.drv/mouse.c
++++ b/dlls/winex11.drv/mouse.c
+@@ -1796,6 +1796,8 @@ BOOL X11DRV_EnterNotify( HWND hwnd, XEvent *xev )
+ 
+     TRACE( "hwnd %p/%lx pos %d,%d detail %d\n", hwnd, event->window, event->x, event->y, event->detail );
+ 
++    x11drv_thread_data()->keymapnotify_hwnd = hwnd;
++
+     if (event->detail == NotifyVirtual) return FALSE;
+     if (hwnd == x11drv_thread_data()->grab_hwnd) return FALSE;
+ 
+diff --git a/dlls/winex11.drv/x11drv.h b/dlls/winex11.drv/x11drv.h
+index 52990283ce7..213143014a7 100644
+--- a/dlls/winex11.drv/x11drv.h
++++ b/dlls/winex11.drv/x11drv.h
+@@ -369,6 +369,7 @@ struct x11drv_thread_data
+     XEvent  *current_event;        /* event currently being processed */
+     HWND     grab_hwnd;            /* window that currently grabs the mouse */
+     HWND     last_focus;           /* last window that had focus */
++    HWND     keymapnotify_hwnd;    /* window that should receive modifier release events */
+     XIM      xim;                  /* input method */
+     HWND     last_xic_hwnd;        /* last xic window */
+     XFontSet font_set;             /* international text drawing font set */
+From c5aa20a70a5e681ba718feb7db9adc357cb7bec0 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Tue, 31 Aug 2021 00:41:15 +0300
+Subject: [PATCH] winex11.drv: HACK: Mind insert_after X11DRV_WindowPosChanged
+ in some cases.
+
+Fixes FH4 rendering black window until focus is lost.
+
+CW-Bug-Id: #19335
+---
+ dlls/winex11.drv/window.c | 50 ++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 44 insertions(+), 6 deletions(-)
+
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 4cd2324bff2..815a6279e59 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -1481,16 +1481,17 @@ void X11DRV_X_to_window_rect( struct x11drv_win_data *data, RECT *rect, int x, i
+  *
+  * Synchronize the X window position with the Windows one
+  */
+-static void sync_window_position( struct x11drv_win_data *data,
++static HWND sync_window_position( struct x11drv_win_data *data,
+                                   UINT swp_flags, const RECT *old_window_rect,
+                                   const RECT *old_whole_rect, const RECT *old_client_rect )
+ {
+     DWORD style = NtUserGetWindowLongW( data->hwnd, GWL_STYLE );
+     DWORD ex_style = NtUserGetWindowLongW( data->hwnd, GWL_EXSTYLE );
++    HWND prev_window = NULL;
+     XWindowChanges changes;
+     unsigned int mask = 0;
+ 
+-    if (data->managed && data->iconic) return;
++    if (data->managed && data->iconic) return NULL;
+ 
+     /* resizing a managed maximized window is not allowed */
+     if (!(style & WS_MAXIMIZE) || !data->managed)
+@@ -1529,9 +1530,10 @@ static void sync_window_position( struct x11drv_win_data *data,
+     {
+         /* find window that this one must be after */
+         HWND prev = NtUserGetWindowRelative( data->hwnd, GW_HWNDPREV );
++
+         while (prev && !(NtUserGetWindowLongW( prev, GWL_STYLE ) & WS_VISIBLE))
+             prev = NtUserGetWindowRelative( prev, GW_HWNDPREV );
+-        if (!prev)  /* top child */
++        if (!(prev_window = prev))  /* top child */
+         {
+             changes.stack_mode = Above;
+             mask |= CWStackMode;
+@@ -1577,6 +1580,8 @@ static void sync_window_position( struct x11drv_win_data *data,
+            data->whole_rect.right - data->whole_rect.left,
+            data->whole_rect.bottom - data->whole_rect.top,
+            changes.sibling, mask, data->configure_serial );
++
++    return prev_window;
+ }
+ 
+ 
+@@ -2733,6 +2738,25 @@ BOOL CDECL X11DRV_WindowPosChanging( HWND hwnd, HWND insert_after, UINT swp_flag
+ }
+ 
+ 
++static void restack_windows( struct x11drv_win_data *data, HWND prev )
++{
++    struct x11drv_win_data *prev_data;
++
++    TRACE("data->hwnd %p, prev %p.\n", data->hwnd, prev);
++
++    while (prev)
++    {
++        if (!(prev_data = get_win_data( prev ))) break;
++
++        TRACE( "Raising window %p.\n", prev );
++
++        if (prev_data->whole_window && data->display == prev_data->display)
++            XRaiseWindow( prev_data->display, prev_data->whole_window );
++        release_win_data( prev_data );
++        prev = NtUserGetWindowRelative( prev, GW_HWNDPREV );
++    }
++}
++
+ /***********************************************************************
+  *     WindowPosChanged   (X11DRV.@)
+  */
+@@ -2745,6 +2769,7 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+     struct x11drv_win_data *data;
+     DWORD new_style = NtUserGetWindowLongW( hwnd, GWL_STYLE );
+     RECT old_window_rect, old_whole_rect, old_client_rect;
++    HWND prev_window = NULL;
+     int event_type;
+ 
+     if (!(data = get_win_data( hwnd ))) return;
+@@ -2847,8 +2872,8 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+ 
+     /* don't change position if we are about to minimize or maximize a managed window */
+     if ((!event_type || event_type == PropertyNotify) &&
+-        !(data->managed && (swp_flags & SWP_STATECHANGED) && (new_style & (WS_MINIMIZE|WS_MAXIMIZE))))
+-        sync_window_position( data, swp_flags, &old_window_rect, &old_whole_rect, &old_client_rect );
++            !(data->managed && (swp_flags & SWP_STATECHANGED) && (new_style & (WS_MINIMIZE|WS_MAXIMIZE))))
++        prev_window = sync_window_position( data, swp_flags, &old_window_rect, &old_whole_rect, &old_client_rect );
+ 
+     if ((new_style & WS_VISIBLE) &&
+         ((new_style & WS_MINIMIZE) || is_window_rect_mapped( rectWindow )))
+@@ -2864,6 +2889,10 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+             release_win_data( data );
+             if (needs_icon) fetch_icon_data( hwnd, 0, 0 );
+             if (needs_map) map_window( hwnd, new_style );
++
++            if (!(data = get_win_data( hwnd ))) return;
++            restack_windows( data, prev_window );
++            release_win_data( data );
+             return;
+         }
+         else if ((swp_flags & SWP_STATECHANGED) && (!data->iconic != !(new_style & WS_MINIMIZE)))
+@@ -2880,10 +2909,20 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+         else
+         {
+             if (swp_flags & (SWP_FRAMECHANGED|SWP_STATECHANGED)) set_wm_hints( data );
+-            if (!event_type || event_type == PropertyNotify) update_net_wm_states( data );
++            if (!event_type || event_type == PropertyNotify)
++            {
++                update_net_wm_states( data );
++                if (!prev_window && insert_after && data->net_wm_state & (1 << NET_WM_STATE_FULLSCREEN))
++                {
++                    prev_window = NtUserGetWindowRelative( hwnd, GW_HWNDPREV );
++                    if (prev_window != insert_after) prev_window = NULL;
++                }
++            }
+         }
+     }
+ 
++    restack_windows( data, prev_window );
++
+     XFlush( data->display );  /* make sure changes are done before we start painting again */
+     if (data->surface && data->vis.visualid != default_visual.visualid)
+         data->surface->funcs->flush( data->surface );
+From 399675bd511cbfd57a44e3afaae32a9ddf6dac87 Mon Sep 17 00:00:00 2001
+From: Zhiyi Zhang <zzhang@codeweavers.com>
+Date: Wed, 11 Nov 2020 10:41:42 +0800
+Subject: [PATCH] winex11.drv: Call XIconifyWindow() after XMapWindow() with a
+ minimized window.
+
+Mutter always unminimizes a window when handling map requests. So a window could be in
+normal state as far as Mutter concerns while Wine mistakenly considers it still minimized.
+
+Fix Disgaea PC black screen after Alt+Tab in fullscreen mode.
+
+CW-Bug-Id: #18364
+Signed-off-by: Zhiyi Zhang <zzhang@codeweavers.com>
+---
+ dlls/winex11.drv/window.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 76d06b57814..b8cba02a0a8 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -1346,6 +1346,9 @@ static void map_window( HWND hwnd, DWORD new_style )
+             update_net_wm_states( data );
+             sync_window_style( data );
+             XMapWindow( data->display, data->whole_window );
++            /* Mutter always unminimizes windows when handling map requests. Restore iconic state */
++            if (new_style & WS_MINIMIZE)
++                XIconifyWindow( data->display, data->whole_window, data->vis.screen );
+             XFlush( data->display );
+             if (data->surface && data->vis.visualid != default_visual.visualid)
+                 data->surface->funcs->flush( data->surface );
+@@ -2947,9 +2950,17 @@ void CDECL X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, UINT swp_flags
+             data->iconic = (new_style & WS_MINIMIZE) != 0;
+             TRACE( "changing win %p iconic state to %u\n", data->hwnd, data->iconic );
+             if (data->iconic)
++            {
+                 XIconifyWindow( data->display, data->whole_window, data->vis.screen );
++            }
+             else if (is_window_rect_mapped( rectWindow ))
++            {
++                /* whole_window could be both iconic and mapped. Since XMapWindow() doesn't do
++                 * anything if the window is already mapped, we need to unmap it first */
++                if (data->mapped)
++                    XUnmapWindow( data->display, data->whole_window );
+                 XMapWindow( data->display, data->whole_window );
++            }
+             update_net_wm_states( data );
+         }
+         else
+From 1a33ba6c9617af4384601a7a0033fc6a62bb147c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Mon, 7 Mar 2022 16:53:09 +0100
+Subject: [PATCH] winex11.drv: Call SetForegroundWindow instead of
+ SetActiveWindow on restore.
+
+So that the window is both active and foreground before we send the
+SC_RESTORE command. Project Cars 3 expects that as it tries to reacquire
+DInput devices on SC_RESTORE.
+
+CW-Bug-Id: #19011
+CW-Bug-Id: #20227
+---
+ dlls/winex11.drv/event.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/winex11.drv/event.c b/dlls/winex11.drv/event.c
+index 7e262646811..15cc47f935a 100644
+--- a/dlls/winex11.drv/event.c
++++ b/dlls/winex11.drv/event.c
+@@ -1411,7 +1411,7 @@ static void handle_wm_state_notify( HWND hwnd, XPropertyEvent *event, BOOL updat
+                 TRACE( "restoring win %p/%lx\n", data->hwnd, data->whole_window );
+                 release_win_data( data );
+                 if ((style & (WS_MINIMIZE | WS_VISIBLE)) == (WS_MINIMIZE | WS_VISIBLE))
+-                    NtUserSetActiveWindow( hwnd );
++                    NtUserSetForegroundWindow( hwnd );
+                 send_message( hwnd, WM_SYSCOMMAND, SC_RESTORE, 0 );
+                 return;
+             }

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-22fa68b.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-22fa68b.patch
@@ -2915,6 +2915,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3994,6 +4062,56 @@ index db7baff269f..12881ab9697 100644
      create_dynamic_registry_keys();
      create_environment_registry_keys();
      create_computer_name_keys();
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From bdb21c72edcccc71416c399ed432ed5eab426e26 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:24:41 +0300
@@ -4175,3 +4293,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-8dd04c7.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-8dd04c7.patch
@@ -2887,6 +2887,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3736,6 +3804,56 @@ index db7baff269f..12881ab9697 100644
      create_environment_registry_keys();
      create_computer_name_keys();
 
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From 9bf094c8a6e962b969a1832613127bc4b7cf0fb3 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:17:41 +0300
@@ -3895,3 +4013,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-dfd5f10.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-dfd5f10.patch
@@ -2915,6 +2915,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3994,6 +4062,56 @@ index db7baff269f..12881ab9697 100644
      create_dynamic_registry_keys();
      create_environment_registry_keys();
      create_computer_name_keys();
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From bdb21c72edcccc71416c399ed432ed5eab426e26 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:24:41 +0300
@@ -4175,3 +4293,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-fefe108.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-fefe108.patch
@@ -2844,6 +2844,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3693,6 +3761,56 @@ index db7baff269f..12881ab9697 100644
      create_environment_registry_keys();
      create_computer_name_keys();
 
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From 9bf094c8a6e962b969a1832613127bc4b7cf0fb3 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:17:41 +0300
@@ -3852,3 +3970,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-fefe108.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/legacy/proton-tkg-staging-fefe108.patch
@@ -1681,39 +1681,51 @@ diff --git a/loader/wine.inf.in b/loader/wine.inf.in
 index 4df88d1f386..1506a73573b 100644
 --- a/loader/wine.inf.in
 +++ b/loader/wine.inf.in
-@@ -67,6 +67,7 @@ AddReg=\
+@@ -91,10 +91,11 @@ AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -95,6 +96,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo,\
+     LicenseInformation
+@@ -117,10 +118,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntamd64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -123,6 +125,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -142,10 +144,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntarm64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -142,6 +145,7 @@ AddReg=\
-     DirectX,\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -163,6 +166,7 @@ AddReg=\
      MCI,\
      Misc,\
 +    Packages.wow64,\
      Tapi,\
      VersionInfo.ntamd64,\
-     LicenseInformation, \
-@@ -234,6 +238,7 @@ CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
+     LicenseInformation
+ 
+@@ -247,6 +251,7 @@ CurrentVersion="Software\Microsoft\Windows\CurrentVersion"
  CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
  FontSubStr="Software\Microsoft\Windows NT\CurrentVersion\FontSubstitutes"
  Control="System\CurrentControlSet\Control"
@@ -1721,7 +1733,7 @@ index 4df88d1f386..1506a73573b 100644
  
  [Classes]
  HKCR,.chm,,2,"chm.file"
-@@ -1129,6 +1134,18 @@ HKLM,System\CurrentControlSet\Control\Nls\Locale\Alternate Sorts,"00030404",,"9"
+@@ -597,6 +602,18 @@ [OLE]
  HKLM,"Software\Microsoft\OLE","EnableDCOM",,"Y"
  HKLM,"Software\Microsoft\OLE","EnableRemoteConnect",,"N"
  

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/proton-tkg-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/proton-tkg-staging.patch
@@ -1669,39 +1669,51 @@ diff --git a/loader/wine.inf.in b/loader/wine.inf.in
 index 4df88d1f386..1506a73573b 100644
 --- a/loader/wine.inf.in
 +++ b/loader/wine.inf.in
-@@ -67,6 +67,7 @@ AddReg=\
+@@ -91,10 +91,11 @@ AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -95,6 +96,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo,\
+     LicenseInformation
+@@ -117,10 +118,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntamd64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -123,6 +125,7 @@ AddReg=\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -142,10 +144,11 @@  AddReg=\
+     MCI,\
      Misc,\
-     Nls,\
      OLE,\
 +    Packages.ntarm64,\
      Printing,\
      Services, \
      SessionMgr,\
-@@ -142,6 +145,7 @@ AddReg=\
-     DirectX,\
+     Tapi,\
+     ThemeManager,\
+     VersionInfo.ntamd64,\
+     LicenseInformation
+@@ -163,6 +166,7 @@ AddReg=\
      MCI,\
      Misc,\
 +    Packages.wow64,\
      Tapi,\
      VersionInfo.ntamd64,\
-     LicenseInformation, \
-@@ -234,6 +238,7 @@ CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
+     LicenseInformation
+ 
+@@ -247,6 +251,7 @@ CurrentVersion="Software\Microsoft\Windows\CurrentVersion"
  CurrentVersionNT="Software\Microsoft\Windows NT\CurrentVersion"
  FontSubStr="Software\Microsoft\Windows NT\CurrentVersion\FontSubstitutes"
  Control="System\CurrentControlSet\Control"
@@ -1709,7 +1721,7 @@ index 4df88d1f386..1506a73573b 100644
  
  [Classes]
  HKCR,.chm,,2,"chm.file"
-@@ -1129,6 +1134,18 @@ HKLM,System\CurrentControlSet\Control\Nls\Locale\Alternate Sorts,"00030404",,"9"
+@@ -597,6 +602,18 @@ [OLE]
  HKLM,"Software\Microsoft\OLE","EnableDCOM",,"Y"
  HKLM,"Software\Microsoft\OLE","EnableRemoteConnect",,"N"
  

--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/proton-tkg-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/staging/proton-tkg-staging.patch
@@ -2832,6 +2832,74 @@ index 82e5fbf811d..b1153ac4927 100644
          UINT sync_interval, UINT flags, const DXGI_PRESENT_PARAMETERS *present_parameters)
  {
      struct d3d11_swapchain *swapchain = d3d11_swapchain_from_IDXGISwapChain1(iface);
+From 0262122fc328410e6b0b410837c35881b3aa85af Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Mon, 19 Apr 2021 15:29:39 +0300
+Subject: [PATCH] winevulkan: Don't hardcode performance frequency.
+
+For Forza Horizon 4.
+---
+ dlls/winevulkan/loader.c    | 33 +++++++++++++++++++++++++++++++++
+ dlls/winevulkan/make_vulkan |  2 +-
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winevulkan/loader.c b/dlls/winevulkan/loader.c
+index d3ac9f57763..fcb79983114 100644
+--- a/dlls/winevulkan/loader.c
++++ b/dlls/winevulkan/loader.c
+@@ -442,6 +442,39 @@ void WINAPI vkGetPhysicalDeviceProperties2KHR(VkPhysicalDevice phys_dev,
+     }
+ }
+ 
++VkResult WINAPI vkGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount, const VkCalibratedTimestampInfoEXT *pTimestampInfos, uint64_t *pTimestamps, uint64_t *pMaxDeviation)
++{
++    struct vkGetCalibratedTimestampsEXT_params params;
++    static LARGE_INTEGER freq;
++    VkResult res;
++    uint32_t i;
++
++    if (!freq.QuadPart)
++    {
++        LARGE_INTEGER temp;
++
++        QueryPerformanceFrequency(&temp);
++        InterlockedCompareExchange64(&freq.QuadPart, temp.QuadPart, 0);
++    }
++
++    params.device = device;
++    params.timestampCount = timestampCount;
++    params.pTimestampInfos = pTimestampInfos;
++    params.pTimestamps = pTimestamps;
++    params.pMaxDeviation = pMaxDeviation;
++    res = vk_unix_call(unix_vkGetCalibratedTimestampsEXT, &params);
++    if (res != VK_SUCCESS)
++        return res;
++
++    for (i = 0; i < timestampCount; i++)
++    {
++        if (pTimestampInfos[i].timeDomain != VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) continue;
++        pTimestamps[i] *= freq.QuadPart / 10000000;
++    }
++
++    return VK_SUCCESS;
++}
++
+ static BOOL WINAPI call_vulkan_debug_report_callback( struct wine_vk_debug_report_params *params, ULONG size )
+ {
+     return params->user_callback(params->flags, params->object_type, params->object_handle, params->location,
+diff --git a/dlls/winevulkan/make_vulkan b/dlls/winevulkan/make_vulkan
+index 516c817715f..a0287c1ff09 100755
+--- a/dlls/winevulkan/make_vulkan
++++ b/dlls/winevulkan/make_vulkan
+@@ -254,7 +254,7 @@ FUNCTION_OVERRIDES = {
+ 
+     # VK_EXT_calibrated_timestamps
+     "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+-    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
++    "vkGetCalibratedTimestampsEXT" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.PRIVATE},
+ 
+     # VK_EXT_debug_utils
+     "vkCreateDebugUtilsMessengerEXT" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
 From fec2ecbd2dfd3c357f63c8f7bd9383b7a10d4553 Mon Sep 17 00:00:00 2001
 From: Esme Povirk <esme@codeweavers.com>
 Date: Thu, 22 Apr 2021 14:35:40 -0500
@@ -3681,6 +3749,56 @@ index db7baff269f..12881ab9697 100644
      create_environment_registry_keys();
      create_computer_name_keys();
 
+From 3244ba9966c0e7bcd445a65b5c325801f9b77131 Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Wed, 5 Jan 2022 13:31:14 +0300
+Subject: [PATCH] audioses: Add stub dll.
+
+CW-Bug-Id: #19918
+---
+ configure.ac                |  1 +
+ dlls/audioses/Makefile.in   |  1 +
+ dlls/audioses/audioses.spec | 11 +++++++++++
+ 3 files changed, 13 insertions(+)
+ create mode 100644 dlls/audioses/Makefile.in
+ create mode 100644 dlls/audioses/audioses.spec
+
+diff --git a/configure.ac b/configure.ac
+index f37f4e02324..95f9a35bf7f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2625,6 +2625,7 @@ WINE_CONFIG_MAKEFILE(dlls/atl90)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk)
+ WINE_CONFIG_MAKEFILE(dlls/atlthunk/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atmlib)
++WINE_CONFIG_MAKEFILE(dlls/audioses)
+ WINE_CONFIG_MAKEFILE(dlls/authz)
+ WINE_CONFIG_MAKEFILE(dlls/avicap32)
+ WINE_CONFIG_MAKEFILE(dlls/avifil32)
+diff --git a/dlls/audioses/Makefile.in b/dlls/audioses/Makefile.in
+new file mode 100644
+index 00000000000..370949ea4fe
+--- /dev/null
++++ b/dlls/audioses/Makefile.in
+@@ -0,0 +1 @@
++MODULE    = audioses.dll
+diff --git a/dlls/audioses/audioses.spec b/dlls/audioses/audioses.spec
+new file mode 100644
+index 00000000000..a1884e53243
+--- /dev/null
++++ b/dlls/audioses/audioses.spec
+@@ -0,0 +1,11 @@
++# @ stub AUDIOSES_1
++# @ stub AUDIOSES_2
++# @ stub AUDIOSES_3
++# @ stub AUDIOSES_4
++# @ stub AUDIOSES_5
++# @ stub DllCanUnloadNow
++# @ stub AUDIOSES_7
++# @ stub DllGetActivationFactory
++# @ stub DllGetClassObject
++# @ stub DllRegisterServer
++# @ stub DllUnregisterServer
 From 9bf094c8a6e962b969a1832613127bc4b7cf0fb3 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Thu, 10 Feb 2022 16:17:41 +0300
@@ -3840,3 +3958,28 @@ index 7e317912dc9..625f487251f 100755
  ]
 
  # Functions part of our winevulkan graphics driver interface.
+From 59b705ed31d38065c12f44e281dc8c18d5024acf Mon Sep 17 00:00:00 2001
+From: Paul Gofman <pgofman@codeweavers.com>
+Date: Fri, 16 Sep 2022 17:14:54 -0500
+Subject: [PATCH] fixup! ntdll: Guard against syscall stack overrun.
+
+Make guard pages readable.
+
+CW-Bug-Id: #21305
+---
+ dlls/ntdll/unix/virtual.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 550d7f41dec..8dfe3da0a7e 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3271,7 +3271,7 @@ NTSTATUS virtual_alloc_thread_stack( INITIAL_TEB *stack, ULONG_PTR zero_bits, SI
+         }
+         /* setup kernel stack no access guard page */
+         kernel_stack = (char *)view->base + view->size;
+-        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED );
++        set_page_vprot( kernel_stack, kernel_stack_guard_size, VPROT_COMMITTED | VPROT_READ );
+         mprotect_range( kernel_stack, kernel_stack_guard_size, 0, 0 );
+     }
+ 


### PR DESCRIPTION
Allows running Forza Horizon 4/5 with wine-tkg.

A few patches from the FS hack (although not directly related to that functionality) rebased to the latest Wine tree and added as an additional patch. The patch only applies on _protonify and inactive _proton_fs_hack. That way the games can be used without the FS hack and also avoid all the reverts :).