### PR TITLE
Disable LAA patch for WoW64 builds

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton/LAA/LAA
+++ b/wine-tkg-git/wine-tkg-patches/proton/LAA/LAA
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 	# IMAGE_FILE_LARGE_ADDRESS_AWARE override - Enable with WINE_LARGE_ADDRESS_AWARE=1
-	if [ "$_large_address_aware" = "true" ]; then
+	if [ "$_large_address_aware" = "true" ] && [ "$_NOLIB32" != "wow64" ]; then
 	  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 46d0da53b61254d52aa86c6cb524609110cb1213 HEAD ); then
 	    if [ "$_use_staging" = "true" ]; then
 	      _patchname='LAA-unix-staging.patch' && _patchmsg="Applied large address aware override support (legacy)" && nonuser_patcher

--- a/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
@@ -190,6 +190,7 @@ _nvidia_hate="false"
 _sdl_joy_support="false"
 
 # IMAGE_FILE_LARGE_ADDRESS_AWARE override - Will be force-disabled on lower than 3.19 - Useful for 32-bit games hitting address space limitations - Disable with WINE_LARGE_ADDRESS_AWARE=0
+# Doesn't work properly together with WoW64 experimental mode
 _large_address_aware="true"
 
 # Proton Bcrypt patches - Fixes RDR2 online, notably - Replaces Staging's bcrypt-ECDHSecretAgreement


### PR DESCRIPTION
Large Address Aware seems to be not adapted to work with WoW64, so it causes an error during runtime: 
`wine client error:1a8: sendmsg: Bad file descriptor`
So I suggest disabling it for all WoW64 builds until it is fixed (probably?). 