### PR TITLE
fastsync: Add some "QoL things" for testers

### DIFF
--- a/proton-tkg/proton-tkg-profiles/sample-external-config.cfg
+++ b/proton-tkg/proton-tkg-profiles/sample-external-config.cfg
@@ -156,9 +156,11 @@ _use_GE_patches="true"
 # ! Make sure to disable staging if your source isn't compatible with it or it will fail to apply !
 _custom_wine_source=""
 
-# fastsync - disable at runtime with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable winesync/fastsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
-# !! on plain: Disables esync / fsync support !!
-# !! on staging: Requires fsync support !!
+# NTsync - Disable with PROTON_NO_NTSYNC=1 or WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable NTsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
+# more info about NTsync and feedback topic - https://github.com/Frogging-Family/wine-tkg-git/issues/936
+# !! For building and using requires special linux-tkg build with winesync module and header (or https://aur.archlinux.org/packages/winesync-dkms/) !!
+# !! Not compatible with Valve trees and some other patches. On Staging depends on fsync patches !!
+# !! For plain Wine required disabling esync and fsync patches applying !!
 _use_fastsync="false"
 
 _use_esync="true"

--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -69,9 +69,11 @@ _LOCAL_PRESET=""
 # List of patches applied with this option enabled: assettocorsa-hud killer-instinct-winevulkan_fix FFVII-and-SpecialK-powerprof 65-proton-fake_current_res_patches unity_crash_hotfix Fix-regression-introduced-by-0e7fd41 15aa8c6-fix-star-citizen-bug-52956 0001-winex11.drv-Define-ControlMask-when-not-available 0002-include-Add-THREAD_POWER_THROTTLING_STATE-type 0003-ntdll-Fake-success-for-ThreadPowerThrottlingState
 _use_GE_patches="true"
 
-# fastsync - disable at runtime with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable winesync/fastsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
-# !! on plain: Disables esync / fsync support !!
-# !! on staging: Requires fsync support !!
+# NTsync - Disable with PROTON_NO_NTSYNC=1 or WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable NTsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
+# more info about NTsync and feedback topic - https://github.com/Frogging-Family/wine-tkg-git/issues/936
+# !! For building and using requires special linux-tkg build with winesync module and header (or https://aur.archlinux.org/packages/winesync-dkms/) !!
+# !! Not compatible with Valve trees and some other patches. On Staging depends on fsync patches !!
+# !! For plain Wine required disabling esync and fsync patches applying !!
 _use_fastsync="false"
 
 _use_esync="true"

--- a/proton-tkg/proton-tkg.sh
+++ b/proton-tkg/proton-tkg.sh
@@ -1163,13 +1163,6 @@ else
       sed -i "s|.*PROTON_BYPASS_SHADERCACHE_PATH.*|     \"PROTON_BYPASS_SHADERCACHE_PATH\": \"${_proton_shadercache_path}\",|g" "proton_tkg_$_protontkg_version/user_settings.py"
     fi
 
-    # Disable esync/fsync by default when fastsync is enabled
-    if [ "$_use_fastsync" = "true" ]; then
-      sed -i 's/.*PROTON_NO_ESYNC.*/     "PROTON_NO_ESYNC": "1",/g' "proton_tkg_$_protontkg_version/user_settings.py"
-      sed -i 's/.*PROTON_NO_FSYNC.*/     "PROTON_NO_FSYNC": "1",/g' "proton_tkg_$_protontkg_version/user_settings.py"
-      sed -i 's/.*PROTON_NO_FUTEX2.*/     "PROTON_NO_FUTEX2": "1",/g' "proton_tkg_$_protontkg_version/user_settings.py"
-    fi
-
     # Use the corresponding DXVK/D9VK combo options
     if [ "$_use_dxvk" != "false" ]; then
       sed -i 's/.*PROTON_USE_WINED3D11.*/#     "PROTON_USE_WINED3D11": "1",/g' "proton_tkg_$_protontkg_version/user_settings.py"

--- a/proton-tkg/proton_template/conf/proton
+++ b/proton-tkg/proton_template/conf/proton
@@ -1499,6 +1499,7 @@ class Session:
         self.check_environment("PROTON_NO_ESYNC", "noesync")
         self.check_environment("PROTON_NO_FSYNC", "nofsync")
         self.check_environment("PROTON_NO_FUTEX2", "nofutex2")
