### PR TITLE
fsync: Rename toggle options

### DIFF
--- a/proton-tkg/proton-tkg-profiles/legacy/legacy-options.cfg
+++ b/proton-tkg/proton-tkg-profiles/legacy/legacy-options.cfg
@@ -76,8 +76,12 @@ _proton_mf_hacks="false"
 
 _plasma_systray_fix="false"
 
+# Disable futex_waitv patches and keep fsync legacy (FUTEX_WAIT_MULTIPLE opcode 31) on Wine 5.20 and above - https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/
+_fsync_legacy="false"
+
 # Allow making use of the futex2 kernel interface for fsync - Requires a patched kernel such as linux-tkg - https://gitlab.collabora.com/tonyk/wine/-/commits/experimental_5.13
-_fsync_futex2="true"
+# ! required _fsync_legacy="true" !
+_fsync_futex2="false"
 
 _warframelauncher_fix="true"
 

--- a/proton-tkg/proton-tkg-profiles/sample-external-config.cfg
+++ b/proton-tkg/proton-tkg-profiles/sample-external-config.cfg
@@ -168,11 +168,6 @@ _use_fastsync="false"
 
 _use_esync="true"
 _use_fsync="true"
-# Allow making use of the futex2 kernel interface for fsync - Requires a patched kernel such as linux-tkg - https://gitlab.collabora.com/tonyk/wine/-/commits/experimental_5.13
-_fsync_futex2="true"
-# futex_waitv() API for fsync - Requires 5.16 kernel or kernel with backported patches - https://github.com/ValveSoftware/wine/pull/128
-# !! Replaces previous fsync interfaces support !!
-_fsync_futex_waitv="true"
 
 # Add a configurable spin count to fsync - might help performance but can introduce stability issues/hanging. Try setting WINEFSYNC_SPINCOUNT=100 envvar
 _fsync_spincounts="true"
@@ -367,8 +362,12 @@ _update_winevulkan="false"
 
 _plasma_systray_fix="false"
 
+# Disable futex_waitv patches and keep fsync legacy (FUTEX_WAIT_MULTIPLE opcode 31) on Wine 5.20 and above - https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/
+_fsync_legacy="false"
+
 # Allow making use of the futex2 kernel interface for fsync - Requires a patched kernel such as linux-tkg - https://gitlab.collabora.com/tonyk/wine/-/commits/experimental_5.13
-_fsync_futex2="true"
+# ! required _fsync_legacy="true" !
+_fsync_futex2="false"
 
 
 # USER PATCHES

--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -79,10 +79,6 @@ _use_fastsync="false"
 _use_esync="true"
 _use_fsync="true"
 
-# futex_waitv() API for fsync - Requires 5.16 kernel or kernel with backported patches - https://github.com/ValveSoftware/wine/pull/128
-# !! Replaces previous fsync interfaces support !!
-_fsync_futex_waitv="true"
-
 _plain_version=""
 _use_staging="true"
 _staging_version=""

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -66,13 +66,10 @@ _use_fastsync="false"
 # You may need to raise your fd limits -> https://github.com/zfigura/wine/blob/esync/README.esync
 _use_esync="true"
 
-# fsync - Enable with WINEFSYNC=1 envvar - Set to true to enable fsync support, an experimental replacement for esync introduced with Proton 4.11-1 - Requires Wine Mainline 4.7.r168.g29914d583f / Staging 4.9.r7.g197e08b4 or newer
-# https://steamcommunity.com/games/221410/announcements/detail/2957094910196249305
+# fsync - Enable with WINEFSYNC=1 envvar - Set to true to enable fsync support on Wine 5.20 and above - Requires kernel 5.16+ or at least linux-tkg 5.13 - https://github.com/ValveSoftware/wine/pull/128
+# !! fsync legacy will be used for Wine 5.19 and lower (Mainline 4.7.r168.g29914d583f / Staging 4.9.r7.g197e08b4) !!
+# !! https://steamcommunity.com/games/221410/announcements/detail/2957094910196249305 !!
 _use_fsync="true"
-
-# futex_waitv() API for fsync - Requires 5.16 kernel or kernel with backported patches - https://github.com/ValveSoftware/wine/pull/128
-# !! Replaces previous fsync interfaces support !!
-_fsync_futex_waitv="true"
 
 # Set to false to add DXVK configuration support to Wine's DXGI, allowing for VKD3D to run while keeping DXVK dxgi functionalities.
 # !! For DXVK to work properly with this option set to false, you'll need a DXVK build that comes with dxvk_config.dll !!

--- a/wine-tkg-git/wine-tkg-patches/proton/fsync/fsync
+++ b/wine-tkg-git/wine-tkg-patches/proton/fsync/fsync
@@ -1,153 +1,151 @@
 #!/bin/bash
 
