### PR TITLE
Add explanation why nightly builds can't be downloaded for users that are not logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wine to rule them all !
 
+You must be logged in to GitHub in order to download Wine or Proton nightly builds.
+
 ## Wine nightly builds
 
 - wine-staging patchset applied


### PR DESCRIPTION
An option to download nightly builds without logging in would be better, but in this way there is at least an explanation.