+        self.check_environment("PROTON_NO_NTSYNC", "nontsync")
         self.check_environment("PROTON_DISABLE_LARGE_ADDRESS_AWARE", "disablelgadd")
         self.check_environment("PROTON_OLD_GL_STRING", "oldglstr")
         self.check_environment("PROTON_USE_SECCOMP", "seccomp")
@@ -1550,6 +1551,11 @@ class Session:
             self.env["WINEFSYNC_FUTEX2"] = "0"
         else:
             self.env["WINEFSYNC_FUTEX2"] = "1"
+
+        if "nontsync" in self.compat_config:
+            self.env.pop("WINE_DISABLE_FAST_SYNC", "1")
+        else:
+            self.env["WINE_DISABLE_FAST_SYNC"] = "0"
 
         if "seccomp" in self.compat_config:
             self.env["WINESECCOMP"] = "1"

--- a/proton-tkg/proton_template/conf/user_settings.py
+++ b/proton-tkg/proton_template/conf/user_settings.py
@@ -105,6 +105,9 @@ user_settings = {
     #Disable futex2-based in-process synchronization primitives
 #    "PROTON_NO_FUTEX2": "1",
 
+    #Disable support for fast (one syscall per NT syscall) synchronization primitives using the winesync driver in the kernel
+#    "PROTON_NO_NTSYNC": "1",
+
     #Enforce driver shader cache path when Steam's shader pre-caching is disabled
 #    "PROTON_BYPASS_SHADERCACHE_PATH": "",
 }

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -55,9 +55,11 @@ _use_staging="true"
 # Leave empty to use latest master - https://github.com/wine-staging/wine-staging/commits/master
 _staging_version=""
 
-# fastsync - disable at runtime with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable winesync/fastsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
-# !! on plain: Disables esync / fsync support !!
-# !! on staging: Requires fsync support !!
+# NTsync - Disable with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable NTsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
+# more info about NTsync and feedback topic - https://github.com/Frogging-Family/wine-tkg-git/issues/936
+# !! For building and using requires special linux-tkg build with winesync module and header (or https://aur.archlinux.org/packages/winesync-dkms/) !!
+# !! Not compatible with Valve trees and some other patches. On Staging depends on fsync patches !!
+# !! For plain Wine required disabling esync and fsync patches applying !!
 _use_fastsync="false"
 
 # esync - Enable with WINEESYNC=1 envvar - Set to true to enable esync support on plain wine or wine-staging <4.6 (it got merged in wine-staging 4.6). The option is ignored on wine-staging 4.6+

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
@@ -1,7 +1,23 @@
 #!/bin/bash
 
-	# winesync / fastsync
+	# fastsync / winesync
 	if [ "$_use_fastsync" = "true" ]; then
+
+	  # check Linux headers
+	  winesync_header_check=$(echo '#include <linux/winesync.h>' | gcc -H -E -fsyntax-only - 2>&1 | head -n1 | cut -d' ' -f2-)
+	  if [[ ! -s $winesync_header_check ]]; then
+	    error $winesync_header_check
+	    error "Winesync header was not found. Build is forcibly prevented."
+	    error 'Please use linux-tkg build with _winesync="true" or https://aur.archlinux.org/packages/winesync-dkms/'
+	    exit 1
+	  fi
+
+	  # not allowed on Valve tree
+	  if [[ "$_custom_wine_source" = *"ValveSoftware"* ]]; then
+	    error "Fastsync is not supported on Valve trees. Build is forcibly prevented. Please disable applying fastsync patches or use non-Valve trees"
+	    exit 1
+	  fi
+
 	  if [ "$_use_staging" = "true" ]; then
 	    if [ "$_staging_esync" = "true" ] && [ "$_use_fsync" = "true" ]; then
 	      if [ "$_protonify" = "true" ]; then
@@ -18,12 +34,8 @@
 	        fi
 	      fi
 	    else
-	      if [[ "$_custom_wine_source" = *"ValveSoftware"* ]]; then
-	        warning "! Fastsync is not currently supported on Valve trees and will be disabled !"
-	      else
-	        warning "! _use_fastsync is enabled, but it depends on _use_fsync. Please enable it in your .cfg to use fastsync !"
-	        _use_fastsync="false"
-	      fi
+	      error "Fastsync for Staging trees depends on _use_fsync. Build is forcibly prevented. Please enable _use_fsync in your .cfg to use fastsync"
+	      exit 1
 	    fi
 	  else
 	    if [ "$_use_esync" = "false" ] && [ "$_use_fsync" = "false" ]; then