-	# _fsync_futex_waitv depends on fsync
-	if [ "$_fsync_futex_waitv" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
-	  _use_fsync="true"
-	fi
-
-	# fsync - experimental replacement for esync introduced with Proton 4.11-1
 	if [ "$_use_fsync" = "true" ]; then
-	  if [ "$_staging_esync" = "true" ]; then
-	    if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor af4378d46dbb72e682017485212442bf865c2226 HEAD ); then
-	      _patchname='fsync-unix-staging.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5b56bad50b85acb05244894990053f8b0de2e458 HEAD ); then
-	      _patchname='fsync-unix-staging-af4378d.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e3001b6a7c087da5a680b412d82da878e0149e8b HEAD ); then
-	      _patchname='fsync-unix-staging-5b56bad.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8d6c33c3bfca4f4ed7b7653fd0b82dfbc12bd3cb HEAD ); then
-	      _patchname='fsync-unix-staging-e3001b6.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 10ca57f4f56f86b433686afbdbe140ba54b239bb HEAD ); then
-	      _patchname='fsync-unix-staging-8d6c33c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 626870abe2e800cc9407d05d5c00500a4ad97b3a HEAD ); then
-	      _patchname='fsync-unix-staging-10ca57f.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 731339cd60c255fd5890063b144ad7c00661f5a0 HEAD ); then
-	      _patchname='fsync-unix-staging-626870a.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor d6ef9401b3ef05e87e0cadd31992a6809008331e HEAD ); then
-	      _patchname='fsync-unix-staging-731339c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c6f2aacb5761801a17b930086111f4b2c4a30075 HEAD ); then
-	      _patchname='fsync-unix-staging-d6ef940.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 44699c324f20690f9d6836919534ca1b5bcc3efe HEAD ); then
-	      _patchname='fsync-unix-staging-c6f2aac.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2b6426da6550c50787eeb2b39affcb766e07ec11 HEAD ); then
-	      _patchname='fsync-unix-staging-44699c3.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c1a042cefbc38eae6e0824a460a0657148e6745a HEAD ); then
-	      _patchname='fsync-unix-staging-2b6426d.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor dc77e28b0f7d6fdb11dafacb73b9889545359572 HEAD ); then
-	      _patchname='fsync-unix-staging-c1a042c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 7bdc1d6bacaba02b914ca3b66ee239103201617d HEAD ); then
-	      _patchname='fsync-unix-staging-3100197.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 459d37643ef72d284eec0dc50573eff59935ae69 HEAD ); then
-	      _patchname='fsync-unix-staging-7bdc1d6.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
-	      _patchname='fsync-unix-staging-459d376.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, staging)" && nonuser_patcher
-	    elif git merge-base --is-ancestor 27a52d0414b68eb9d74c058afc4775b43f151263 HEAD; then
-	      _patchname='fsync-staging.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging)" && nonuser_patcher
-	    elif git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD; then
-	      _patchname='fsync-staging-27a52d0.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging)" && nonuser_patcher
-	    elif git merge-base --is-ancestor e5030a4ac0a303d6788ae79ffdcd88e66cf78bd2 HEAD; then
-	      _patchname='fsync-staging-2633a5c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging)" && nonuser_patcher
-	    elif git merge-base --is-ancestor 40e849ffa46ae3cd060e2db83305dda1c4d2648e HEAD; then
-	      _patchname='fsync-staging-e5030a4.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging)" && nonuser_patcher
-	    elif git merge-base --is-ancestor 87012607688f730755ee91de14620e6e3b78395c HEAD; then
-	      _patchname='fsync-staging-40e849f.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging)" && nonuser_patcher
-	    elif git merge-base --is-ancestor fc17535eb98a4b200d6a418337a7e280568c7cfd HEAD; then
-	      _patchname='fsync-staging-8701260.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging)" && nonuser_patcher
-	    elif git merge-base --is-ancestor 608d086f1b1bb7168e9322c65224c23f34e75f29 HEAD; then
-	      _patchname='fsync-staging-fc17535.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging <fc17535)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor cf04b8d6ac710c83dc9a433aea3e5d3c451095a1 HEAD ); then
-	      _patchname='fsync-staging-608d086.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging <608d086)" && nonuser_patcher
-	    elif git merge-base --is-ancestor 1d9a3f6d12322891a2af4aadd66a92ea66479233 HEAD; then
-	      _patchname='fsync-staging-cf04b8d.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (staging <cf04b8d)" && nonuser_patcher
-	    fi
-	    if [[ ! ${_staging_args[*]} =~ "server-Desktop_Refcount" ]] && ( cd "${srcdir}"/"${_stgsrcdir}" && ! git merge-base --is-ancestor 7fc716aa5f8595e5bca9206f86859f1ac70894ad HEAD ); then
-	      _patchname='fsync-staging-no_alloc_handle.patch' && _patchmsg="Added no_alloc_handle object method to fsync" && nonuser_patcher
-	      if ([ "$_EXTERNAL_INSTALL" = "proton" ]) || [ "$_protonify" = "true" ] && git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD; then
-	        if git merge-base --is-ancestor d6ef9401b3ef05e87e0cadd31992a6809008331e HEAD; then
-	          _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it-no_alloc_handle.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch (no_alloc_handle edition)" && nonuser_patcher
-	        elif git merge-base --is-ancestor c6f2aacb5761801a17b930086111f4b2c4a30075 HEAD; then
-	          _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it-no_alloc_handle-d6ef940.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch (no_alloc_handle edition)" && nonuser_patcher
+	  # fsync-unix - requares 5.20+ Wine version
+	  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
+	    if [ "$_staging_esync" = "true" ]; then
+	      if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor af4378d46dbb72e682017485212442bf865c2226 HEAD ); then
+	        _patchname='fsync-unix-staging.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5b56bad50b85acb05244894990053f8b0de2e458 HEAD ); then
+	        _patchname='fsync-unix-staging-af4378d.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e3001b6a7c087da5a680b412d82da878e0149e8b HEAD ); then
+	        _patchname='fsync-unix-staging-5b56bad.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8d6c33c3bfca4f4ed7b7653fd0b82dfbc12bd3cb HEAD ); then
+	        _patchname='fsync-unix-staging-e3001b6.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 10ca57f4f56f86b433686afbdbe140ba54b239bb HEAD ); then
+	        _patchname='fsync-unix-staging-8d6c33c.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 626870abe2e800cc9407d05d5c00500a4ad97b3a HEAD ); then
+	        _patchname='fsync-unix-staging-10ca57f.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 731339cd60c255fd5890063b144ad7c00661f5a0 HEAD ); then
+	        _patchname='fsync-unix-staging-626870a.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor d6ef9401b3ef05e87e0cadd31992a6809008331e HEAD ); then
+	        _patchname='fsync-unix-staging-731339c.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c6f2aacb5761801a17b930086111f4b2c4a30075 HEAD ); then
+	        _patchname='fsync-unix-staging-d6ef940.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 44699c324f20690f9d6836919534ca1b5bcc3efe HEAD ); then
+	        _patchname='fsync-unix-staging-c6f2aac.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2b6426da6550c50787eeb2b39affcb766e07ec11 HEAD ); then
+	        _patchname='fsync-unix-staging-44699c3.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c1a042cefbc38eae6e0824a460a0657148e6745a HEAD ); then
+	        _patchname='fsync-unix-staging-2b6426d.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor dc77e28b0f7d6fdb11dafacb73b9889545359572 HEAD ); then
+	        _patchname='fsync-unix-staging-c1a042c.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 7bdc1d6bacaba02b914ca3b66ee239103201617d HEAD ); then
+	        _patchname='fsync-unix-staging-3100197.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 459d37643ef72d284eec0dc50573eff59935ae69 HEAD ); then
+	        _patchname='fsync-unix-staging-7bdc1d6.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
+	        _patchname='fsync-unix-staging-459d376.patch' && _patchmsg="Applied fsync patches (unix, staging)" && nonuser_patcher
+	      fi
+	      if [ "$_protonify" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c6f2aacb5761801a17b930086111f4b2c4a30075 HEAD ); then
+	        if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor d6ef9401b3ef05e87e0cadd31992a6809008331e HEAD ); then
+	          _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch" && nonuser_patcher
 	        else
