### PR TITLE
Fix tkg starting scripts

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/wine-tkg
+++ b/wine-tkg-git/wine-tkg-scripts/wine-tkg
@@ -42,7 +42,7 @@ cat >&2 << 'EOM'
 EOM
 
 if [ -x "$(command -v _wine)" ]; then
-  _wine ${@:1}
+  _wine "${@:1}"
 else
-  wine ${@:1}
+  wine "${@:1}"
 fi

--- a/wine-tkg-git/wine-tkg-scripts/wine-tkg
+++ b/wine-tkg-git/wine-tkg-scripts/wine-tkg
@@ -3,15 +3,15 @@
 winetkgbindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 if [ -z "$PATH" ]; then
-  PATH="$winetkgbindir"
+  export PATH="$winetkgbindir"
 else
-  PATH="$winetkgbindir:$PATH"
+  export PATH="$winetkgbindir:$PATH"
 fi
 
 if [ -z "$LD_LIBRARY_PATH" ]; then
-  LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32"
+  export LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32"
 else
-  LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32:$LD_LIBRARY_PATH"
+  export LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32:$LD_LIBRARY_PATH"
 fi
 
 # Debian-based distros

--- a/wine-tkg-git/wine-tkg-scripts/wine-tkg
+++ b/wine-tkg-git/wine-tkg-scripts/wine-tkg
@@ -19,7 +19,7 @@ if [ -f "/etc/debian_version" ]; then
   export WINEDLLPATH="/usr/lib/x86_64-linux-gnu/wine:/usr/lib/i386-linux-gnu/wine"
 fi
 
-cat << 'EOM'
+cat >&2 << 'EOM'
        .---.`               `.---.
     `/syhhhyso-           -osyhhhys/`
    .syNMdhNNhss/``.---.``/sshNNhdMNys.

--- a/wine-tkg-git/wine-tkg-scripts/wine-tkg-interactive
+++ b/wine-tkg-git/wine-tkg-scripts/wine-tkg-interactive
@@ -3,15 +3,15 @@
 winetkgbindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 if [ -z "$PATH" ]; then
-  PATH="$winetkgbindir"
+  export PATH="$winetkgbindir"
 else
-  PATH="$winetkgbindir:$PATH"
+  export PATH="$winetkgbindir:$PATH"
 fi
 
 if [ -z "$LD_LIBRARY_PATH" ]; then
-  LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32"
+  export LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32"
 else
-  LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32:$LD_LIBRARY_PATH"
+  export LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32:$LD_LIBRARY_PATH"
 fi
 
 # Debian-based distros

--- a/wine-tkg-git/wine-tkg-scripts/wine-tkg-interactive
+++ b/wine-tkg-git/wine-tkg-scripts/wine-tkg-interactive
@@ -19,7 +19,7 @@ if [ -f "/etc/debian_version" ]; then
   export WINEDLLPATH="/usr/lib/x86_64-linux-gnu/wine:/usr/lib/i386-linux-gnu/wine"
 fi
 
-cat << 'EOM'
+cat >&2 << 'EOM'
        .---.`               `.---.
     `/syhhhyso-           -osyhhhys/`
    .syNMdhNNhss/``.---.``/sshNNhdMNys.

--- a/wine-tkg-git/wine-tkg-scripts/wine64-tkg
+++ b/wine-tkg-git/wine-tkg-scripts/wine64-tkg
@@ -42,7 +42,7 @@ cat >&2 << 'EOM'
 EOM
 
 if [ -x "$(command -v _wine64)" ]; then
-  _wine64 ${@:1}
+  _wine64 "${@:1}"
 else
-  wine64 ${@:1}
+  wine64 "${@:1}"
 fi

--- a/wine-tkg-git/wine-tkg-scripts/wine64-tkg
+++ b/wine-tkg-git/wine-tkg-scripts/wine64-tkg
@@ -3,15 +3,15 @@
 winetkgbindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 if [ -z "$PATH" ]; then
-  PATH="$winetkgbindir"
+  export PATH="$winetkgbindir"
 else
-  PATH="$winetkgbindir:$PATH"
+  export PATH="$winetkgbindir:$PATH"
 fi
 
 if [ -z "$LD_LIBRARY_PATH" ]; then
-  LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32"
+  export LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32"
 else
-  LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32:$LD_LIBRARY_PATH"
+  export LD_LIBRARY_PATH="$winetkgbindir/../lib64:$winetkgbindir/../lib:$winetkgbindir/../lib32:$LD_LIBRARY_PATH"
 fi
 
 # Debian-based distros

--- a/wine-tkg-git/wine-tkg-scripts/wine64-tkg
+++ b/wine-tkg-git/wine-tkg-scripts/wine64-tkg
@@ -19,7 +19,7 @@ if [ -f "/etc/debian_version" ]; then
   export WINEDLLPATH="/usr/lib/x86_64-linux-gnu/wine:/usr/lib/i386-linux-gnu/wine"
 fi
 
-cat << 'EOM'
+cat >&2 << 'EOM'
        .---.`               `.---.
     `/syhhhyso-           -osyhhhys/`
    .syNMdhNNhss/``.---.``/sshNNhdMNys.


### PR DESCRIPTION
There were three issues in the starting scripts `bin/wine-tkg`, `bin/wine64-tkg`, `bin/wine-tkg-interactive` that are packaged with a complete wine-tkg.

- The `PATH` and `LD_LIBRARY_PATH` variables were not exported. That means the variables were not passed down to the wine binary and therefore were not doing anything.
- The ascii frog image printed at startup was printed to stdout. This caused the frog to be part of every script output that used wine, so wine-tkg could not be used in scripts. This issue was solved by printing the frog to stderr instead.
- There were no quotes around the `${@:1}` parameter given to wine. This caused any quotes around arguments to be stripped, so arguments with spaces would not work. Example: `wine-tkg cmd /c echo "a & echo b"` should print `a & echo b` but instead it was printing a and b on different lines.