### PR TITLE
Use relative path instead of absolute path

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -241,7 +241,7 @@ _package_nomakepkg() {
 	# Fixes compatibility with installation scripts (like winetricks) that use
 	# the wine64 binary, which is not present in WoW64 builds.
 	if [ "$_NOLIB32" = "wow64" ]; then
-	    ln -s "$_prefix"/bin/wine "${pkgdir}$_prefix"/bin/wine64
+	    ( cd "$_prefix/bin" && ln -s wine wine64 )
 	fi
 
 	# strip


### PR DESCRIPTION
Indeed when you want to move the construction or share it, the link is no longer correct.

Before:
```
$ ls -la .
-rwxr-xr-x 1 iroalexis wheel  16488 Aug 12 14:21 wine
lrwxrwxrwx 1 iroalexis wheel    110 Aug 12 14:23 wine64 -> /home/iroalexis/projects/wine-tkg-git/wine-tkg-git/wine-tkg-clean-mainline-git-8.13.r343.gb2a099b3cee/bin/wine
```
Now
```
$ ls -la .
-rwxr-xr-x 1 iroalexis wheel  16488 Aug 12 14:00 wine
lrwxrwxrwx 1 iroalexis wheel      4 Aug 12 14:02 wine64 -> wine
```