### PR TITLE
Don't disable ntdll-Syscall-Emulation from 'abbfbb8e'

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
@@ -277,9 +277,13 @@ EOM
 
     # Disable problematic syscall emulation patchset in semi-recent trees that enable it (for new-style WoW64 builds)
     # This workarounds the "Internal error" message when running a 32-bit program in the new-style WoW64 mode
-    if ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 2e9f238732289907b4f07335d826ac3e7882f5ba HEAD ) && [ "${_NOLIB32}" != "false" ]; then
-      warning "Disable ntdll-Syscall_Emulation patchset for WoW64 builds (on staging 2e9f2387+)"
-      _staging_args+=(-W ntdll-Syscall_Emulation)
+    # Staging commit 'abbfbb8e' disables this patchset by default; trying to disable it again would trigger a failure in the staging patch script
+    if ( cd "${srcdir}"/"${_stgsrcdir}" &&
+    git merge-base --is-ancestor 2e9f238732289907b4f07335d826ac3e7882f5ba HEAD &&
+    ! git merge-base --is-ancestor abbfbb8e1565bf4c8006aba37cd76d4b0020d7f8 HEAD ) &&
+    [ "${_NOLIB32}" != "false" ]; then
+    warning "Disable ntdll-Syscall_Emulation patchset for WoW64 builds (on staging 2e9f2387+, until abbfbb8e)"
+    _staging_args+=(-W ntdll-Syscall_Emulation)
     fi
 
     # Esync is broken on staging commit dc77e28, breaking fsync as a result. Some hunks are getting unordered due to similar contexts. So let's add a bit more context as a fix.


### PR DESCRIPTION
Starting from 'abbfbb8e' this patch is disabled by default, so trying to disable it again would trigger a build failure because the staging patch script wouldn't find the patch, hence the failure.