### PR TITLE
Add wine64 symlink for WoW64 builds

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -238,6 +238,12 @@ _package_nomakepkg() {
 	cp -v "$_where"/wine-tkg-scripts/wine64-tkg "$_prefix"/bin/wine64-tkg
 	cp -v "$_where"/wine-tkg-scripts/wine-tkg-interactive "$_prefix"/bin/wine-tkg-interactive
 
+	# Fixes compatibility with installation scripts (like winetricks) that use
+	# the wine64 binary, which is not present in WoW64 builds.
+	if [ "$_NOLIB32" = "wow64" ]; then
+	    ln -s "$_prefix"/bin/wine "${pkgdir}$_prefix"/bin/wine64
+	fi
+
 	# strip
 	if [ "$_EXTERNAL_INSTALL" != "proton" ]; then
 	  if [ "$_protonify" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && ! git merge-base --is-ancestor 2e5e5ade82b5e3b1d70ebe6b1a824bdfdedfd04e HEAD ); then
@@ -403,6 +409,12 @@ _package_makepkg() {
 	cp "$_where"/wine-tkg-scripts/wine-tkg "${pkgdir}$_prefix"/bin/wine-tkg
 	cp "$_where"/wine-tkg-scripts/wine64-tkg "${pkgdir}$_prefix"/bin/wine64-tkg
 	cp "$_where"/wine-tkg-scripts/wine-tkg-interactive "${pkgdir}$_prefix"/bin/wine-tkg-interactive
+
+	# Fixes compatibility with installation scripts (like winetricks) that use
+	# the wine64 binary, which is not present in WoW64 builds.
+	if [ "$_NOLIB32" = "wow64" ]; then
+	    ln -s "$_prefix"/bin/wine "${pkgdir}$_prefix"/bin/wine64
+	fi
 
 	# strip
 	if [ "$_EXTERNAL_INSTALL" != "proton" ]; then


### PR DESCRIPTION
This fixes installation scripts such as winetricks and setup_dxvk for WoW64 builds that don't have the wine64 binary in them. Of course, this should be fixed on the side of the scripts themselves, but for now I suggest create symlink to make life easier for users.