@@ -33,11 +45,12 @@
 	        _patchname='fastsync-mainline-f076e5f.patch' && _patchmsg="Using fastsync (mainline) patchset" && nonuser_patcher
 	      fi
 	    else
-	      warning "! _use_fastsync is enabled, but _use_esync/_use_fsync disables it. Please disable them in your .cfg to use fastsync !"
-	      _use_fastsync="false"
+	      error "Fastsync for Plain trees conflicts with _use_esync and _use_fsync. Build is forcibly prevented. Please disable them in your .cfg to use fastsync"
+	      exit 1
 	    fi
 	  fi
-	  if [ "$_use_fastsync" = "true" ] && [ "$_clock_monotonic" = "true" ]; then
+	  if [ "$_use_fastsync" = "true" ] && [ "$_clock_monotonic" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 36b45c6d1c124dd16b3475ba743fcbbc99d6862d HEAD ); then
 	    _patchname='fastsync-clock_monotonic-fixup.patch' && _patchmsg="Applied fastsync fix due clock_monotonic" && nonuser_patcher
 	  fi
+
 	fi

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-mainline.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-mainline.patch
@@ -886,7 +886,7 @@ new file mode 100644
 index 00000000000..cbf14bf8081
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,297 @@
+@@ -0,0 +1,298 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -1020,6 +1020,7 @@ index 00000000000..cbf14bf8081
 +    if (unix_fd == -1)
 +    {
 +        file_set_error();
++        fprintf( stderr, "fastsync: /dev/winesync not available. (Please check winesync module)\n" );
 +        return NULL;
 +    }
 +

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-staging-protonify.patch
@@ -911,7 +911,7 @@ new file mode 100644
 index 00000000000..cbf14bf8081
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,301 @@
+@@ -0,0 +1,302 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -1047,6 +1047,7 @@ index 00000000000..cbf14bf8081
 +    if (unix_fd == -1)
 +    {
 +        file_set_error();
++        fprintf( stderr, "fastsync: /dev/winesync not available. (Please check winesync module)\n" );
 +        return NULL;
 +    }
 +
@@ -5072,13 +5073,11 @@ diff --git a/server/fast_sync.c b/server/fast_sync.c
 index 6b738519c7a..8e7ac54d16c 100644
 --- a/server/fast_sync.c
 +++ b/server/fast_sync.c
-@@ -126,6 +126,14 @@ static struct linux_device *get_linux_device(void)
+@@ -126,6 +126,12 @@ static struct linux_device *get_linux_device(void)
      struct linux_device *device;
      int unix_fd;
  
