### PR TITLE
Hotfixes: Update Proton 8.0 de-steamify patches

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/valve/de-steamify-80-be.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/valve/de-steamify-80-be.mypatch
@@ -1,6 +1,6 @@
-From c9e5a91b9aa3b21e1b007b6177deb669b4e9b349 Mon Sep 17 00:00:00 2001
+From 25a2de878c9fcaad2c2d6c3935cf368552e5ff6d Mon Sep 17 00:00:00 2001
 From: kotarac <stipe@kotarac.net>
-Date: Wed, 24 May 2023 08:34:17 +0200
+Date: Wed, 24 May 2023 08:30:51 +0200
 Subject: [PATCH] de-steamify
 
 ---
@@ -184,10 +184,10 @@ index ca367ec3a7c..c0e2a874788 100644
      registration->DriverObject->DriverUnload = driver_unload;
  
 diff --git a/dlls/kernelbase/process.c b/dlls/kernelbase/process.c
-index 2fe9d93e76e..2fa5a1da88e 100644
+index 24c43357a17..d71d0780044 100644
 --- a/dlls/kernelbase/process.c
 +++ b/dlls/kernelbase/process.c
-@@ -1232,21 +1232,6 @@ HANDLE WINAPI DECLSPEC_HOTPATCH OpenProcess( DWORD access, BOOL inherit, DWORD i
+@@ -1223,21 +1223,6 @@ HANDLE WINAPI DECLSPEC_HOTPATCH OpenProcess( DWORD access, BOOL inherit, DWORD i
      attr.SecurityDescriptor = NULL;
      attr.SecurityQualityOfService = NULL;
  
@@ -210,7 +210,7 @@ index 2fe9d93e76e..2fa5a1da88e 100644
      cid.UniqueThread  = 0;
  
 diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
-index 14fc568f0d2..6c068fd6afe 100644
+index 9bd07a9bec7..a827e4e47c1 100644
 --- a/dlls/ntdll/loader.c
 +++ b/dlls/ntdll/loader.c
 @@ -86,7 +86,7 @@ const WCHAR windows_dir[] = L"C:\\windows";
@@ -223,7 +223,7 @@ index 14fc568f0d2..6c068fd6afe 100644
  static BOOL is_prefix_bootstrap;  /* are we bootstrapping the prefix? */
  static BOOL imports_fixup_done = FALSE;  /* set once the imports have been fixed up, before attaching them */
 diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
-index ef38691b15a..f525b614211 100644
+index d3b086f2731..948a46fa70c 100644
 --- a/dlls/ntdll/unix/loader.c
 +++ b/dlls/ntdll/unix/loader.c
 @@ -773,42 +773,11 @@ NTSTATUS exec_wineloader( char **argv, int socketfd, const pe_image_info_t *pe_i
@@ -390,10 +390,10 @@ index f4414ae1f50..4ed55ce9c01 100644
      {
          ntdll_umbstowcs(sdl_serial, strlen(sdl_serial) + 1, desc.serialnumber, ARRAY_SIZE(desc.serialnumber));
 diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
-index 697203dd499..44b4261cf82 100644
+index a502ea9166f..adcc82e4f7c 100644
 --- a/dlls/winex11.drv/window.c
 +++ b/dlls/winex11.drv/window.c
-@@ -1055,19 +1055,8 @@ static void set_initial_wm_hints( Display *display, Window window )
+@@ -1056,19 +1056,8 @@ static void set_initial_wm_hints( Display *display, Window window )
      /* class hints */
      if ((class_hints = XAllocClassHint()))
      {
@@ -650,7 +650,7 @@ index 192d75413fa..2abf33a8d45 100644
  
      return ERROR_SUCCESS;
 diff --git a/loader/wine.inf.in b/loader/wine.inf.in
-index 40dcd9eb0d2..1263d322587 100644
+index c61e81ac645..9fd647eda0a 100644
 --- a/loader/wine.inf.in
 +++ b/loader/wine.inf.in
 @@ -335,7 +335,6 @@ HKCR,ftp\shell\open\command,,2,"""%11%\winebrowser.exe"" ""%1"""
@@ -662,10 +662,10 @@ index 40dcd9eb0d2..1263d322587 100644
  [ContentIndex]
  HKLM,System\CurrentControlSet\Control\ContentIndex\Language\Neutral,"WBreakerClass",,"{369647e0-17b0-11ce-9950-00aa004bbb1f}"
 diff --git a/programs/winedbg/debugger.h b/programs/winedbg/debugger.h
-index 4d2b946162b..6368248cd08 100644
+index 570ed52143f..0fed24fd7e7 100644
 --- a/programs/winedbg/debugger.h
 +++ b/programs/winedbg/debugger.h
-@@ -304,7 +304,6 @@ extern	DWORD	                dbg_curr_tid;
+@@ -312,7 +312,6 @@ extern	DWORD	                dbg_curr_tid;
  extern  dbg_ctx_t               dbg_context;
  extern  BOOL                    dbg_interactiveP;
  extern  HANDLE                  dbg_houtput;
@@ -674,7 +674,7 @@ index 4d2b946162b..6368248cd08 100644
  
  struct dbg_internal_var
 diff --git a/programs/winedbg/tgt_active.c b/programs/winedbg/tgt_active.c
-index 5d660ab81dd..3c9b465e702 100644
+index 069d0a39c23..6d40506c671 100644
 --- a/programs/winedbg/tgt_active.c
 +++ b/programs/winedbg/tgt_active.c
 @@ -22,8 +22,6 @@
@@ -686,7 +686,7 @@ index 5d660ab81dd..3c9b465e702 100644
  
  #include "debugger.h"
  #include "psapi.h"
-@@ -799,48 +797,6 @@ static HANDLE create_temp_file(void)
+@@ -798,48 +796,6 @@ static HANDLE create_temp_file(void)
                          NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE, 0 );
  }
  
@@ -735,7 +735,7 @@ index 5d660ab81dd..3c9b465e702 100644
  static const struct
  {
      int type;
-@@ -1024,7 +980,6 @@ enum dbg_start dbg_active_auto(int argc, char* argv[])
+@@ -1023,7 +979,6 @@ enum dbg_start dbg_active_auto(int argc, char* argv[])
          break;
      case TRUE:
          dbg_use_wine_dbg_output = TRUE;
@@ -744,7 +744,7 @@ index 5d660ab81dd..3c9b465e702 100644
      }
  
 diff --git a/programs/winedbg/winedbg.c b/programs/winedbg/winedbg.c
-index b2a1706117a..f0f02438934 100644
+index 8cccf30fa09..048e6c2c2a7 100644
 --- a/programs/winedbg/winedbg.c
 +++ b/programs/winedbg/winedbg.c
 @@ -82,7 +82,6 @@ DWORD	                dbg_curr_pid = 0;

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/valve/de-steamify-80-exp.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/valve/de-steamify-80-exp.mypatch
@@ -1,14 +1,11 @@
-From 376d942ddb8a213528eddd45f9452e6ff2598cd6 Mon Sep 17 00:00:00 2001
+From e016bbba7d61acee00402a8f16761f8e61fc165d Mon Sep 17 00:00:00 2001
 From: kotarac <stipe@kotarac.net>
-Date: Fri, 28 Apr 2023 23:26:04 +0200
+Date: Wed, 24 May 2023 08:35:13 +0200
 Subject: [PATCH] de-steamify
 
 ---
  dlls/advapi32/advapi.c        |  34 ++++----
  dlls/dbghelp/dwarf.c          |   5 --
- dlls/dinput/dinput_main.c     |   7 --
- dlls/dinput/dinput_private.h  |   2 -
- dlls/dinput/joystick_hid.c    |  20 -----
  dlls/hidclass.sys/device.c    |   7 +-
  dlls/hidclass.sys/hid.h       |   6 --
  dlls/hidclass.sys/pnp.c       |  12 ---
@@ -23,8 +20,7 @@ Subject: [PATCH] de-steamify
  programs/winedbg/debugger.h   |   1 -
  programs/winedbg/tgt_active.c |  45 -----------
  programs/winedbg/winedbg.c    |   9 +--
- server/main.c                 |   2 +-
- 20 files changed, 88 insertions(+), 321 deletions(-)
+ 16 files changed, 87 insertions(+), 291 deletions(-)
 
 diff --git a/dlls/advapi32/advapi.c b/dlls/advapi32/advapi.c
 index a22e896c88a..6b3ffe2ea25 100644
@@ -94,102 +90,6 @@ index a2d57173587..9ed63463513 100644
      if (!dwarf2_init_section(&eh_frame,                fmap, ".eh_frame",     NULL,             &eh_frame_sect))
          /* lld produces .eh_fram to avoid generating a long name */
          dwarf2_init_section(&eh_frame,                fmap, ".eh_fram",      NULL,             &eh_frame_sect);
-diff --git a/dlls/dinput/dinput_main.c b/dlls/dinput/dinput_main.c
-index 33f98eda120..0d502821966 100644
---- a/dlls/dinput/dinput_main.c
-+++ b/dlls/dinput/dinput_main.c
-@@ -480,9 +480,6 @@ void check_dinput_events(void)
-     MsgWaitForMultipleObjectsEx(0, NULL, 0, QS_ALLINPUT, 0);
- }
- 
--HANDLE steam_overlay_event;
--HANDLE steam_keyboard_event;
--
- BOOL WINAPI DllMain( HINSTANCE inst, DWORD reason, void *reserved )
- {
-     TRACE( "inst %p, reason %lu, reserved %p.\n", inst, reason, reserved );
-@@ -491,16 +488,12 @@ BOOL WINAPI DllMain( HINSTANCE inst, DWORD reason, void *reserved )
-     {
-       case DLL_PROCESS_ATTACH:
-         DisableThreadLibraryCalls(inst);
--        steam_overlay_event = CreateEventA(NULL, TRUE, FALSE, "__wine_steamclient_GameOverlayActivated");
--        steam_keyboard_event = CreateEventA(NULL, TRUE, FALSE, "__wine_steamclient_KeyboardActivated");
-         DINPUT_instance = inst;
-         register_di_em_win_class();
-         break;
-       case DLL_PROCESS_DETACH:
-         if (reserved) break;
-         unregister_di_em_win_class();
--        CloseHandle(steam_overlay_event);
--        CloseHandle(steam_keyboard_event);
-         break;
-     }
-     return TRUE;
-diff --git a/dlls/dinput/dinput_private.h b/dlls/dinput/dinput_private.h
-index b12936e750f..944d12b860f 100644
---- a/dlls/dinput/dinput_private.h
-+++ b/dlls/dinput/dinput_private.h
-@@ -46,8 +46,6 @@ struct dinput
- 
- extern const IDirectInput7AVtbl dinput7_a_vtbl DECLSPEC_HIDDEN;
- extern const IDirectInput8AVtbl dinput8_a_vtbl DECLSPEC_HIDDEN;
--extern HANDLE steam_overlay_event DECLSPEC_HIDDEN;
--extern HANDLE steam_keyboard_event DECLSPEC_HIDDEN;
- 
- extern void dinput_internal_addref( struct dinput *dinput );
- extern void dinput_internal_release( struct dinput *dinput );
-diff --git a/dlls/dinput/joystick_hid.c b/dlls/dinput/joystick_hid.c
-index e4fe64c0e81..5fbe3d1dff8 100644
---- a/dlls/dinput/joystick_hid.c
-+++ b/dlls/dinput/joystick_hid.c
-@@ -1142,7 +1142,6 @@ struct parse_device_state_params
- {
-     BYTE old_state[DEVICE_STATE_MAX_SIZE];
-     BYTE buttons[128];
--    BOOL reset_state;
-     DWORD time;
-     DWORD seq;
- };
-@@ -1158,9 +1157,6 @@ static BOOL check_device_state_button( struct hid_joystick *impl, struct hid_val
- 
-     value = params->buttons[instance->wUsage - 1];
-     old_value = params->old_state[instance->dwOfs];
--
--    if (params->reset_state) value = 0;
--
-     impl->base.device_state[instance->dwOfs] = value;
-     if (old_value != value)
-         queue_event( iface, instance->dwType, value, params->time, params->seq );
-@@ -1243,16 +1239,6 @@ static BOOL read_device_state_value( struct hid_joystick *impl, struct hid_value
-     if (instance->dwType & DIDFT_AXIS) value = scale_axis_value( logical_value, properties );
-     else value = scale_value( logical_value, properties );
- 
--    if (params->reset_state)
--    {
--        if (instance->dwType & DIDFT_POV) value = -1;
--        else if (instance->dwType & DIDFT_AXIS)
--        {
--            if (!properties->range_min) value = properties->range_max / 2;
--            else value = round( (properties->range_min + properties->range_max) / 2.0 );
--        }
--    }
--
-     old_value = *(LONG *)(params->old_state + instance->dwOfs);
-     *(LONG *)(impl->base.device_state + instance->dwOfs) = value;
-     if (old_value != value)
-@@ -1283,12 +1269,6 @@ static HRESULT hid_joystick_read( IDirectInputDevice8W *iface )
- 
-     ret = GetOverlappedResult( impl->device, &impl->read_ovl, &count, FALSE );
- 
--    if (WaitForSingleObject(steam_overlay_event, 0) == WAIT_OBJECT_0 || /* steam overlay is enabled */
--        WaitForSingleObject(steam_keyboard_event, 0) == WAIT_OBJECT_0) /* steam keyboard is enabled */
--        params.reset_state = TRUE;
--    else
--        params.reset_state = FALSE;
--
-     EnterCriticalSection( &impl->base.crit );
-     while (ret)
-     {
 diff --git a/dlls/hidclass.sys/device.c b/dlls/hidclass.sys/device.c
 index 2092054d8ca..ac201afeddf 100644
 --- a/dlls/hidclass.sys/device.c
@@ -284,7 +184,7 @@ index ca367ec3a7c..c0e2a874788 100644
      registration->DriverObject->DriverUnload = driver_unload;
  
 diff --git a/dlls/kernelbase/process.c b/dlls/kernelbase/process.c
-index 54f9435bc16..ac30af8156e 100644
+index 0c5f5498df4..c869a5c9aa9 100644
 --- a/dlls/kernelbase/process.c
 +++ b/dlls/kernelbase/process.c
 @@ -1223,21 +1223,6 @@ HANDLE WINAPI DECLSPEC_HOTPATCH OpenProcess( DWORD access, BOOL inherit, DWORD i
@@ -323,7 +223,7 @@ index 9bd07a9bec7..a827e4e47c1 100644
  static BOOL is_prefix_bootstrap;  /* are we bootstrapping the prefix? */
  static BOOL imports_fixup_done = FALSE;  /* set once the imports have been fixed up, before attaching them */
 diff --git a/dlls/ntdll/unix/loader.c b/dlls/ntdll/unix/loader.c
-index 9c5aa5122a3..1a1b656c325 100644
+index e0e5006f498..f5e8a211ee6 100644
 --- a/dlls/ntdll/unix/loader.c
 +++ b/dlls/ntdll/unix/loader.c
 @@ -773,42 +773,11 @@ NTSTATUS exec_wineloader( char **argv, int socketfd, const pe_image_info_t *pe_i
@@ -490,10 +390,10 @@ index f4414ae1f50..4ed55ce9c01 100644
      {
          ntdll_umbstowcs(sdl_serial, strlen(sdl_serial) + 1, desc.serialnumber, ARRAY_SIZE(desc.serialnumber));
 diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
-index 30af723210a..f342a233f1c 100644
+index 116342f45c0..64bdf34552d 100644
 --- a/dlls/winex11.drv/window.c
 +++ b/dlls/winex11.drv/window.c
-@@ -1054,19 +1054,8 @@ static void set_initial_wm_hints( Display *display, Window window )
+@@ -1055,19 +1055,8 @@ static void set_initial_wm_hints( Display *display, Window window )
      /* class hints */
      if ((class_hints = XAllocClassHint()))
      {
@@ -878,19 +778,6 @@ index 8cccf30fa09..048e6c2c2a7 100644
          memmove( line_buff, line_buff + i, line_pos - i );
          line_pos -= i;
      }
-diff --git a/server/main.c b/server/main.c
-index 898e9af202d..afbe59351e8 100644
---- a/server/main.c
-+++ b/server/main.c
-@@ -41,7 +41,7 @@
- /* command-line options */
- int debug_level = 0;
- int foreground = 0;
--timeout_t master_socket_timeout = 0; /* master socket timeout, default is 3 seconds */
-+timeout_t master_socket_timeout = 3 * -TICKS_PER_SEC;  /* master socket timeout, default is 3 seconds */
- const char *server_argv0;
- 
- /* parse-line args */
 -- 
 2.40.1
 

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/valve/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/valve/hotfixes
@@ -11,8 +11,10 @@ if [ "$_EXTERNAL_INSTALL" != "proton" ]; then
   else
     if [ "$_LOCAL_PRESET" = "valve" ]; then
       cp "$_where"/wine-tkg-patches/hotfixes/valve/de-steamify-80.mypatch "$_where"/
+    elif [ "$_LOCAL_PRESET" = "valve-exp" ]; then
+      cp "$_where"/wine-tkg-patches/hotfixes/valve/de-steamify-80-exp.mypatch "$_where"/
     else
-      cp "$_where"/wine-tkg-patches/hotfixes/valve/de-steamify-80-exp-be.mypatch "$_where"/
+      cp "$_where"/wine-tkg-patches/hotfixes/valve/de-steamify-80-be.mypatch "$_where"/
     fi
   fi
 fi


### PR DESCRIPTION
compared to the initial 8.0 patches:
- https://github.com/ValveSoftware/wine/commit/5e2c6582eb763f2600af60f6e8eb03a4c11f3f6a left it in, doesn't revert cleanly on latest bleeding-edge anymore
- https://github.com/ValveSoftware/wine/commit/87a85d50c502f705eeaf7a9f3f4c9e54c707ae56 left it in, can be useful and it's not steam specific
- patches split up between valve, valve-exp, valve-exp-bleeding presets now

reverted commits list
```
9b9fd5eb1006cc3f2e12667a7cf45c7a6affa94d
7ad552e281600825a3046005b3ae60c0e1eea49b
d472faa571c4611ccc7a273b57cf053dfdd9ddfb
d78c8ed306c5da9ce35e488358fd4274cc59f3ab
762ca38cf350f01e813ad97459826941a5b77c1e
84b39d3aef9a63e3bc46f3142786fcd7f7aca849
89631f2bf0cd5a1dd4a075c50db2fc365442b3c3
a3f687c45dff423b27dcda55fe1a7175d435547b
77a7990f8f57a0d321934a698eb0c9b27ee50e19
d60d512f5a4baa52e70624ea9eb25e50be750953
653847dd8d2740ee886648e96a3eb20db6a6cbe7
a55c9c74a1ddae88ff300fb8b63e9bc7c7b2d266
92e01e33fe6eb993582ba40e931479d78f4e9d60
5b5785001537dea33fb3aa93b0e0d0a6e4c9b794
890c356dda291442ce73c71976e66f75a75e072d
```