-	          _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it-no_alloc_handle-c6f2aac.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch (no_alloc_handle edition)" && nonuser_patcher
+	          _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it-d6ef940.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch" && nonuser_patcher
 	        fi
 	      fi
-	    elif [ "$_protonify" = "true" ] && git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD; then
-	      if git merge-base --is-ancestor d6ef9401b3ef05e87e0cadd31992a6809008331e HEAD; then
-	        _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch" && nonuser_patcher
-	      elif git merge-base --is-ancestor c6f2aacb5761801a17b930086111f4b2c4a30075 HEAD; then
-	        _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it-d6ef940.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch" && nonuser_patcher
+	    elif [ "$_use_esync" = "true" ]; then
+	      if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor af4378d46dbb72e682017485212442bf865c2226 HEAD ); then
+	        _patchname='fsync-unix-mainline.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5b56bad50b85acb05244894990053f8b0de2e458 HEAD ); then
+	        _patchname='fsync-unix-mainline-af4378d.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e3001b6a7c087da5a680b412d82da878e0149e8b HEAD ); then
+	        _patchname='fsync-unix-mainline-5b56bad.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8d6c33c3bfca4f4ed7b7653fd0b82dfbc12bd3cb HEAD ); then
+	        _patchname='fsync-unix-mainline-e3001b6.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 10ca57f4f56f86b433686afbdbe140ba54b239bb HEAD ); then
+	        _patchname='fsync-unix-mainline-8d6c33c.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 731339cd60c255fd5890063b144ad7c00661f5a0 HEAD ); then
+	        _patchname='fsync-unix-mainline-10ca57f.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor d6ef9401b3ef05e87e0cadd31992a6809008331e HEAD ); then
+	        _patchname='fsync-unix-mainline-731339c.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c6f2aacb5761801a17b930086111f4b2c4a30075 HEAD ); then
+	        _patchname='fsync-unix-mainline-d6ef940.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 44699c324f20690f9d6836919534ca1b5bcc3efe HEAD ); then
+	        _patchname='fsync-unix-mainline-c6f2aac.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2b6426da6550c50787eeb2b39affcb766e07ec11 HEAD ); then
+	        _patchname='fsync-unix-mainline-44699c3.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c1a042cefbc38eae6e0824a460a0657148e6745a HEAD ); then
+	        _patchname='fsync-unix-mainline-2b6426d.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 310019789f7bde12ae3f25f723957c975fb2f804 HEAD ); then
+	        _patchname='fsync-unix-mainline-c1a042c.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor cf49617c1a378dd4a37ab7226187708c501b046f HEAD ); then
+	        _patchname='fsync-unix-mainline-3100197.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 459d37643ef72d284eec0dc50573eff59935ae69 HEAD ); then
+	        _patchname='fsync-unix-mainline-7bdc1d6.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
+	        _patchname='fsync-unix-mainline-459d376.patch' && _patchmsg="Applied fsync patches (unix, mainline)" && nonuser_patcher
+	      fi
+	    else
+	      echo "Fsync forcefully disabled due to incompatible tree" >> "$_where"/last_build_config.log
+	    fi
+	    # choosing between futex_waitv, fsync legacy and futex2
+	    if [ "$_staging_esync" = "true" ] || [ "$_use_esync" = "true" ]; then
+	      if [ "$_fsync_legacy" = "true" ]; then
+	        if [ "$_fsync_futex2" = "true" ]; then
+	          _patchname='fsync_futex2.patch' && _patchmsg="Add futex2 support to fsync (DEPRECATED)" && nonuser_patcher
+	        else
+	          echo "Keep Fsync legacy version in this build" >> "$_where"/last_build_config.log
+	        fi
 	      else