-+    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ) ||
-+         getenv( "WINEESYNC" ) && atoi( getenv( "WINEESYNC" ) ) ||
-+         getenv( "WINEFSYNC" ) && atoi( getenv( "WINEFSYNC" ) ))
++    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ))
 +    {
 +        set_error( STATUS_NOT_IMPLEMENTED );
 +        return NULL;
@@ -5403,18 +5402,80 @@ index d71561e1247..59afc88cc6c 100644
 -- 
 2.35.3
 
+diff --git a/dlls/ntdll/unix/esync.c b/dlls/ntdll/unix/esync.c
+index 3b97bfd62ad..a1ed9961c00 100644
+--- a/dlls/ntdll/unix/esync.c
++++ b/dlls/ntdll/unix/esync.c
+@@ -60,7 +61,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index 86bb7dce85a..0e09e4e42d9 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -167,7 +168,7 @@ int do_fsync(void)
+         }
+ 
+         syscall( __NR_futex_waitv, NULL, 0, 0, NULL, 0 );
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
+diff --git a/server/esync.c b/server/esync.c
+index f180a545314..9a91ce82cd3 100644
+--- a/server/esync.c
++++ b/server/esync.c
+@@ -50,7 +51,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/server/fsync.c b/server/fsync.c
+index 7e4ff469300..11ff602cac3 100644
+--- a/server/fsync.c
++++ b/server/fsync.c
+@@ -58,7 +59,7 @@ int do_fsync(void)
+     if (do_fsync_cached == -1)
+     {
+         syscall( __NR_futex_waitv, 0, 0, 0, 0, 0);
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
 diff --git a/server/main.c b/server/main.c
-index d935017cd8d..8bc1c47100a 100644
+index 6c4d8117514..701b99cbf77 100644
 --- a/server/main.c
 +++ b/server/main.c
-@@ -148,8 +148,8 @@ int main( int argc, char *argv[] )
-     if (do_esync())
+@@ -231,14 +232,17 @@ int main( int argc, char *argv[] )
+     sock_init();
+     open_master_socket();
+ 
+-    if (do_fsync())
++    if (getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC")))
++    {
++      if (do_fsync())
+         fsync_init();
+ 
+-    if (do_esync())
++      if (do_esync())
          esync_init();
  
 -    if (!do_fsync() && !do_esync())
--        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-+//    if (!do_fsync() && !do_esync())
-+//        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-
++      if (!do_fsync() && !do_esync())
+         fprintf( stderr, "wineserver: using server-side synchronization.\n" );
++    }
+ 
      if (debug_level) fprintf( stderr, "wineserver: starting (pid=%ld)\n", (long) getpid() );
      set_current_time();

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync-staging.patch
@@ -911,7 +911,7 @@ new file mode 100644
 index 00000000000..cbf14bf8081
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,301 @@
+@@ -0,0 +1,302 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -1047,6 +1047,7 @@ index 00000000000..cbf14bf8081
 +    if (unix_fd == -1)
 +    {
 +        file_set_error();
++        fprintf( stderr, "fastsync: /dev/winesync not available. (Please check winesync module)\n" );
 +        return NULL;
 +    }
 +
@@ -5071,13 +5072,11 @@ diff --git a/server/fast_sync.c b/server/fast_sync.c
 index 6b738519c7a..8e7ac54d16c 100644
 --- a/server/fast_sync.c
 +++ b/server/fast_sync.c
-@@ -126,6 +126,14 @@ static struct linux_device *get_linux_device(void)
+@@ -126,6 +126,12 @@ static struct linux_device *get_linux_device(void)
      struct linux_device *device;
      int unix_fd;
  
-+    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ) ||
-+         getenv( "WINEESYNC" ) && atoi( getenv( "WINEESYNC" ) ) ||
-+         getenv( "WINEFSYNC" ) && atoi( getenv( "WINEFSYNC" ) ))
++    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ))
 +    {
 +        set_error( STATUS_NOT_IMPLEMENTED );
 +        return NULL;
@@ -5402,18 +5401,80 @@ index d71561e1247..59afc88cc6c 100644
 -- 
 2.35.3
 
+diff --git a/dlls/ntdll/unix/esync.c b/dlls/ntdll/unix/esync.c
+index 3b97bfd62ad..a1ed9961c00 100644
+--- a/dlls/ntdll/unix/esync.c
++++ b/dlls/ntdll/unix/esync.c
+@@ -60,7 +61,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index 86bb7dce85a..0e09e4e42d9 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -167,7 +168,7 @@ int do_fsync(void)
+         }
+ 
+         syscall( __NR_futex_waitv, NULL, 0, 0, NULL, 0 );
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
+diff --git a/server/esync.c b/server/esync.c
+index f180a545314..9a91ce82cd3 100644
+--- a/server/esync.c
++++ b/server/esync.c
+@@ -50,7 +51,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/server/fsync.c b/server/fsync.c
+index 7e4ff469300..11ff602cac3 100644
+--- a/server/fsync.c
++++ b/server/fsync.c
+@@ -58,7 +59,7 @@ int do_fsync(void)
+     if (do_fsync_cached == -1)
+     {
+         syscall( __NR_futex_waitv, 0, 0, 0, 0, 0);
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
 diff --git a/server/main.c b/server/main.c
-index d935017cd8d..8bc1c47100a 100644
+index 6c4d8117514..701b99cbf77 100644
 --- a/server/main.c
 +++ b/server/main.c
-@@ -148,8 +148,8 @@ int main( int argc, char *argv[] )
-     if (do_esync())
+@@ -231,14 +232,17 @@ int main( int argc, char *argv[] )
+     sock_init();
+     open_master_socket();
+ 
+-    if (do_fsync())
++    if (getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC")))
++    {
++      if (do_fsync())
+         fsync_init();
+ 
+-    if (do_esync())
++      if (do_esync())
          esync_init();
  
 -    if (!do_fsync() && !do_esync())
--        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-+//    if (!do_fsync() && !do_esync())
-+//        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-
++      if (!do_fsync() && !do_esync())
+         fprintf( stderr, "wineserver: using server-side synchronization.\n" );
++    }
+ 
      if (debug_level) fprintf( stderr, "wineserver: starting (pid=%ld)\n", (long) getpid() );
      set_current_time();

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-mainline-f076e5f.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-mainline-f076e5f.patch
@@ -887,7 +887,7 @@ new file mode 100644
 index 00000000000..cbf14bf8081
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,297 @@
+@@ -0,0 +1,298 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -1021,6 +1021,7 @@ index 00000000000..cbf14bf8081
 +    if (unix_fd == -1)
 +    {
 +        file_set_error();
++        fprintf( stderr, "fastsync: /dev/winesync not available. (Please check winesync module)\n" );
 +        return NULL;
 +    }
 +

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-e534d65.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-e534d65.patch
@@ -912,7 +912,7 @@ new file mode 100644
 index 00000000000..cbf14bf8081
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,301 @@
+@@ -0,0 +1,302 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -1048,6 +1048,7 @@ index 00000000000..cbf14bf8081
 +    if (unix_fd == -1)
 +    {
 +        file_set_error();
++        fprintf( stderr, "fastsync: /dev/winesync not available. (Please check winesync module)\n" );
 +        return NULL;
 +    }
 +
@@ -5072,13 +5073,11 @@ diff --git a/server/fast_sync.c b/server/fast_sync.c
 index 6b738519c7a..8e7ac54d16c 100644
 --- a/server/fast_sync.c
 +++ b/server/fast_sync.c
-@@ -126,6 +126,14 @@ static struct linux_device *get_linux_device(void)
+@@ -126,6 +126,12 @@ static struct linux_device *get_linux_device(void)
      struct linux_device *device;
      int unix_fd;
  
-+    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ) ||
-+         getenv( "WINEESYNC" ) && atoi( getenv( "WINEESYNC" ) ) ||
-+         getenv( "WINEFSYNC" ) && atoi( getenv( "WINEFSYNC" ) ))
++    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ))
 +    {
 +        set_error( STATUS_NOT_IMPLEMENTED );
 +        return NULL;
@@ -5403,18 +5402,80 @@ index d71561e1247..59afc88cc6c 100644
 -- 
 2.35.3
 
+diff --git a/dlls/ntdll/unix/esync.c b/dlls/ntdll/unix/esync.c
+index 3b97bfd62ad..a1ed9961c00 100644
+--- a/dlls/ntdll/unix/esync.c
++++ b/dlls/ntdll/unix/esync.c
+@@ -60,7 +61,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index 86bb7dce85a..0e09e4e42d9 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -167,7 +168,7 @@ int do_fsync(void)
+         }
+ 
+         syscall( __NR_futex_waitv, NULL, 0, 0, NULL, 0 );
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
+diff --git a/server/esync.c b/server/esync.c
+index f180a545314..9a91ce82cd3 100644
+--- a/server/esync.c
++++ b/server/esync.c
+@@ -50,7 +51,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/server/fsync.c b/server/fsync.c
+index 7e4ff469300..11ff602cac3 100644
+--- a/server/fsync.c
++++ b/server/fsync.c
+@@ -58,7 +59,7 @@ int do_fsync(void)
+     if (do_fsync_cached == -1)
+     {
+         syscall( __NR_futex_waitv, 0, 0, 0, 0, 0);
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
 diff --git a/server/main.c b/server/main.c
-index d935017cd8d..8bc1c47100a 100644
+index 6c4d8117514..701b99cbf77 100644
 --- a/server/main.c
 +++ b/server/main.c
-@@ -148,8 +148,8 @@ int main( int argc, char *argv[] )
-     if (do_esync())
+@@ -231,14 +232,17 @@ int main( int argc, char *argv[] )
+     sock_init();
+     open_master_socket();
+ 
+-    if (do_fsync())
++    if (getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC")))
++    {
++      if (do_fsync())
+         fsync_init();
+ 
+-    if (do_esync())
++      if (do_esync())
          esync_init();
  
 -    if (!do_fsync() && !do_esync())
--        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-+//    if (!do_fsync() && !do_esync())
-+//        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-
++      if (!do_fsync() && !do_esync())
+         fprintf( stderr, "wineserver: using server-side synchronization.\n" );
++    }
+ 
      if (debug_level) fprintf( stderr, "wineserver: starting (pid=%ld)\n", (long) getpid() );
      set_current_time();

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-protonify-e534d65.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/fastsync-staging-protonify-e534d65.patch
@@ -912,7 +912,7 @@ new file mode 100644
 index 00000000000..cbf14bf8081
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,301 @@
+@@ -0,0 +1,302 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -1048,6 +1048,7 @@ index 00000000000..cbf14bf8081
 +    if (unix_fd == -1)
 +    {
 +        file_set_error();
++        fprintf( stderr, "fastsync: /dev/winesync not available. (Please check winesync module)\n" );
 +        return NULL;
 +    }
 +
@@ -5073,13 +5074,11 @@ diff --git a/server/fast_sync.c b/server/fast_sync.c
 index 6b738519c7a..8e7ac54d16c 100644
 --- a/server/fast_sync.c
 +++ b/server/fast_sync.c
-@@ -126,6 +126,14 @@ static struct linux_device *get_linux_device(void)
+@@ -126,6 +126,12 @@ static struct linux_device *get_linux_device(void)
      struct linux_device *device;
      int unix_fd;
  
-+    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ) ||
-+         getenv( "WINEESYNC" ) && atoi( getenv( "WINEESYNC" ) ) ||
-+         getenv( "WINEFSYNC" ) && atoi( getenv( "WINEFSYNC" ) ))
++    if (getenv( "WINE_DISABLE_FAST_SYNC" ) && atoi( getenv( "WINE_DISABLE_FAST_SYNC" ) ))
 +    {
 +        set_error( STATUS_NOT_IMPLEMENTED );
 +        return NULL;
@@ -5404,18 +5403,80 @@ index d71561e1247..59afc88cc6c 100644
 -- 
 2.35.3
 
+diff --git a/dlls/ntdll/unix/esync.c b/dlls/ntdll/unix/esync.c
+index 3b97bfd62ad..a1ed9961c00 100644
+--- a/dlls/ntdll/unix/esync.c
++++ b/dlls/ntdll/unix/esync.c
+@@ -60,7 +61,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/dlls/ntdll/unix/fsync.c b/dlls/ntdll/unix/fsync.c
+index 86bb7dce85a..0e09e4e42d9 100644
+--- a/dlls/ntdll/unix/fsync.c
++++ b/dlls/ntdll/unix/fsync.c
+@@ -167,7 +168,7 @@ int do_fsync(void)
+         }
+ 
+         syscall( __NR_futex_waitv, NULL, 0, 0, NULL, 0 );
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
+diff --git a/server/esync.c b/server/esync.c
+index f180a545314..9a91ce82cd3 100644
+--- a/server/esync.c
++++ b/server/esync.c
+@@ -50,7 +51,7 @@ int do_esync(void)
+     static int do_esync_cached = -1;
+ 
+     if (do_esync_cached == -1)
+-        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync();
++        do_esync_cached = getenv("WINEESYNC") && atoi(getenv("WINEESYNC")) && !do_fsync() && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+ 
+     return do_esync_cached;
+ #else
+diff --git a/server/fsync.c b/server/fsync.c
+index 7e4ff469300..11ff602cac3 100644
+--- a/server/fsync.c
++++ b/server/fsync.c
+@@ -58,7 +59,7 @@ int do_fsync(void)
+     if (do_fsync_cached == -1)
+     {
+         syscall( __NR_futex_waitv, 0, 0, 0, 0, 0);
+-        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS;
++        do_fsync_cached = getenv("WINEFSYNC") && atoi(getenv("WINEFSYNC")) && errno != ENOSYS && getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC"));
+     }
+ 
+     return do_fsync_cached;
 diff --git a/server/main.c b/server/main.c
