### PR TITLE
Skip the Steam patch on new enough trees

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/steam/steam
+++ b/wine-tkg-git/wine-tkg-patches/misc/steam/steam
@@ -2,7 +2,7 @@
 
 	# steam crossover hack for store/web functionality
 	# https://bugs.winehq.org/show_bug.cgi?id=39403
-	if [ "$_steam_fix" = "true" ]; then
+	if [ "$_steam_fix" = "true" ] && ! git merge-base --is-ancestor 917a206b01c82170a862e8497cbe26b6f1bfade0 HEAD; then
 	  if git merge-base --is-ancestor 712ae337fe02c2e222e7c3067e5f624160bb84a1 HEAD; then
 	    _patchname='steam.patch' && _patchmsg="Applied steam crossover hack" && nonuser_patcher
 	  else


### PR DESCRIPTION
The bug report linked in the patch file reveals that the bug has been fixed a long time ago, so update the patch target accordingly

I also confirmed that Steam works on regular wine-staging too, so this patch definitely isn't necessary :frog: