### PR TITLE
Implement single-make mode

### DIFF
--- a/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
@@ -82,6 +82,9 @@ _NOCOMPILE="false"
 # Set to true if you want to skip the initial prompt
 _NOINITIALPROMPT="false"
 
+# Set to true to build 64-bit and 32-bit wine in parallel (Experimental)
+_SINGLE_MAKE="false"
+
 # Optionally set additional dependencies for makepkg builds. Multiple elements should be separated by a space.
 # Only affect makepkg
 _user_deps=""

--- a/wine-tkg-git/wine-tkg-scripts/Makefile.single
+++ b/wine-tkg-git/wine-tkg-scripts/Makefile.single
@@ -1,0 +1,45 @@
+.POSIX:
+
+SHELL = bash
+
+all: build64 build32
+
+configure64:
+	set +e; \
+	. "$$_FROGMINER_VARFILE" 2>/dev/null ||:; \
+	unset _FROGMINER_VARFILE _SINGLE_MAKE; \
+	_SINGLE_MAKE=true; \
+	. "$$_where"/wine-tkg-scripts/build-64.sh; \
+	_exports_64; \
+	_configure_64 $(MAKE); \
+	_tools_64 $(MAKE)
+
+configure32: configure64
+	set +e; \
+	. "$$_FROGMINER_VARFILE" 2>/dev/null ||:; \
+	unset _FROGMINER_VARFILE _SINGLE_MAKE; \
+	_SINGLE_MAKE=true; \
+	. "$$_where"/wine-tkg-scripts/build-32.sh; \
+	_exports_32; \
+	_configure_32 $(MAKE)
+
+build64: configure32
+	set +e; \
+	. "$$_FROGMINER_VARFILE" 2>/dev/null ||:; \
+	unset _FROGMINER_VARFILE _SINGLE_MAKE; \
+	_SINGLE_MAKE=true; \
+	. "$$_where"/wine-tkg-scripts/build-64.sh; \
+	_LAST_BUILD_CONFIG=/dev/null _exports_64; \
+	_build_64 $(MAKE)
+
+build32: configure32
+	set +e; \
+	. "$$_FROGMINER_VARFILE" 2>/dev/null ||:; \
+	unset _FROGMINER_VARFILE _SINGLE_MAKE; \
+	_SINGLE_MAKE=true; \
+	. "$$_where"/wine-tkg-scripts/build-32.sh; \
+	_LAST_BUILD_CONFIG=/dev/null _exports_32; \
+	_build_32 $(MAKE)
+
+.PHONY: all configure64 configure32 build64 build32
+.ONESHELL:

--- a/wine-tkg-git/wine-tkg-scripts/build-32.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build-32.sh
@@ -1,0 +1,67 @@
+_exports_32() {
+  if [ "$_NOCCACHE" != "true" ]; then
+	if [ -e /usr/bin/ccache ]; then
+		export CC="ccache gcc"
+		export CXX="ccache g++"
+	fi
+	if [ -e /usr/bin/ccache ] && [ "$_NOMINGW" != "true" ]; then
+		export CROSSCC="ccache i686-w64-mingw32-gcc" && echo "CROSSCC32 = ${CROSSCC}" >>"$_LAST_BUILD_CONFIG"
+	fi
+  fi
+  # build wine 32-bit
+  if [ -d '/usr/lib32/pkgconfig' ]; then # Typical Arch path
+    export PKG_CONFIG_PATH='/usr/lib32/pkgconfig'
+  elif [ -d '/usr/lib/i386-linux-gnu/pkgconfig' ]; then # Ubuntu 18.04/19.04 path
+    export PKG_CONFIG_PATH='/usr/lib/i386-linux-gnu/pkgconfig'
+  else
+    export PKG_CONFIG_PATH='/usr/lib/pkgconfig' # Pretty common path, possibly helpful for OpenSuse & Fedora
+  fi
+}
+
+_configure_32() {
+  msg2 'Configuring Wine-32...'
+  cd "${srcdir}/${pkgname}"-32-build
+  if [ "$_NUKR" != "debug" ] || [[ "$_DEBUGANSW3" =~ [yY] ]]; then
+	 if [ "$_NOLIB64" = "true" ]; then
+       ../"${_winesrcdir}"/configure \
+	      --prefix="$_prefix" \
+	      "${_configure_args32[@]}" \
+	      "${_configure_args[@]}"
+	  else
+        ../"${_winesrcdir}"/configure \
+	      --prefix="$_prefix" \
+	      "${_configure_args32[@]}" \
+	      "${_configure_args[@]}" \
+	      --with-wine64="${srcdir}/${pkgname}"-64-build
+	 fi
+  fi
+  if [ "$_pkg_strip" != "true" ]; then
+    msg2 "Disable strip"
+    sed 's|STRIP = strip|STRIP =|g' "${srcdir}/${pkgname}"-32-build/Makefile -i
+  fi
+}
+
+_build_32() {
+  msg2 'Building Wine-32...'
+  cd "${srcdir}/${pkgname}"-32-build
+  if [ "$_SINGLE_MAKE" = 'true' ]; then
+    MAKEFLAGS="${MFLAGS#-j* }"
+    exec "$@"
+  elif [ "$_LOCAL_OPTIMIZED" = 'true' ]; then
+    # make using all available threads
+    if [ "$_log_errors_to_file" = "true" ]; then
+      make -j$(nproc) 2> "$_where/debug.log"
+    else
+      #_buildtime32=$( time ( make -j$(nproc) 2>&1 ) 3>&1 1>&2 2>&3 ) - Bash 5.2 is frogged - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1018727
+      make -j$(nproc)
+    fi
+  else
+    # make using makepkg settings
+    if [ "$_log_errors_to_file" = "true" ]; then
+      make 2> "$_where/debug.log"
+    else
+      #_buildtime32=$( time ( make 2>&1 ) 3>&1 1>&2 2>&3 ) - Bash 5.2 is frogged - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1018727
+      make
+    fi
+  fi
+}