-index d935017cd8d..8bc1c47100a 100644
+index 6c4d8117514..701b99cbf77 100644
 --- a/server/main.c
 +++ b/server/main.c
-@@ -148,8 +148,8 @@ int main( int argc, char *argv[] )
-     if (do_esync())
+@@ -231,14 +232,17 @@ int main( int argc, char *argv[] )
+     sock_init();
+     open_master_socket();
+ 
+-    if (do_fsync())
++    if (getenv("WINE_DISABLE_FAST_SYNC") && atoi(getenv("WINE_DISABLE_FAST_SYNC")))
++    {
++      if (do_fsync())
+         fsync_init();
+ 
+-    if (do_esync())
++      if (do_esync())
          esync_init();
  
 -    if (!do_fsync() && !do_esync())
--        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-+//    if (!do_fsync() && !do_esync())
-+//        fprintf( stderr, "wineserver: using server-side synchronization.\n" );
-
++      if (!do_fsync() && !do_esync())
+         fprintf( stderr, "wineserver: using server-side synchronization.\n" );
++    }
+ 
      if (debug_level) fprintf( stderr, "wineserver: starting (pid=%ld)\n", (long) getpid() );
      set_current_time();

--- a/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
@@ -153,9 +153,11 @@ _configure_userargs64="--with-x --with-gstreamer --with-xattr"
 # Sets custom configure-args for 32-bit, separated by a space (example: "--without-mingw --with-vkd3d")
 _configure_userargs32="--with-x --with-gstreamer --with-xattr"
 
