### PR TITLE
Disable syscall emu patchset on WoW64 builds

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
@@ -275,6 +275,13 @@ EOM
       fi
     fi
 
+    # Disable problematic syscall emulation patchset in semi-recent trees that enable it (for new-style WoW64 builds)
+    # This workarounds the "Internal error" message when running a 32-bit program in the new-style WoW64 mode
+    if ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 2e9f238732289907b4f07335d826ac3e7882f5ba HEAD ) && [ "${_NOLIB32}" != "false" ]; then
+      warning "Disable ntdll-Syscall_Emulation patchset for WoW64 builds (on staging 2e9f2387+)"
+      _staging_args+=(-W ntdll-Syscall_Emulation)
+    fi
+
     # Esync is broken on staging commit dc77e28, breaking fsync as a result. Some hunks are getting unordered due to similar contexts. So let's add a bit more context as a fix.
     if ( cd "${srcdir}"/"${_stgsrcdir}" && [ "$(git rev-parse HEAD)" = "dc77e28b0f7d6fdb11dafacb73b9889545359572" ] ); then
       warning "Fix eventfd_synchronization on staging dc77e28"


### PR DESCRIPTION
It's currently broken in this case because it causes an error when running a 32-bit application in the WoW64 mode :frog:

Note: I targeted a high enough commit because I doubt WoW64 works on Wine v7.20 well enough to be usable