--- a/wine-tkg-git/wine-tkg-scripts/build-64.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build-64.sh
@@ -1,0 +1,65 @@
+_exports_64() {
+  if [ "$_NOCCACHE" != "true" ]; then
+	if [ -e /usr/bin/ccache ]; then
+		export CC="ccache gcc" && echo "CC = ${CC}" >>"$_LAST_BUILD_CONFIG"
+		export CXX="ccache g++" && echo "CXX = ${CXX}" >>"$_LAST_BUILD_CONFIG"
+	fi
+	if [ -e /usr/bin/ccache ] && [ "$_NOMINGW" != "true" ]; then
+		export CROSSCC="ccache x86_64-w64-mingw32-gcc" && echo "CROSSCC64 = ${CROSSCC}" >>"$_LAST_BUILD_CONFIG"
+	fi
+  fi
+  # If /usr/lib32 doesn't exist (such as on Fedora), make sure we're using /usr/lib64 for 64-bit pkgconfig path
+  if [ ! -d '/usr/lib32' ]; then
+    export PKG_CONFIG_PATH='/usr/lib64/pkgconfig'
+  fi
+}
+
+_configure_64() {
+  msg2 'Configuring Wine-64...'
+  cd  "${srcdir}"/"${pkgname}"-64-build
+  if [ "$_NUKR" != "debug" ] || [[ "$_DEBUGANSW3" =~ [yY] ]]; then
+  chmod +x ../"${_winesrcdir}"/configure
+    ../"${_winesrcdir}"/configure \
+	    --prefix="$_prefix" \
+		--enable-win64 \
+		"${_configure_args64[@]}" \
+		"${_configure_args[@]}"
+  fi
+  if [ "$_pkg_strip" != "true" ]; then
+    msg2 "Disable strip"
+    sed 's|STRIP = strip|STRIP =|g' "${srcdir}/${pkgname}"-64-build/Makefile -i
+  fi
+}
+
+# Needed for _SINGLE_MAKE build
+_tools_64() (
+  msg2 'Building Wine-64 Tools...'
+  shopt -s globstar
+  for mkfile in tools/Makefile tools/**/Makefile; do
+    "$@" -C "${mkfile%/Makefile}"
+  done
+)
+
+_build_64() {
+  msg2 'Building Wine-64...'
+  cd  "${srcdir}"/"${pkgname}"-64-build
+  if [ "$_SINGLE_MAKE" = 'true' ]; then
+    exec "$@"
+  elif [ "$_LOCAL_OPTIMIZED" = 'true' ]; then
+    # make using all available threads
+    if [ "$_log_errors_to_file" = "true" ]; then
+      make -j$(nproc) 2> "$_where/debug.log"
+    else
+      #_buildtime64=$( time ( make -j$(nproc) 2>&1 ) 3>&1 1>&2 2>&3 ) - Bash 5.2 is frogged - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1018727
+      make -j$(nproc)
+    fi
+  else
+    # make using makepkg settings
+    if [ "$_log_errors_to_file" = "true" ]; then
+      make 2> "$_where/debug.log"
+    else
+      #_buildtime64=$( time ( make 2>&1 ) 3>&1 1>&2 2>&3 ) - Bash 5.2 is frogged - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1018727
+      make
+    fi
+  fi
+}


### PR DESCRIPTION
This allows building 64-bit and 32-bit Wine in parallel, using GNU Make's jobserver to limit the number of processes.

Reason: Some parts of Wine (e.g. actxprxy_shobjidl_p.c) take quite long to compile with high optimization flags, it would be nice if those parts wouldn't effectively halt the compilation process.

The name of the variable may be a little bit wrong, since we are actually starting multiple `make` processes, but there's only one jobserver. Eh, whatever.