### PR TITLE
Fix the gitignore not ignoring wine-tkg-git/src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 *.old
 *.db
 *.files
-*/src/
+*/src
 */pkg/
 wine-tkg-git/wine-staging-git/
 wine-tkg-git/wine-git/


### PR DESCRIPTION
This might affect other directories too, but I'm only interested in fixing this one.

If I find any other directories that need to be ignored, I'll make another MR including them.