+	        if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5b56bad50b85acb05244894990053f8b0de2e458 HEAD ); then
+	          _patchname='fsync_futex_waitv.patch' && _patchmsg="Applied patches for fsync to support futex_waitv" && nonuser_patcher
+	        elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
+	          _patchname='fsync_futex_waitv-5b56bad.patch' && _patchmsg="Applied patches for fsync to support futex_waitv" && nonuser_patcher
+	        fi
+	      fi
+	    fi
+	  # fsync legacy only - before 5.20
+	  elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 29914d583fe098521472332687b8da69fc692690 HEAD ); then
+	    if [ "$_staging_esync" = "true" ]; then
+	      if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 27a52d0414b68eb9d74c058afc4775b43f151263 HEAD ); then
+	        _patchname='fsync-staging.patch' && _patchmsg="Applied fsync legacy patches (staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD ); then
+	        _patchname='fsync-staging-27a52d0.patch' && _patchmsg="Applied fsync legacy patches (staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e5030a4ac0a303d6788ae79ffdcd88e66cf78bd2 HEAD ); then
+	        _patchname='fsync-staging-2633a5c.patch' && _patchmsg="Applied fsync legacy patches (staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 40e849ffa46ae3cd060e2db83305dda1c4d2648e HEAD ); then
+	        _patchname='fsync-staging-e5030a4.patch' && _patchmsg="Applied fsync legacy patches (staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 87012607688f730755ee91de14620e6e3b78395c HEAD ); then
+	        _patchname='fsync-staging-40e849f.patch' && _patchmsg="Applied fsync legacy patches (staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fc17535eb98a4b200d6a418337a7e280568c7cfd HEAD ); then
+	        _patchname='fsync-staging-8701260.patch' && _patchmsg="Applied fsync legacy patches (staging)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 608d086f1b1bb7168e9322c65224c23f34e75f29 HEAD ); then
+	        _patchname='fsync-staging-fc17535.patch' && _patchmsg="Applied fsync legacy patches (staging <fc17535)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor cf04b8d6ac710c83dc9a433aea3e5d3c451095a1 HEAD ); then
+	        _patchname='fsync-staging-608d086.patch' && _patchmsg="Applied fsync legacy patches (staging <608d086)" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 1d9a3f6d12322891a2af4aadd66a92ea66479233 HEAD ); then
+	        _patchname='fsync-staging-cf04b8d.patch' && _patchmsg="Applied fsync legacy patches (staging <cf04b8d)" && nonuser_patcher
+	      fi
+	      if [[ ! ${_staging_args[*]} =~ "server-Desktop_Refcount" ]] && ( cd "${srcdir}"/"${_stgsrcdir}" && ! git merge-base --is-ancestor 7fc716aa5f8595e5bca9206f86859f1ac70894ad HEAD ); then
+	        _patchname='fsync-staging-no_alloc_handle.patch' && _patchmsg="Added no_alloc_handle object method to fsync" && nonuser_patcher
+	        if ([ "$_EXTERNAL_INSTALL" = "proton" ]) || [ "$_protonify" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD ); then
+	          _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it-no_alloc_handle-c6f2aac.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch (no_alloc_handle edition)" && nonuser_patcher
+	        fi
+	      elif [ "$_protonify" = "true" ] &&  ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD ); then
 	        _patchname='server_Abort_waiting_on_a_completion_port_when_closing_it-c6f2aac.patch' && _patchmsg="Added Abort waiting on a completion port when closing it Proton patch" && nonuser_patcher
 	      fi
