### PR TITLE
Adjust wine64 symlink fix for use it too into PKGBUILD

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -413,7 +413,7 @@ _package_makepkg() {
 	# Fixes compatibility with installation scripts (like winetricks) that use
 	# the wine64 binary, which is not present in WoW64 builds.
 	if [ "$_NOLIB32" = "wow64" ]; then
-	    ln -s "$_prefix"/bin/wine "${pkgdir}$_prefix"/bin/wine64
+	    ( cd "${pkgdir}$_prefix/bin" && ln -s wine wine64 )
 	fi
 
 	# strip


### PR DESCRIPTION
I forgot the PKGBUILD build even if it's less serious but it's cleaner and adopts the same behavior as Wine's tools (winecpp for example) :frog: 