### PR TITLE
Fix ccache not being set on newer Wine versions/WoW64

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/build-32.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build-32.sh
@@ -6,6 +6,7 @@ _exports_32() {
 	fi
 	if [ -e /usr/bin/ccache ] && [ "$_NOMINGW" != "true" ]; then
 		export CROSSCC="ccache i686-w64-mingw32-gcc" && echo "CROSSCC32 = ${CROSSCC}" >>"$_LAST_BUILD_CONFIG"
+		export i386_CC="${CROSSCC}"
 	fi
   fi
   # build wine 32-bit

--- a/wine-tkg-git/wine-tkg-scripts/build-64.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build-64.sh
@@ -6,6 +6,12 @@ _exports_64() {
 	fi
 	if [ -e /usr/bin/ccache ] && [ "$_NOMINGW" != "true" ]; then
 		export CROSSCC="ccache x86_64-w64-mingw32-gcc" && echo "CROSSCC64 = ${CROSSCC}" >>"$_LAST_BUILD_CONFIG"
+		export x86_64_CC="${CROSSCC}"
+
+		# Required for new-style WoW64 builds (otherwise 32-bit portions won't be ccached)
+		if [ "${_NOLIB32}" != "false" ]; then
+			export i386_CC="ccache i686-w64-mingw32-gcc"
+		fi
 	fi
   fi
   # If /usr/lib32 doesn't exist (such as on Fedora), make sure we're using /usr/lib64 for 64-bit pkgconfig path


### PR DESCRIPTION
Wine commit b1f59bc679a8c2dea18a6789a5b9b1a1ae825129 made some changes to how CC variables work, so we have to set it for the individual architectures now

This also sets the i386 variable for 64-bit-only WoW64 builds (this is because of the way new-style WoW64 builds work)