-	    fi
-	  elif [ "$_use_esync" = "true" ]; then
-	    if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor af4378d46dbb72e682017485212442bf865c2226 HEAD ); then
-	      _patchname='fsync-unix-mainline.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5b56bad50b85acb05244894990053f8b0de2e458 HEAD ); then
-	      _patchname='fsync-unix-mainline-af4378d.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e3001b6a7c087da5a680b412d82da878e0149e8b HEAD ); then
-	      _patchname='fsync-unix-mainline-5b56bad.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8d6c33c3bfca4f4ed7b7653fd0b82dfbc12bd3cb HEAD ); then
-	      _patchname='fsync-unix-mainline-e3001b6.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 10ca57f4f56f86b433686afbdbe140ba54b239bb HEAD ); then
-	      _patchname='fsync-unix-mainline-8d6c33c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 731339cd60c255fd5890063b144ad7c00661f5a0 HEAD ); then
-	      _patchname='fsync-unix-mainline-10ca57f.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor d6ef9401b3ef05e87e0cadd31992a6809008331e HEAD ); then
-	      _patchname='fsync-unix-mainline-731339c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c6f2aacb5761801a17b930086111f4b2c4a30075 HEAD ); then
-	      _patchname='fsync-unix-mainline-d6ef940.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 44699c324f20690f9d6836919534ca1b5bcc3efe HEAD ); then
-	      _patchname='fsync-unix-mainline-c6f2aac.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2b6426da6550c50787eeb2b39affcb766e07ec11 HEAD ); then
-	      _patchname='fsync-unix-mainline-44699c3.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor c1a042cefbc38eae6e0824a460a0657148e6745a HEAD ); then
-	      _patchname='fsync-unix-mainline-2b6426d.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 310019789f7bde12ae3f25f723957c975fb2f804 HEAD ); then
-	      _patchname='fsync-unix-mainline-c1a042c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor cf49617c1a378dd4a37ab7226187708c501b046f HEAD ); then
-	      _patchname='fsync-unix-mainline-3100197.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 459d37643ef72d284eec0dc50573eff59935ae69 HEAD ); then
-	      _patchname='fsync-unix-mainline-7bdc1d6.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
-	      _patchname='fsync-unix-mainline-459d376.patch' && _patchmsg="Applied fsync, an experimental replacement for esync (unix, mainline)" && nonuser_patcher
-	    elif git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD; then
-	      _patchname='fsync-mainline.patch' && _patchmsg="Applied fsync, an experimental replacement for esync" && nonuser_patcher
-	    elif git merge-base --is-ancestor e5030a4ac0a303d6788ae79ffdcd88e66cf78bd2 HEAD; then
-	      _patchname='fsync-mainline-2633a5c.patch' && _patchmsg="Applied fsync, an experimental replacement for esync" && nonuser_patcher
-	    elif git merge-base --is-ancestor 40e849ffa46ae3cd060e2db83305dda1c4d2648e HEAD; then
-	      _patchname='fsync-mainline-e5030a4.patch' && _patchmsg="Applied fsync, an experimental replacement for esync" && nonuser_patcher
-	    elif git merge-base --is-ancestor 87012607688f730755ee91de14620e6e3b78395c HEAD; then
-	      _patchname='fsync-mainline-40e849f.patch' && _patchmsg="Applied fsync, an experimental replacement for esync" && nonuser_patcher
-	    elif git merge-base --is-ancestor fc17535eb98a4b200d6a418337a7e280568c7cfd HEAD; then
-	      _patchname='fsync-mainline-8701260.patch' && _patchmsg="Applied fsync, an experimental replacement for esync" && nonuser_patcher
-	    elif git merge-base --is-ancestor 608d086f1b1bb7168e9322c65224c23f34e75f29 HEAD; then
-	      _patchname='fsync-mainline-fc17535.patch' && _patchmsg="Applied fsync, an experimental replacement for esync" && nonuser_patcher
-	    elif git merge-base --is-ancestor 29914d583fe098521472332687b8da69fc692690 HEAD; then
-	      _patchname='fsync-mainline-608d086.patch' && _patchmsg="Applied fsync, an experimental replacement for esync" && nonuser_patcher
-	    fi
-	  else
-	    echo "Fsync forcefully disabled due to incompatible tree" >> "$_where"/last_build_config.log
-	  fi
-	  if [ "$_fsync_spincounts" = "true" ] && [ "$_use_staging" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 8b2fd051c97187c68dee2ba2f0df7aca65c4cca6 HEAD ) && ( cd "${srcdir}"/"${_winesrcdir}" && ! git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then # Temporarily only allow on staging - we depend on esync mutexes abandonment
-	    _patchname='fsync-spincounts.patch' && _patchmsg="Add a configurable spin count to fsync" && nonuser_patcher
-	  fi
-
-	  # futex_waitv
-	  if [ "$_staging_esync" = "true" ] || [ "$_use_esync" = "true" ] && [ "$_use_fsync" = "true" ]; then
-	    if [ "$_fsync_futex_waitv" = "true" ]; then
-	      if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5b56bad50b85acb05244894990053f8b0de2e458 HEAD ); then
-	        _patchname='fsync_futex_waitv.patch' && _patchmsg="Replace all fsync interfaces with futex_waitv" && nonuser_patcher
-	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
-	        _patchname='fsync_futex_waitv-5b56bad.patch' && _patchmsg="Replace all fsync interfaces with futex_waitv" && nonuser_patcher
+	    elif [ "$_use_esync" = "true" ]; then
+	      if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 2633a5c1ae542f08f127ba737fa59fb03ed6180b HEAD ); then
+	        _patchname='fsync-mainline.patch' && _patchmsg="Applied fsync legacy patches" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e5030a4ac0a303d6788ae79ffdcd88e66cf78bd2 HEAD ); then
+	        _patchname='fsync-mainline-2633a5c.patch' && _patchmsg="Applied fsync legacy patches" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 40e849ffa46ae3cd060e2db83305dda1c4d2648e HEAD ); then
+	        _patchname='fsync-mainline-e5030a4.patch' && _patchmsg="Applied fsync legacy patches" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 87012607688f730755ee91de14620e6e3b78395c HEAD ); then
+	        _patchname='fsync-mainline-40e849f.patch' && _patchmsg="Applied fsync legacy patches" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fc17535eb98a4b200d6a418337a7e280568c7cfd HEAD ); then
+	        _patchname='fsync-mainline-8701260.patch' && _patchmsg="Applied fsync legacy patches" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 608d086f1b1bb7168e9322c65224c23f34e75f29 HEAD ); then
+	        _patchname='fsync-mainline-fc17535.patch' && _patchmsg="Applied fsync legacy patches" && nonuser_patcher
+	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 29914d583fe098521472332687b8da69fc692690 HEAD ); then
+	        _patchname='fsync-mainline-608d086.patch' && _patchmsg="Applied fsync legacy patches" && nonuser_patcher
 	      fi