-# fastsync - disable at runtime with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable winesync/fastsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
-# !! on plain: Disables esync / fsync support !!
-# !! on staging: Requires fsync support !!
+# NTsync - Disable with WINE_DISABLE_FAST_SYNC=1 envvar - Set to true to enable NTsync support - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/fastsync4
+# more info about NTsync and feedback topic - https://github.com/Frogging-Family/wine-tkg-git/issues/936
+# !! For building and using requires special linux-tkg build with winesync module and header (or https://aur.archlinux.org/packages/winesync-dkms/) !!
+# !! Not compatible with Valve trees and some other patches. On Staging depends on fsync patches !!
+# !! For plain Wine required disabling esync and fsync patches applying !!
 _use_fastsync="false"
 
 # esync - Enable with WINEESYNC=1 envvar - Set to true to enable esync support on plain wine or wine-staging <4.6 (it got merged in wine-staging 4.6). The option is ignored on wine-staging 4.6+

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -428,6 +428,20 @@ _package_makepkg() {
 	  fi
 	fi
 
+	if [ "$_use_fastsync" = "true" ]; then
+	  msg2 '##########################################################################################################################'
+	  msg2 ''
+	  msg2 'To disable NTsync, export WINE_DISABLE_FAST_SYNC=1'
+	  if [ "$_use_fsync" = "true" ]; then
+	    msg2 'Any WINEESYNC and WINEFSYNC values will be ignored unless NTsync is disabled via an environment variable'
+	  fi
+	  msg2 ''
+	  msg2 'https://github.com/Frogging-Family/wine-tkg-git/issues/936 - feedback topic for reporting test results'
+	  msg2 "(please do not report issues related to builds or NTsync installation there - it's only for testing results)"
+	  msg2 ''
+	  msg2 '##########################################################################################################################'
+	fi
+
 	# External install
 	if [ "$_EXTERNAL_INSTALL" = "true" ]; then
 	  msg2 "### This wine will be installed to: $_prefix"

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -58,7 +58,6 @@ _exit_cleanup() {
     echo "_proton_pkgdest='${pkgdir}'" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_proton_branch_exp='${_proton_branch_exp}'" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_steamvr_support='${_steamvr_support}'" >> "$_proton_tkg_path"/proton_tkg_token
-    echo "_use_fastsync='${_use_fastsync}'" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_NUKR='${_NUKR}'" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_winesrcdir='${_winesrcdir}'" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_standard_dlopen='${_standard_dlopen}'" >> "$_proton_tkg_path"/proton_tkg_token


### PR DESCRIPTION
- "immediately prevent building without winesync header"
if `_use_fastsync="true"` was set, we probably don't want to run into fastsync not working on _that_ build of Wine. No need to waste time compiling such builds.
- "not make conflicts fail-safe, stop the build immediately"
The same as the previous one. With `_use_fastsync="true"` we want the Wine build with Fastsync. So let's save the User time and let them start resolving conflicts _before_ compiling.
- "output terminal message if `/dev/winesync` not exist"
Sometimes people forget that they haven't loaded the winesync module. _Numerous_ complaints from fastsync should clear things up _a bit_.
- "make priority over fsync/esync (it's **NOT** failsafe, like fsync!)."
any `WINEESYNC` and `WINEFSYNC` values will be completely ignored untill we set env var `WINE_DISABLE_FAST_SYNC=1`. If `_use_fastsync="true"` was set, we're probably interested in getting this to work out of the box. Will help people to know for sure that they didn't mess up anything in the environment variables.

Not perfect, but should help with some common problems.