### PR TITLE
[wine-tkg] Call tool/make_makefile after userpatch application, plus a autoconf fix

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/hotfixes
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Patch opencl.h header to it's correct location without breaking successive autoconf call, as it was done by the sed workaround
+if ( cd "${srcdir}"/"${_winesrcdir}" ); then
+  warning "Hotfix: Fix for CL/opencl.h header recognition"
+  _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup)
+fi

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup.mypatch
@@ -1,0 +1,52 @@
+From 7b06d5e9906ebb92d4a1dae2fb04120e9c1b60dd Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Thu, 17 Nov 2022 15:25:45 +0100
+Subject: [PATCH] Explicitly define HAVE_OPENCL_OPENCL_H when checking opencl.h
+ header and use Cl/opencl.h instead
+
+---
+ configure.ac | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 2bb09f618c7..9cc74660864 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -50,7 +50,7 @@ AC_ARG_WITH(netapi,    AS_HELP_STRING([--without-netapi],[do not use the Samba N
+ AC_ARG_WITH(openal,    AS_HELP_STRING([--without-openal],[do not use OpenAL]),
+             [if test "x$withval" = "xno"; then ac_cv_header_AL_al_h=no; ac_cv_header_OpenAL_al_h=no; fi])
+ AC_ARG_WITH(opencl,    AS_HELP_STRING([--without-opencl],[do not use OpenCL]),
+-            [if test "x$withval" = "xno"; then ac_cv_header_CL_cl_h=no; ac_cv_header_OpenCL_opencl_h=no; fi])
++            [if test "x$withval" = "xno"; then ac_cv_header_CL_cl_h=no; ac_cv_header_CL_opencl_h=no; fi])
+ AC_ARG_WITH(opengl,    AS_HELP_STRING([--without-opengl],[do not use OpenGL]))
+ AC_ARG_WITH(osmesa,     AS_HELP_STRING([--without-osmesa],[do not use the OSMesa library]))
+ AC_ARG_WITH(oss,       AS_HELP_STRING([--without-oss],[do not use the OSS sound support]))
+@@ -430,7 +430,6 @@ AC_CHECK_HEADERS(\
+ 	IOKit/IOKitLib.h \
+ 	IOKit/hid/IOHIDLib.h \
+ 	OpenAL/al.h \
+-	OpenCL/opencl.h \
+ 	Security/Security.h \
+ 	SystemConfiguration/SCDynamicStoreCopyDHCPInfo.h \
+ 	SystemConfiguration/SCNetworkConfiguration.h \
+@@ -515,6 +514,8 @@ AC_CHECK_HEADERS(\
+ 	valgrind/memcheck.h \
+ 	valgrind/valgrind.h
+ )
++dnl Wine use HAVE_OPENCL_OPENCL_H to condition, explicit it.
++AC_CHECK_HEADER(CL/opencl.h,[AC_DEFINE(HAVE_OPENCL_OPENCL_H, 1, [Define to 1 if you have the <CL/opencl.h> header file.])])
+ WINE_HEADER_MAJOR()
+ AC_HEADER_STAT()
+ 
+@@ -754,7 +755,7 @@ case $host_os in
+         AC_DEFINE_UNQUOTED(HAVE_OPENAL,1,[Define to 1 if OpenAL is available])
+         ac_cv_lib_openal=yes
+     fi
+-    if test "$ac_cv_header_OpenCL_opencl_h" = "yes"
++    if test "$ac_cv_header_CL_opencl_h" = "yes"
+     then
+         AC_SUBST(OPENCL_LIBS,"-framework OpenCL")
+         ac_cv_lib_OpenCL_clGetPlatformInfo=yes
+-- 
+2.38.1
+

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -42,6 +42,7 @@ if [ "$_unfrog" != "true" ]; then
   #_hotfix="RtlGetCurrentUmsThread" _hotfix_boundary="" _hotfix_import # This doesn't actually fix https://bugs.winehq.org/show_bug.cgi?id=51990
   _hotfix="EGS" _hotfix_boundary="" _hotfix_import
   _hotfix="ow2" _hotfix_boundary="" _hotfix_import
+  _hotfix="autoconf-opencl-hotfix" _hotfix_boundary="" _hotfix_import
 
   # Custom hotfix patches with a commit boundary
   _hotfix="fd799297" _hotfix_boundary="1f6423f778f7036a3875613e10b9c8c3b84584f0" _hotfix_import

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -1023,8 +1023,10 @@ _polish() {
 
 	echo "" >> "$_where"/last_build_config.log
 
-    source "$_where"/wine-tkg-patches/misc/wine-tkg/wine-tkg
+	source "$_where"/wine-tkg-patches/misc/wine-tkg/wine-tkg
 
+	git add * && true
+	tools/make_makefiles
 	echo -e "\nRunning make_vulkan" >> "$_where"/prepare.log && dlls/winevulkan/make_vulkan >> "$_where"/prepare.log 2>&1
 	tools/make_requests
 	autoreconf -fiv
@@ -1112,9 +1114,6 @@ _polish() {
 	    sed -i "s|-lldap_r|-lldap|" "$srcdir/$_winesrcdir/configure"
 	  fi
 	fi
-
-	# fix path of opencl headers
-	sed 's|OpenCL/opencl.h|CL/opencl.h|g' -i configure*
 
 	_commitmsg="07-tags-n-polish" _committer
 


### PR DESCRIPTION
Hi. As  I was writing on discord yesterday, currently wine-tkg doesn't call tools/make_makefiles however it seems to include at least one patch that cause doesn't properly include the configure.ac changes. 
This can be seen after the preparation step by using the following commands in the wine_mirror-git folder
git add * (to add all files to git )
git commit -m "base"  (create a base commit)
./tools/make_makefiles
git diff

It's possible to see various changes around nv* dlls (this is with staging, protonify, sharedgpures), a sign it wasn't updated properly before

The change in this PR also allow to use properly patchset that doesn't properly provide configure.ac modifications for added or modified dlls. And also allow  is to remove most of the configure/configure.ac parts of the patchsets.

Linked there is the other issue.

To fix opencl.h the prepare.sh sciprt is doing a sed pass to replace OpenCL/opencl.h to CL/opencl.h in configure and configure.ac (to avoid autoconf issues), however the second changes have issues.
AC_CHECK_HEADERS use the name of the header to generate the cache var and the define. With OpenCL/opencl.h it was generating:
HAVE_OPENCL_OPENCL_H as a define guard
ac_cv_header_OpenCL_opencl_h as a cache var of the result

The first is used inside wine source and the second is used later in the configure.ac script itself
Now when I use autoreconf with the new header value it change how these are generated, generating:
HAVE_CL_OPENCL_H as a define guard
ac_cv_header_CL_opencl_h as a cache var of the result

however both are senseless in the optic of the configure script and wine code.

The patch is more complex and exact:
It remove the header check from the AC_CHECK_HEADERS and use AC_CHECK_HEADER to make  a check for this specific header. When the header is found I explictily  define the guard HAVE_OPENCL_OPENCL_H
the other script part where it was using ac_cv_header_OpenCL_opencl_h  are changed to use ac_cv_header_CL_opencl_h
(as what variable it generate for the result cannot be changed)

Now autoreconf doesn't break opencl anymore