-	      _fsync_futex2="false"
+	    else
+	      echo "Fsync forcefully disabled due to incompatible tree" >> "$_where"/last_build_config.log
 	    fi
-	  fi
-
-	  # futex2 - DEPRECATED
-	  if [ "$_staging_esync" = "true" ] || [ "$_use_esync" = "true" ]; then
-	    if [ "$_fsync_futex2" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then
-	      _patchname='fsync_futex2.patch' && _patchmsg="Add futex2 support to fsync (DEPRECATED)" && nonuser_patcher
+	    if [ "$_fsync_spincounts" = "true" ] && [ "$_use_staging" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 8b2fd051c97187c68dee2ba2f0df7aca65c4cca6 HEAD ) && ( cd "${srcdir}"/"${_winesrcdir}" && ! git merge-base --is-ancestor 0c249e6125fc9dc6ee86b4ef6ae0d9fa2fc6291b HEAD ); then # Temporarily only allow on staging - we depend on esync mutexes abandonment
+	      _patchname='fsync-spincounts.patch' && _patchmsg="Add a configurable spin count to fsync" && nonuser_patcher
 	    fi
 	  fi
 	fi

--- a/wine-tkg-git/wine-tkg-profiles/legacy/legacy-options.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/legacy/legacy-options.cfg
@@ -69,8 +69,12 @@ _proton_mf_hacks="false"
 # Partial fix for systray on plasma 5 - https://bugs.winehq.org/show_bug.cgi?id=38409
 _plasma_systray_fix="false"
 
+# Disable futex_waitv patches and keep fsync legacy (FUTEX_WAIT_MULTIPLE opcode 31) on Wine 5.20 and above - https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/
+_fsync_legacy="false"
+
 # Allow making use of the futex2 kernel interface for fsync - Requires a patched kernel such as linux-tkg - https://gitlab.collabora.com/tonyk/wine/-/commits/experimental_5.13
-_fsync_futex2="true"
+# ! required _fsync_legacy="true" !
+_fsync_futex2="false"
 
 # use CLOCK_MONOTONIC instead of CLOCK_MONOTONIC_RAW in ntdll/server - Increases performance in some CPU limited cases - https://github.com/ValveSoftware/wine/commit/eece6bb2e453e16e99ec61f75fb4152ab4a939d8
 # No more useful on newer kernels. Breaks Vulkan calibrated timestamps (used by LatencyFleX for example)

--- a/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/sample-external-config.cfg
@@ -168,13 +168,10 @@ _use_esync="true"
 # Leave empty for auto-selection depending on detected Wine version.
 _esync_version=""
 
-# fsync - Enable with WINEFSYNC=1 envvar - Set to true to enable fsync support, an experimental replacement for esync introduced with Proton 4.11-1 - Requires Wine Mainline 4.7.r168.g29914d583f / Staging 4.9.r7.g197e08b4 or newer
-# https://steamcommunity.com/games/221410/announcements/detail/2957094910196249305
+# fsync - Enable with WINEFSYNC=1 envvar - Set to true to enable fsync support on Wine 5.20 and above - Requires kernel 5.16+ or at least linux-tkg 5.13 - https://github.com/ValveSoftware/wine/pull/128
+# !! fsync legacy will be used for Wine 5.19 and lower (Mainline 4.7.r168.g29914d583f / Staging 4.9.r7.g197e08b4) !!
+# !! https://steamcommunity.com/games/221410/announcements/detail/2957094910196249305 !!
 _use_fsync="true"
-
-# futex_waitv() API for fsync - Requires 5.16 kernel or kernel with backported patches - https://github.com/ValveSoftware/wine/pull/128
-# !! Replaces previous fsync interfaces support !!
-_fsync_futex_waitv="true"
 
 # Add a configurable spin count to fsync - might help performance but can introduce stability issues/hanging. Try setting WINEFSYNC_SPINCOUNT=100 envvar
 _fsync_spincounts="true"
@@ -386,8 +383,12 @@ _mtga_fix="false"
 # Partial fix for systray on plasma 5 - https://bugs.winehq.org/show_bug.cgi?id=38409
 _plasma_systray_fix="false"
 
+# Disable futex_waitv patches and keep fsync legacy (FUTEX_WAIT_MULTIPLE opcode 31) on Wine 5.20 and above - https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/
+_fsync_legacy="false"
+
 # Allow making use of the futex2 kernel interface for fsync - Requires a patched kernel such as linux-tkg - https://gitlab.collabora.com/tonyk/wine/-/commits/experimental_5.13
-_fsync_futex2="true"
+# ! required _fsync_legacy="true" !
+_fsync_futex2="false"
 
 # use CLOCK_MONOTONIC instead of CLOCK_MONOTONIC_RAW in ntdll/server - Increases performance in some CPU limited cases - https://github.com/ValveSoftware/wine/commit/eece6bb2e453e16e99ec61f75fb4152ab4a939d8
 # No more useful on newer kernels. Breaks Vulkan calibrated timestamps (used by LatencyFleX for example)

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg-mainline.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg-mainline.cfg
@@ -20,7 +20,6 @@ _EXTERNAL_NOVER="false"
 
 _use_esync="false"
 _use_fsync="false"
-_fsync_futex_waitv="false"
 _esync_version=""
 _use_staging="false"
 _use_pba="false"

--- a/wine-tkg-git/wine-tkg-profiles/wine-tkg-staging.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/wine-tkg-staging.cfg
@@ -20,7 +20,6 @@ _EXTERNAL_NOVER="false"
 
 _use_esync="false"
 _use_fsync="false"
-_fsync_futex_waitv="false"
 _esync_version=""
 _use_staging="true"
 _use_pba="false"

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -294,10 +294,23 @@ _package_nomakepkg() {
 	  if [ "$_use_fsync" = "true" ]; then
 	    msg2 '##########################################################################################################################'
 	    msg2 ''
-	    msg2 'To enable fsync, export WINEFSYNC=1 and use a Fsync patched kernel (such as linux52-tkg or newer). If no compatible kernel'
-	    msg2 'is found and Esync is enabled, it will fallback to it. You can enable both to get a dynamic "failsafe" mechanism.'
-	    msg2 ''
-	    msg2 'https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/'
+	    if [ "$_fsync_legacy" = "true" ]; then
+	      msg2 'To enable fsync legacy, export WINEFSYNC=1 and use a linux54-tkg or newer. If no compatible kernel'
+	      msg2 'is found and Esync is enabled, it will fallback to it. You can enable both to get a dynamic "failsafe" mechanism.'
+	      msg2 ''
+	      msg2 'https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/'
+	        if [ "$_fsync_futex2" = "true" ]; then
+	          msg2 ''
+	          msg2 'To enable fsync_futex2, additionally export WINEFSYNC_FUTEX2=1 and use a linux510-tkg or newer.'
+	          msg2 ''
+	          msg2 'https://github.com/ValveSoftware/Proton/issues/4568'
+	        fi
+	    else
+	      msg2 'To enable fsync, export WINEFSYNC=1 and use a kernel 5.16+ (or at least linux513-tkg). If no compatible kernel'
+	      msg2 'is found and Esync is enabled, it will fallback to it. You can enable both to get a dynamic "failsafe" mechanism.'
+	      msg2 ''
+	      msg2 'https://github.com/ValveSoftware/wine/pull/128'
+	    fi
 	    msg2 ''
 	    msg2 '##########################################################################################################################'
 	  fi
@@ -435,10 +448,23 @@ _package_makepkg() {
 	  if [ "$_use_fsync" = "true" ]; then
 	    msg2 '##########################################################################################################################'
 	    msg2 ''
-	    msg2 'To enable fsync, export WINEFSYNC=1 and use a Fsync patched kernel (such as linux52-tkg or newer). If no compatible kernel'
-	    msg2 'is found and Esync is enabled, it will fallback to it. You can enable both to get a dynamic "failsafe" mechanism.'
-	    msg2 ''
-	    msg2 'https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/'
+	    if [ "$_fsync_legacy" = "true" ]; then
+	      msg2 'To enable fsync legacy, export WINEFSYNC=1 and use a linux54-tkg or newer. If no compatible kernel'
+	      msg2 'is found and Esync is enabled, it will fallback to it. You can enable both to get a dynamic "failsafe" mechanism.'
+	      msg2 ''
+	      msg2 'https://steamcommunity.com/app/221410/discussions/0/3158631000006906163/'
+	        if [ "$_fsync_futex2" = "true" ]; then
+	          msg2 ''
+	          msg2 'To enable fsync_futex2, additionally export WINEFSYNC_FUTEX2=1 and use a linux510-tkg or newer.'
+	          msg2 ''
+	          msg2 'https://github.com/ValveSoftware/Proton/issues/4568'
+	        fi
+	    else
+	      msg2 'To enable fsync, export WINEFSYNC=1 and use a kernel 5.16+ (or at least linux513-tkg). If no compatible kernel'
+	      msg2 'is found and Esync is enabled, it will fallback to it. You can enable both to get a dynamic "failsafe" mechanism.'
+	      msg2 ''
+	      msg2 'https://github.com/ValveSoftware/wine/pull/128'
+	    fi
 	    msg2 ''
 	    msg2 '##########################################################################################################################'
 	  fi

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -392,7 +392,6 @@ msg2 ''
     _use_esync="false"
     _use_fsync="false"
     _use_fastsync="false"
-    _fsync_futex_waitv="false"
 #    _use_staging="false"
     _proton_fs_hack="false"
     _proton_rawinput="false"


### PR DESCRIPTION
enough time has passed, so there should be no more problems associated with the transition to using futex_waitv.
this PR should clean up some the fsync things:
- for [the main fsync patch script](https://github.com/Frogging-Family/wine-tkg-git/blob/c15b9c448bf101a3bf32bf15ee852199e5d430d1/wine-tkg-git/wine-tkg-patches/proton/fsync/fsync): more explicitly split patches into two blocks - before and after 5.20 (for versions before 5.20, bring checks to the current common style.)
- `_fsync_futex_waitv` already enabled by default since https://github.com/Frogging-Family/wine-tkg-git/commit/764ff67d6fd7aad4edc3d03d7d46d69c6bbd07ff . So let's just stick this to fsync-unix patches as the official fsync version (for wine-5.20+) and remove unnecessary checks. 
 - allow build (for wine-5.20+) with Fsync legacy (`FUTEX_WAIT_MULTIPLE`) and deprecated (`futex2`) versions
 
##### * _For older Wine versions (prior to 5.20), there is only one "Fsync Legacy" version, so there is nothing left but to continue to apply this version_