### PR TITLE
ntsync5: Update all ntsync5 patch files

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index ae5def6a6b1..6848ae65ff9 100755
+index 83a641f..2016c09 100755
 --- a/configure
 +++ b/configure
-@@ -8004,6 +8004,12 @@ if test "x$ac_cv_header_linux_major_h" = xyes
+@@ -7977,6 +7977,12 @@ if test "x$ac_cv_header_linux_major_h" = xyes
  then :
    printf "%s\n" "#define HAVE_LINUX_MAJOR_H 1" >>confdefs.h
  
@@ -16,10 +16,10 @@ index ae5def6a6b1..6848ae65ff9 100755
  ac_fn_c_check_header_compile "$LINENO" "linux/param.h" "ac_cv_header_linux_param_h" "$ac_includes_default"
  if test "x$ac_cv_header_linux_param_h" = xyes
 diff --git a/configure.ac b/configure.ac
-index 475743bc121..f4155253181 100644
+index 64083de..f6c7639 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -425,6 +425,7 @@ AC_CHECK_HEADERS(\
+@@ -402,6 +402,7 @@ AC_CHECK_HEADERS(\
  	linux/input.h \
  	linux/ioctl.h \
  	linux/major.h \
@@ -28,10 +28,10 @@ index 475743bc121..f4155253181 100644
  	linux/serial.h \
  	linux/types.h \
 diff --git a/dlls/kernel32/tests/sync.c b/dlls/kernel32/tests/sync.c
-index 56a9d6e4859..48e4f8d7b4d 100644
+index 25cf75c..50e81aa 100644
 --- a/dlls/kernel32/tests/sync.c
 +++ b/dlls/kernel32/tests/sync.c
-@@ -2841,6 +2841,84 @@ static void test_QueueUserAPC(void)
+@@ -2871,6 +2871,84 @@ static void test_QueueUserAPC(void)
      ok(apc_count == 1, "APC count %u\n", apc_count);
  }
  
@@ -116,7 +116,7 @@ index 56a9d6e4859..48e4f8d7b4d 100644
  START_TEST(sync)
  {
      char **argv;
-@@ -2911,5 +2989,6 @@ START_TEST(sync)
+@@ -2941,5 +3019,6 @@ START_TEST(sync)
      test_srwlock_example();
      test_alertable_wait();
      test_apc_deadlock();
@@ -124,10 +124,10 @@ index 56a9d6e4859..48e4f8d7b4d 100644
      test_crit_section();
  }
 diff --git a/dlls/ntdll/unix/file.c b/dlls/ntdll/unix/file.c
-index ee68e4dee9b..9f2707f9eeb 100644
+index d292d93..17e7266 100644
 --- a/dlls/ntdll/unix/file.c
 +++ b/dlls/ntdll/unix/file.c
-@@ -6344,7 +6344,7 @@ NTSTATUS WINAPI NtLockFile( HANDLE file, HANDLE event, PIO_APC_ROUTINE apc, void
+@@ -6372,7 +6372,7 @@ NTSTATUS WINAPI NtLockFile( HANDLE file, HANDLE event, PIO_APC_ROUTINE apc, void
          }
          if (handle)
          {
@@ -137,10 +137,10 @@ index ee68e4dee9b..9f2707f9eeb 100644
          }
          else  /* Unix lock conflict, sleep a bit and retry */
 diff --git a/dlls/ntdll/unix/process.c b/dlls/ntdll/unix/process.c
-index 71eab55920d..8e4407e7a6d 100644
+index bf24161..30ba4a4 100644
 --- a/dlls/ntdll/unix/process.c
 +++ b/dlls/ntdll/unix/process.c
-@@ -916,7 +916,7 @@ NTSTATUS WINAPI NtCreateUserProcess( HANDLE *process_handle_ptr, HANDLE *thread_
+@@ -921,7 +921,7 @@ NTSTATUS WINAPI NtCreateUserProcess( HANDLE *process_handle_ptr, HANDLE *thread_
  
      /* wait for the new process info to be ready */
  
@@ -150,7 +150,7 @@ index 71eab55920d..8e4407e7a6d 100644
      {
          req->info = wine_server_obj_handle( process_info );
 diff --git a/dlls/ntdll/unix/server.c b/dlls/ntdll/unix/server.c
-index 69e6567c911..c90f8ab4019 100644
+index 88ac955..59ad123 100644
 --- a/dlls/ntdll/unix/server.c
 +++ b/dlls/ntdll/unix/server.c
 @@ -103,7 +103,7 @@ sigset_t server_block_set;  /* signals to block during server calls */
@@ -193,7 +193,7 @@ index 69e6567c911..c90f8ab4019 100644
  
              SERVER_START_REQ( get_apc_result )
              {
-@@ -1774,12 +1789,17 @@ NTSTATUS WINAPI NtDuplicateObject( HANDLE source_process, HANDLE source, HANDLE
+@@ -1773,12 +1788,17 @@ NTSTATUS WINAPI NtDuplicateObject( HANDLE source_process, HANDLE source, HANDLE
          return result.dup_handle.status;
      }
  
@@ -211,7 +211,7 @@ index 69e6567c911..c90f8ab4019 100644
  
      SERVER_START_REQ( dup_handle )
      {
-@@ -1845,12 +1865,16 @@ NTSTATUS WINAPI NtClose( HANDLE handle )
+@@ -1844,12 +1864,16 @@ NTSTATUS WINAPI NtClose( HANDLE handle )
      if (HandleToLong( handle ) >= ~5 && HandleToLong( handle ) <= ~0)
          return STATUS_SUCCESS;
  
@@ -229,7 +229,7 @@ index 69e6567c911..c90f8ab4019 100644
      {
          req->handle = wine_server_obj_handle( handle );
 diff --git a/dlls/ntdll/unix/sync.c b/dlls/ntdll/unix/sync.c
-index bfbcaf4a851..f650d072cd4 100644
+index cde6a0f..a9a0a2c 100644
 --- a/dlls/ntdll/unix/sync.c
 +++ b/dlls/ntdll/unix/sync.c
 @@ -30,9 +30,11 @@
@@ -275,7 +275,7 @@ index bfbcaf4a851..f650d072cd4 100644
  /* return a monotonic time counter, in Win32 ticks */
  static inline ULONGLONG monotonic_counter(void)
  {
-@@ -258,6 +266,908 @@ static unsigned int validate_open_object_attributes( const OBJECT_ATTRIBUTES *at
+@@ -238,6 +246,902 @@ static unsigned int validate_open_object_attributes( const OBJECT_ATTRIBUTES *at
  }
  
  
@@ -372,9 +372,10 @@ index bfbcaf4a851..f650d072cd4 100644
 +
 +static void release_fast_sync_obj( struct fast_sync_cache_entry *cache )
 +{
-+    /* save the handle now; as soon as the refcount hits 0 we cannot access the
-+     * cache anymore */
++    /* save the handle and fd now; as soon as the refcount hits 0 we cannot
++     * access the cache anymore */
 +    HANDLE handle = wine_server_ptr_handle( cache->handle );
++    int fd = cache->fd;
 +    LONG refcount = InterlockedDecrement( &cache->refcount );
 +
 +    assert( refcount >= 0 );
@@ -392,6 +393,7 @@ index bfbcaf4a851..f650d072cd4 100644
 +        SERVER_END_REQ;
 +
 +        assert( !ret );
++        close( fd );
 +    }
 +}
 +
@@ -865,33 +867,6 @@ index bfbcaf4a851..f650d072cd4 100644
 +    return ret;
 +}
 +
-+static __u64 fast_get_timeout( const LARGE_INTEGER *timeout )
-+{
-+    struct timespec now;
-+    timeout_t relative;
-+
-+    if (!timeout || timeout->QuadPart == TIMEOUT_INFINITE)
-+        return ~(__u64)0;
-+
-+    clock_gettime( CLOCK_MONOTONIC, &now );
-+
-+    if (timeout->QuadPart <= 0)
-+    {
-+        relative = -timeout->QuadPart;
-+    }
-+    else
-+    {
-+        LARGE_INTEGER system_now;
-+
-+        /* the system clock is REALTIME, so we need to convert to
-+         * relative time first */
-+        NtQuerySystemTime( &system_now );
-+        relative = timeout->QuadPart - system_now.QuadPart;
-+    }
-+
-+    return (now.tv_sec * 1000000000) + now.tv_nsec + (relative * 100);
-+}
-+
 +static void select_queue( HANDLE queue )
 +{
 +    SERVER_START_REQ( fast_select_queue )
@@ -933,6 +908,10 @@ index bfbcaf4a851..f650d072cd4 100644
 +        if ((ret = get_fast_sync_obj( alert_handle, 0, SYNCHRONIZE, &stack_cache, &cache )))
 +            ERR( "failed to get fast alert obj, status %#x\n", ret );
 +        data->fast_alert_obj = cache->fd;
++        /* Set the fd to -1 so release_fast_sync_obj() won't close it.
++         * Manhandling the cache entry here is fine since we're the only thread
++         * that can access our own alert event. */
++        cache->fd = -1;
 +        release_fast_sync_obj( cache );
 +        NtClose( alert_handle );
 +    }
@@ -945,9 +924,24 @@ index bfbcaf4a851..f650d072cd4 100644
 +{
 +    struct ntsync_wait_args args = {0};
 +    unsigned long request;
++    struct timespec now;
 +    int ret;
 +
-+    args.timeout = fast_get_timeout( timeout );
++    if (!timeout || timeout->QuadPart == TIMEOUT_INFINITE)
++    {
++        args.timeout = ~(__u64)0;
++    }
++    else if (timeout->QuadPart <= 0)
++    {
++        clock_gettime( CLOCK_MONOTONIC, &now );
++        args.timeout = (now.tv_sec * NSECPERSEC) + now.tv_nsec + (-timeout->QuadPart * 100);
++    }
++    else
++    {
++        args.timeout = (timeout->QuadPart * 100) - (SECS_1601_TO_1970 * NSECPERSEC);
++        args.flags |= NTSYNC_WAIT_REALTIME;
++    }
++
 +    args.objs = (uintptr_t)objs;
 +    args.count = count;
 +    args.owner = GetCurrentThreadId();
@@ -1184,7 +1178,7 @@ index bfbcaf4a851..f650d072cd4 100644
  /******************************************************************************
   *              NtCreateSemaphore (NTDLL.@)
   */
-@@ -268,6 +1178,9 @@ NTSTATUS WINAPI NtCreateSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJ
+@@ -248,6 +1152,9 @@ NTSTATUS WINAPI NtCreateSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJ
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1194,7 +1188,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if (max <= 0 || initial < 0 || initial > max) return STATUS_INVALID_PARAMETER;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
-@@ -295,6 +1208,8 @@ NTSTATUS WINAPI NtOpenSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJEC
+@@ -275,6 +1182,8 @@ NTSTATUS WINAPI NtOpenSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJEC
  {
      unsigned int ret;
  
@@ -1203,7 +1197,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -332,6 +1247,12 @@ NTSTATUS WINAPI NtQuerySemaphore( HANDLE handle, SEMAPHORE_INFORMATION_CLASS cla
+@@ -312,6 +1221,12 @@ NTSTATUS WINAPI NtQuerySemaphore( HANDLE handle, SEMAPHORE_INFORMATION_CLASS cla
  
      if (len != sizeof(SEMAPHORE_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
  
@@ -1216,7 +1210,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( query_semaphore )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -354,6 +1275,11 @@ NTSTATUS WINAPI NtReleaseSemaphore( HANDLE handle, ULONG count, ULONG *previous
+@@ -334,6 +1249,11 @@ NTSTATUS WINAPI NtReleaseSemaphore( HANDLE handle, ULONG count, ULONG *previous
  {
      unsigned int ret;
  
@@ -1228,7 +1222,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( release_semaphore )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -378,6 +1304,9 @@ NTSTATUS WINAPI NtCreateEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_
+@@ -358,6 +1278,9 @@ NTSTATUS WINAPI NtCreateEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1238,7 +1232,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if (type != NotificationEvent && type != SynchronizationEvent) return STATUS_INVALID_PARAMETER;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
-@@ -405,6 +1334,8 @@ NTSTATUS WINAPI NtOpenEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
+@@ -385,6 +1308,8 @@ NTSTATUS WINAPI NtOpenEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
  {
      unsigned int ret;
  
@@ -1247,7 +1241,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -430,6 +1361,11 @@ NTSTATUS WINAPI NtSetEvent( HANDLE handle, LONG *prev_state )
+@@ -410,6 +1335,11 @@ NTSTATUS WINAPI NtSetEvent( HANDLE handle, LONG *prev_state )
  {
      unsigned int ret;
  
@@ -1259,7 +1253,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( event_op )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -449,6 +1385,11 @@ NTSTATUS WINAPI NtResetEvent( HANDLE handle, LONG *prev_state )
+@@ -429,6 +1359,11 @@ NTSTATUS WINAPI NtResetEvent( HANDLE handle, LONG *prev_state )
  {
      unsigned int ret;
  
@@ -1271,7 +1265,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( event_op )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -478,6 +1419,11 @@ NTSTATUS WINAPI NtPulseEvent( HANDLE handle, LONG *prev_state )
+@@ -458,6 +1393,11 @@ NTSTATUS WINAPI NtPulseEvent( HANDLE handle, LONG *prev_state )
  {
      unsigned int ret;
  
@@ -1283,7 +1277,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( event_op )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -509,6 +1455,12 @@ NTSTATUS WINAPI NtQueryEvent( HANDLE handle, EVENT_INFORMATION_CLASS class,
+@@ -489,6 +1429,12 @@ NTSTATUS WINAPI NtQueryEvent( HANDLE handle, EVENT_INFORMATION_CLASS class,
  
      if (len != sizeof(EVENT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
  
@@ -1296,7 +1290,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( query_event )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -534,6 +1486,9 @@ NTSTATUS WINAPI NtCreateMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT
+@@ -514,6 +1460,9 @@ NTSTATUS WINAPI NtCreateMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1306,7 +1300,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
  
-@@ -559,6 +1514,8 @@ NTSTATUS WINAPI NtOpenMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT_A
+@@ -539,6 +1488,8 @@ NTSTATUS WINAPI NtOpenMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT_A
  {
      unsigned int ret;
  
@@ -1315,7 +1309,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -584,6 +1541,11 @@ NTSTATUS WINAPI NtReleaseMutant( HANDLE handle, LONG *prev_count )
+@@ -564,6 +1515,11 @@ NTSTATUS WINAPI NtReleaseMutant( HANDLE handle, LONG *prev_count )
  {
      unsigned int ret;
  
@@ -1327,7 +1321,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( release_mutex )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -614,6 +1576,12 @@ NTSTATUS WINAPI NtQueryMutant( HANDLE handle, MUTANT_INFORMATION_CLASS class,
+@@ -594,6 +1550,12 @@ NTSTATUS WINAPI NtQueryMutant( HANDLE handle, MUTANT_INFORMATION_CLASS class,
  
      if (len != sizeof(MUTANT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
  
@@ -1340,7 +1334,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( query_mutex )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -1321,6 +2289,9 @@ NTSTATUS WINAPI NtCreateTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_
+@@ -1301,6 +2263,9 @@ NTSTATUS WINAPI NtCreateTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1350,7 +1344,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if (type != NotificationTimer && type != SynchronizationTimer) return STATUS_INVALID_PARAMETER;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
-@@ -1348,6 +2319,8 @@ NTSTATUS WINAPI NtOpenTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
+@@ -1328,6 +2293,8 @@ NTSTATUS WINAPI NtOpenTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
  {
      unsigned int ret;
  
@@ -1359,7 +1353,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -1401,6 +2374,8 @@ NTSTATUS WINAPI NtCancelTimer( HANDLE handle, BOOLEAN *state )
+@@ -1381,6 +2348,8 @@ NTSTATUS WINAPI NtCancelTimer( HANDLE handle, BOOLEAN *state )
  {
      unsigned int ret;
  
@@ -1368,7 +1362,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( cancel_timer )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -1469,13 +2444,29 @@ NTSTATUS WINAPI NtWaitForMultipleObjects( DWORD count, const HANDLE *handles, BO
+@@ -1449,13 +2418,29 @@ NTSTATUS WINAPI NtWaitForMultipleObjects( DWORD count, const HANDLE *handles, BO
  {
      select_op_t select_op;
      UINT i, flags = SELECT_INTERRUPTIBLE;
@@ -1399,7 +1393,7 @@ index bfbcaf4a851..f650d072cd4 100644
  }
  
  
-@@ -1496,9 +2487,15 @@ NTSTATUS WINAPI NtSignalAndWaitForSingleObject( HANDLE signal, HANDLE wait,
+@@ -1476,9 +2461,15 @@ NTSTATUS WINAPI NtSignalAndWaitForSingleObject( HANDLE signal, HANDLE wait,
  {
      select_op_t select_op;
      UINT flags = SELECT_INTERRUPTIBLE;
@@ -1415,7 +1409,7 @@ index bfbcaf4a851..f650d072cd4 100644
      if (alertable) flags |= SELECT_ALERTABLE;
      select_op.signal_and_wait.op = SELECT_SIGNAL_AND_WAIT;
      select_op.signal_and_wait.wait = wine_server_obj_handle( wait );
-@@ -1721,6 +2718,9 @@ NTSTATUS WINAPI NtCreateKeyedEvent( HANDLE *handle, ACCESS_MASK access,
+@@ -1701,6 +2692,9 @@ NTSTATUS WINAPI NtCreateKeyedEvent( HANDLE *handle, ACCESS_MASK access,
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1425,7 +1419,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
  
-@@ -1745,6 +2745,8 @@ NTSTATUS WINAPI NtOpenKeyedEvent( HANDLE *handle, ACCESS_MASK access, const OBJE
+@@ -1725,6 +2719,8 @@ NTSTATUS WINAPI NtOpenKeyedEvent( HANDLE *handle, ACCESS_MASK access, const OBJE
  {
      unsigned int ret;
  
@@ -1434,7 +1428,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -1771,6 +2773,8 @@ NTSTATUS WINAPI NtWaitForKeyedEvent( HANDLE handle, const void *key,
+@@ -1751,6 +2747,8 @@ NTSTATUS WINAPI NtWaitForKeyedEvent( HANDLE handle, const void *key,
      select_op_t select_op;
      UINT flags = SELECT_INTERRUPTIBLE;
  
@@ -1443,7 +1437,7 @@ index bfbcaf4a851..f650d072cd4 100644
      if (!handle) handle = keyed_event;
      if ((ULONG_PTR)key & 1) return STATUS_INVALID_PARAMETER_1;
      if (alertable) flags |= SELECT_ALERTABLE;
-@@ -1790,6 +2794,8 @@ NTSTATUS WINAPI NtReleaseKeyedEvent( HANDLE handle, const void *key,
+@@ -1770,6 +2768,8 @@ NTSTATUS WINAPI NtReleaseKeyedEvent( HANDLE handle, const void *key,
      select_op_t select_op;
      UINT flags = SELECT_INTERRUPTIBLE;
  
@@ -1453,10 +1447,10 @@ index bfbcaf4a851..f650d072cd4 100644
      if ((ULONG_PTR)key & 1) return STATUS_INVALID_PARAMETER_1;
      if (alertable) flags |= SELECT_ALERTABLE;
 diff --git a/dlls/ntdll/unix/thread.c b/dlls/ntdll/unix/thread.c
-index 9e84ec3cc96..d0cb1db090e 100644
+index 6a0f2fa..a5a0490 100644
 --- a/dlls/ntdll/unix/thread.c
 +++ b/dlls/ntdll/unix/thread.c
-@@ -1755,7 +1755,7 @@ NTSTATUS get_thread_context( HANDLE handle, void *context, BOOL *self, USHORT ma
+@@ -1758,7 +1758,7 @@ NTSTATUS get_thread_context( HANDLE handle, void *context, BOOL *self, USHORT ma
  
      if (ret == STATUS_PENDING)
      {
@@ -1466,7 +1460,7 @@ index 9e84ec3cc96..d0cb1db090e 100644
          SERVER_START_REQ( get_thread_context )
          {
 diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
-index 07f2724eac7..e8dd9bbb035 100644
+index b249570..11998df 100644
 --- a/dlls/ntdll/unix/unix_private.h
 +++ b/dlls/ntdll/unix/unix_private.h
 @@ -101,6 +101,7 @@ struct ntdll_thread_data
@@ -1477,8 +1471,8 @@ index 07f2724eac7..e8dd9bbb035 100644
  };
  
  C_ASSERT( sizeof(struct ntdll_thread_data) <= sizeof(((TEB *)0)->GdiTebBatch) );
-@@ -192,6 +193,8 @@ extern NTSTATUS load_main_exe( const WCHAR *name, const char *unix_name, const W
- extern NTSTATUS load_start_exe( WCHAR **image, void **module );
+@@ -194,6 +195,8 @@ extern NTSTATUS load_start_exe( WCHAR **image, void **module );
+ extern ULONG_PTR redirect_arm64ec_rva( void *module, ULONG_PTR rva, const IMAGE_ARM64EC_METADATA *metadata );
  extern void start_server( BOOL debug );
  
 +extern pthread_mutex_t fd_cache_mutex;
@@ -1486,7 +1480,7 @@ index 07f2724eac7..e8dd9bbb035 100644
  extern unsigned int server_call_unlocked( void *req_ptr );
  extern void server_enter_uninterrupted_section( pthread_mutex_t *mutex, sigset_t *sigset );
  extern void server_leave_uninterrupted_section( pthread_mutex_t *mutex, sigset_t *sigset );
-@@ -199,6 +202,7 @@ extern unsigned int server_select( const select_op_t *select_op, data_size_t siz
+@@ -201,6 +204,7 @@ extern unsigned int server_select( const select_op_t *select_op, data_size_t siz
                                     timeout_t abs_timeout, context_t *context, user_apc_t *user_apc );
  extern unsigned int server_wait( const select_op_t *select_op, data_size_t size, UINT flags,
                                   const LARGE_INTEGER *timeout );
@@ -1494,7 +1488,7 @@ index 07f2724eac7..e8dd9bbb035 100644
  extern unsigned int server_queue_process_apc( HANDLE process, const apc_call_t *call,
                                                apc_result_t *result );
  extern int server_get_unix_fd( HANDLE handle, unsigned int wanted_access, int *unix_fd,
-@@ -335,6 +339,8 @@ extern NTSTATUS wow64_wine_spawnvp( void *args );
+@@ -349,6 +353,8 @@ extern NTSTATUS wow64_wine_spawnvp( void *args );
  
  extern void dbg_init(void);
  
@@ -1503,7 +1497,15 @@ index 07f2724eac7..e8dd9bbb035 100644
  extern NTSTATUS call_user_apc_dispatcher( CONTEXT *context_ptr, ULONG_PTR arg1, ULONG_PTR arg2, ULONG_PTR arg3,
                                            PNTAPCFUNC func, NTSTATUS status );
  extern NTSTATUS call_user_exception_dispatcher( EXCEPTION_RECORD *rec, CONTEXT *context );
-@@ -401,7 +407,7 @@ static inline async_data_t server_async( HANDLE handle, struct async_fileio *use
+@@ -357,6 +363,7 @@ extern void call_raise_user_exception_dispatcher(void);
+ #define IMAGE_DLLCHARACTERISTICS_PREFER_NATIVE 0x0010 /* Wine extension */
+ 
+ #define TICKSPERSEC 10000000
++#define NSECPERSEC 1000000000
+ #define SECS_1601_TO_1970  ((369 * 365 + 89) * (ULONGLONG)86400)
+ 
+ static inline ULONGLONG ticks_from_time_t( time_t time )
+@@ -415,7 +422,7 @@ static inline async_data_t server_async( HANDLE handle, struct async_fileio *use
  
  static inline NTSTATUS wait_async( HANDLE handle, BOOL alertable )
  {
@@ -1513,7 +1515,7 @@ index 07f2724eac7..e8dd9bbb035 100644
  
  static inline BOOL in_wow64_call(void)
 diff --git a/dlls/webservices/tests/channel.c b/dlls/webservices/tests/channel.c
-index 4cf39c10732..1fb12297eef 100644
+index 4cf39c1..1fb1229 100644
 --- a/dlls/webservices/tests/channel.c
 +++ b/dlls/webservices/tests/channel.c
 @@ -1214,6 +1214,9 @@ static const char send_record_begin[] = {
@@ -1527,7 +1529,7 @@ index 4cf39c10732..1fb12297eef 100644
  {
      char buf[512], dict_buf[256], body_buf[128], dict_size_buf[5];
 diff --git a/include/config.h.in b/include/config.h.in
-index cda76fcfe2e..16685419788 100644
+index a910b2c..7789dbd 100644
 --- a/include/config.h.in
 +++ b/include/config.h.in
 @@ -174,6 +174,9 @@
@@ -1541,10 +1543,10 @@ index cda76fcfe2e..16685419788 100644
  #undef HAVE_LINUX_PARAM_H
  
 diff --git a/include/wine/server_protocol.h b/include/wine/server_protocol.h
-index 139a7bca69e..9de93637410 100644
+index 34655d1..1f8e10a 100644
 --- a/include/wine/server_protocol.h
 +++ b/include/wine/server_protocol.h
-@@ -5637,6 +5637,88 @@ struct get_next_thread_reply
+@@ -5634,6 +5634,88 @@ struct get_next_thread_reply
  };
  
  
@@ -1633,7 +1635,7 @@ index 139a7bca69e..9de93637410 100644
  enum request
  {
      REQ_new_process,
-@@ -5923,6 +6005,11 @@ enum request
+@@ -5921,6 +6003,11 @@ enum request
      REQ_suspend_process,
      REQ_resume_process,
      REQ_get_next_thread,
@@ -1645,7 +1647,7 @@ index 139a7bca69e..9de93637410 100644
      REQ_NB_REQUESTS
  };
  
-@@ -6214,6 +6301,11 @@ union generic_request
+@@ -6213,6 +6300,11 @@ union generic_request
      struct suspend_process_request suspend_process_request;
      struct resume_process_request resume_process_request;
      struct get_next_thread_request get_next_thread_request;
@@ -1670,7 +1672,7 @@ index 139a7bca69e..9de93637410 100644
  
  /* ### protocol_version begin ### */
 diff --git a/server/Makefile.in b/server/Makefile.in
-index 7b46b924c46..d21bd5541c7 100644
+index 7b46b92..d21bd55 100644
 --- a/server/Makefile.in
 +++ b/server/Makefile.in
 @@ -12,6 +12,7 @@ SOURCES = \
@@ -1682,7 +1684,7 @@ index 7b46b924c46..d21bd5541c7 100644
  	file.c \
  	handle.c \
 diff --git a/server/async.c b/server/async.c
-index 9cb251df5ce..09c5e1ec9a7 100644
+index 80129ac..02fb966 100644
 --- a/server/async.c
 +++ b/server/async.c
 @@ -89,6 +89,7 @@ static const struct object_ops async_ops =
@@ -1693,7 +1695,7 @@ index 9cb251df5ce..09c5e1ec9a7 100644
      no_close_handle,           /* close_handle */
      async_destroy              /* destroy */
  };
-@@ -688,6 +689,7 @@ static const struct object_ops iosb_ops =
+@@ -698,6 +699,7 @@ static const struct object_ops iosb_ops =
      NULL,                     /* unlink_name */
      no_open_file,             /* open_file */
      no_kernel_obj_list,       /* get_kernel_obj_list */
@@ -1702,7 +1704,7 @@ index 9cb251df5ce..09c5e1ec9a7 100644
      iosb_destroy              /* destroy */
  };
 diff --git a/server/atom.c b/server/atom.c
-index ff0799f5880..ba320c4c630 100644
+index ff0799f..ba320c4 100644
 --- a/server/atom.c
 +++ b/server/atom.c
 @@ -91,6 +91,7 @@ static const struct object_ops atom_table_ops =
@@ -1714,7 +1716,7 @@ index ff0799f5880..ba320c4c630 100644
      atom_table_destroy            /* destroy */
  };
 diff --git a/server/change.c b/server/change.c
-index 843e495411c..20b80f98548 100644
+index 843e495..20b80f9 100644
 --- a/server/change.c
 +++ b/server/change.c
 @@ -124,6 +124,7 @@ static const struct object_ops dir_ops =
@@ -1726,7 +1728,7 @@ index 843e495411c..20b80f98548 100644
      dir_destroy               /* destroy */
  };
 diff --git a/server/clipboard.c b/server/clipboard.c
-index 8118a467dd8..de9f84f74d0 100644
+index 8118a46..de9f84f 100644
 --- a/server/clipboard.c
 +++ b/server/clipboard.c
 @@ -88,6 +88,7 @@ static const struct object_ops clipboard_ops =
@@ -1738,7 +1740,7 @@ index 8118a467dd8..de9f84f74d0 100644
      clipboard_destroy             /* destroy */
  };
 diff --git a/server/completion.c b/server/completion.c
-index 6933195e72d..5ec6d209d13 100644
+index 6933195..5ec6d20 100644
 --- a/server/completion.c
 +++ b/server/completion.c
 @@ -61,10 +61,12 @@ struct completion
@@ -1813,7 +1815,7 @@ index 6933195e72d..5ec6d209d13 100644
  
      release_object( completion );
 diff --git a/server/console.c b/server/console.c
-index b64283baf4a..17708df7953 100644
+index b64283b..17708df 100644
 --- a/server/console.c
 +++ b/server/console.c
 @@ -61,6 +61,7 @@ struct console
@@ -2101,7 +2103,7 @@ index b64283baf4a..17708df7953 100644
      release_object( server );
  }
 diff --git a/server/debugger.c b/server/debugger.c
-index 48adb244b09..04172b7e66d 100644
+index c59a0ab..7975fc4 100644
 --- a/server/debugger.c
 +++ b/server/debugger.c
 @@ -71,6 +71,7 @@ struct debug_obj
@@ -2197,7 +2199,7 @@ index 48adb244b09..04172b7e66d 100644
      else
      {
 diff --git a/server/device.c b/server/device.c
-index 436dac6bfe9..698fee63f03 100644
+index 436dac6..698fee6 100644
 --- a/server/device.c
 +++ b/server/device.c
 @@ -78,6 +78,7 @@ static const struct object_ops irp_call_ops =
@@ -2315,7 +2317,7 @@ index 436dac6bfe9..698fee63f03 100644
                  if (irp->file) grab_object( irp );
                  manager->current_call = irp;
 diff --git a/server/directory.c b/server/directory.c
-index 23d7eb0a2b7..8e32abbcff2 100644
+index 23d7eb0..8e32abb 100644
 --- a/server/directory.c
 +++ b/server/directory.c
 @@ -81,6 +81,7 @@ static const struct object_ops object_type_ops =
@@ -2335,7 +2337,7 @@ index 23d7eb0a2b7..8e32abbcff2 100644
      directory_destroy             /* destroy */
  };
 diff --git a/server/event.c b/server/event.c
-index f1b79b1b35e..b750a22487b 100644
+index f1b79b1..b750a22 100644
 --- a/server/event.c
 +++ b/server/event.c
 @@ -56,6 +56,7 @@ struct event
@@ -2474,10 +2476,10 @@ index f1b79b1b35e..b750a22487b 100644
  {
 diff --git a/server/fast_sync.c b/server/fast_sync.c
 new file mode 100644
-index 00000000000..8684eb6dcd7
+index 0000000..51fe32e
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,420 @@
+@@ -0,0 +1,417 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -2635,6 +2637,7 @@ index 00000000000..8684eb6dcd7
 +        return NULL;
 +    }
 +
++    fprintf( stderr, "wine: using fast synchronization.\n" );
 +    linux_device_object = device;
 +    return device;
 +}
@@ -2876,10 +2879,6 @@ index 00000000000..8684eb6dcd7
 +{
 +#ifdef HAVE_LINUX_NTSYNC_H
 +    struct object *obj;
-+    static int once;
-+
-+    if (!once++)
-+        fprintf( stderr, "wine: using fast synchronization.\n" );
 +
 +    if ((obj = get_handle_obj( current->process, req->handle, 0, NULL )))
 +    {
@@ -2899,7 +2898,7 @@ index 00000000000..8684eb6dcd7
 +#endif
 +}
 diff --git a/server/fd.c b/server/fd.c
-index 8576882aaa9..39b94fd283a 100644
+index 8576882..39b94fd 100644
 --- a/server/fd.c
 +++ b/server/fd.c
 @@ -156,6 +156,7 @@ struct fd
@@ -3004,7 +3003,7 @@ index 8576882aaa9..39b94fd283a 100644
  {
      int events = 0;
 diff --git a/server/file.c b/server/file.c
-index 76c687833c9..1191303c35a 100644
+index 76c6878..1191303 100644
 --- a/server/file.c
 +++ b/server/file.c
 @@ -106,6 +106,7 @@ static const struct object_ops file_ops =
@@ -3016,7 +3015,7 @@ index 76c687833c9..1191303c35a 100644
      file_destroy                  /* destroy */
  };
 diff --git a/server/file.h b/server/file.h
-index 39a833cd105..69f5df9b463 100644
+index 7f2d163..2ec50aa 100644
 --- a/server/file.h
 +++ b/server/file.h
 @@ -108,6 +108,7 @@ extern char *dup_fd_name( struct fd *root, const char *name ) __WINE_DEALLOC(fre
@@ -3028,7 +3027,7 @@ index 39a833cd105..69f5df9b463 100644
  extern void default_poll_event( struct fd *fd, int event );
  extern void fd_cancel_async( struct fd *fd, struct async *async );
 diff --git a/server/handle.c b/server/handle.c
-index 0595fdb403b..17d3617f0a3 100644
+index 71cdd2e..e07f32c 100644
 --- a/server/handle.c
 +++ b/server/handle.c
 @@ -138,6 +138,7 @@ static const struct object_ops handle_table_ops =
@@ -3040,7 +3039,7 @@ index 0595fdb403b..17d3617f0a3 100644
      handle_table_destroy             /* destroy */
  };
 diff --git a/server/hook.c b/server/hook.c
-index 5abdf39ad37..5a00699283d 100644
+index 5abdf39..5a00699 100644
 --- a/server/hook.c
 +++ b/server/hook.c
 @@ -92,6 +92,7 @@ static const struct object_ops hook_table_ops =
@@ -3052,7 +3051,7 @@ index 5abdf39ad37..5a00699283d 100644
      hook_table_destroy            /* destroy */
  };
 diff --git a/server/mailslot.c b/server/mailslot.c
-index 2d8697ec9bd..d9807b4ad23 100644
+index 2d8697e..d9807b4 100644
 --- a/server/mailslot.c
 +++ b/server/mailslot.c
 @@ -86,6 +86,7 @@ static const struct object_ops mailslot_ops =
@@ -3088,7 +3087,7 @@ index 2d8697ec9bd..d9807b4ad23 100644
      mailslot_device_file_destroy            /* destroy */
  };
 diff --git a/server/mapping.c b/server/mapping.c
-index f754078acf7..23901aa6f76 100644
+index 6b0de1b..c3cba90 100644
 --- a/server/mapping.c
 +++ b/server/mapping.c
 @@ -79,6 +79,7 @@ static const struct object_ops ranges_ops =
@@ -3116,7 +3115,7 @@ index f754078acf7..23901aa6f76 100644
      mapping_destroy              /* destroy */
  };
 diff --git a/server/mutex.c b/server/mutex.c
-index af0efe72132..167c236e014 100644
+index af0efe7..167c236 100644
 --- a/server/mutex.c
 +++ b/server/mutex.c
 @@ -38,6 +38,8 @@
@@ -3224,7 +3223,7 @@ index af0efe72132..167c236e014 100644
  
  /* create a mutex */
 diff --git a/server/named_pipe.c b/server/named_pipe.c
-index f3404a33c3b..6d8cb3ea350 100644
+index f3404a3..6d8cb3e 100644
 --- a/server/named_pipe.c
 +++ b/server/named_pipe.c
 @@ -131,6 +131,7 @@ static const struct object_ops named_pipe_ops =
@@ -3268,7 +3267,7 @@ index f3404a33c3b..6d8cb3ea350 100644
      named_pipe_device_file_destroy           /* destroy */
  };
 diff --git a/server/object.c b/server/object.c
-index 89e541ffb6b..6c6568e5d24 100644
+index 89e541f..6c6568e 100644
 --- a/server/object.c
 +++ b/server/object.c
 @@ -538,6 +538,12 @@ struct fd *no_get_fd( struct object *obj )
@@ -3285,7 +3284,7 @@ index 89e541ffb6b..6c6568e5d24 100644
  {
      return map_access( access, &obj->ops->type->mapping );
 diff --git a/server/object.h b/server/object.h
-index dfdd691601f..f1f39571136 100644
+index d4d6653..b1147bc 100644
 --- a/server/object.h
 +++ b/server/object.h
 @@ -42,6 +42,7 @@ struct async;
@@ -3324,7 +3323,7 @@ index dfdd691601f..f1f39571136 100644
  
  int get_serial_async_timeout(struct object *obj, int type, int count);
 diff --git a/server/process.c b/server/process.c
-index a0d5ea64d97..f61916d3adf 100644
+index c9ab161..056095e 100644
 --- a/server/process.c
 +++ b/server/process.c
 @@ -94,6 +94,7 @@ static unsigned int process_map_access( struct object *obj, unsigned int access
@@ -3410,15 +3409,15 @@ index a0d5ea64d97..f61916d3adf 100644
  }
  
  static void job_dump( struct object *obj, int verbose )
-@@ -682,6 +702,7 @@ struct process *create_process( int fd, struct process *parent, unsigned int fla
+@@ -683,6 +703,7 @@ struct process *create_process( int fd, struct process *parent, unsigned int fla
      process->rawinput_device_count = 0;
      process->rawinput_mouse  = NULL;
      process->rawinput_kbd    = NULL;
 +    process->fast_sync       = NULL;
      memset( &process->image_info, 0, sizeof(process->image_info) );
+     list_init( &process->rawinput_entry );
      list_init( &process->kernel_object );
-     list_init( &process->thread_list );
-@@ -786,6 +807,8 @@ static void process_destroy( struct object *obj )
+@@ -789,6 +810,8 @@ static void process_destroy( struct object *obj )
      free( process->rawinput_devices );
      free( process->dir_cache );
      free( process->image );
@@ -3427,7 +3426,7 @@ index a0d5ea64d97..f61916d3adf 100644
  }
  
  /* dump a process on stdout for debugging purposes */
-@@ -817,6 +840,16 @@ static struct list *process_get_kernel_obj_list( struct object *obj )
+@@ -820,6 +843,16 @@ static struct list *process_get_kernel_obj_list( struct object *obj )
      return &process->kernel_object;
  }
  
@@ -3444,7 +3443,7 @@ index a0d5ea64d97..f61916d3adf 100644
  static struct security_descriptor *process_get_sd( struct object *obj )
  {
      static struct security_descriptor *process_default_sd;
-@@ -981,6 +1014,7 @@ static void process_killed( struct process *process )
+@@ -984,6 +1017,7 @@ static void process_killed( struct process *process )
      release_job_process( process );
      start_sigkill_timer( process );
      wake_up( &process->obj, 0 );
@@ -3453,11 +3452,11 @@ index a0d5ea64d97..f61916d3adf 100644
  
  /* add a thread to a process running threads list */
 diff --git a/server/process.h b/server/process.h
-index 97e0d455ece..6ec97ae4527 100644
+index 1e73e9d..2140427 100644
 --- a/server/process.h
 +++ b/server/process.h
-@@ -85,6 +85,7 @@ struct process
-     const struct rawinput_device *rawinput_kbd;   /* rawinput keyboard device, if any */
+@@ -86,6 +86,7 @@ struct process
+     struct list          rawinput_entry;  /* entry in the rawinput process list */
      struct list          kernel_object;   /* list of kernel object pointers */
      pe_image_info_t      image_info;      /* main exe image info */
 +    struct fast_sync    *fast_sync;       /* fast synchronization object */
@@ -3465,10 +3464,10 @@ index 97e0d455ece..6ec97ae4527 100644
  
  /* process functions */
 diff --git a/server/protocol.def b/server/protocol.def
-index 5d60e7fcda3..38b0d9d062e 100644
+index fa78e04..0dcd832 100644
 --- a/server/protocol.def
 +++ b/server/protocol.def
-@@ -3884,3 +3884,52 @@ struct handle_info
+@@ -3875,3 +3875,52 @@ struct handle_info
  @REPLY
      obj_handle_t handle;       /* next thread handle */
  @END
@@ -3522,10 +3521,10 @@ index 5d60e7fcda3..38b0d9d062e 100644
 +    obj_handle_t handle;          /* handle to the event */
 +@END
 diff --git a/server/queue.c b/server/queue.c
-index cd913ae03e5..7afa1dce898 100644
+index 4373bd7..5387df4 100644
 --- a/server/queue.c
 +++ b/server/queue.c
-@@ -142,6 +142,8 @@ struct msg_queue
+@@ -145,6 +145,8 @@ struct msg_queue
      struct hook_table     *hooks;           /* hook table */
      timeout_t              last_get_msg;    /* time of last get message call */
      int                    keystate_lock;   /* owns an input keystate lock */
@@ -3534,7 +3533,7 @@ index cd913ae03e5..7afa1dce898 100644
  };
  
  struct hotkey
-@@ -159,6 +161,7 @@ static int msg_queue_add_queue( struct object *obj, struct wait_queue_entry *ent
+@@ -162,6 +164,7 @@ static int msg_queue_add_queue( struct object *obj, struct wait_queue_entry *ent
  static void msg_queue_remove_queue( struct object *obj, struct wait_queue_entry *entry );
  static int msg_queue_signaled( struct object *obj, struct wait_queue_entry *entry );
  static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *entry );
@@ -3542,7 +3541,7 @@ index cd913ae03e5..7afa1dce898 100644
  static void msg_queue_destroy( struct object *obj );
  static void msg_queue_poll_event( struct fd *fd, int event );
  static void thread_input_dump( struct object *obj, int verbose );
-@@ -185,6 +188,7 @@ static const struct object_ops msg_queue_ops =
+@@ -188,6 +191,7 @@ static const struct object_ops msg_queue_ops =
      NULL,                      /* unlink_name */
      no_open_file,              /* open_file */
      no_kernel_obj_list,        /* get_kernel_obj_list */
@@ -3550,7 +3549,7 @@ index cd913ae03e5..7afa1dce898 100644
      no_close_handle,           /* close_handle */
      msg_queue_destroy          /* destroy */
  };
-@@ -222,6 +226,7 @@ static const struct object_ops thread_input_ops =
+@@ -225,6 +229,7 @@ static const struct object_ops thread_input_ops =
      NULL,                         /* unlink_name */
      no_open_file,                 /* open_file */
      no_kernel_obj_list,           /* get_kernel_obj_list */
@@ -3558,7 +3557,7 @@ index cd913ae03e5..7afa1dce898 100644
      no_close_handle,              /* close_handle */
      thread_input_destroy          /* destroy */
  };
-@@ -310,6 +315,8 @@ static struct msg_queue *create_msg_queue( struct thread *thread, struct thread_
+@@ -313,6 +318,8 @@ static struct msg_queue *create_msg_queue( struct thread *thread, struct thread_
          queue->hooks           = NULL;
          queue->last_get_msg    = current_time;
          queue->keystate_lock   = 0;
@@ -3567,7 +3566,7 @@ index cd913ae03e5..7afa1dce898 100644
          list_init( &queue->send_result );
          list_init( &queue->callback_result );
          list_init( &queue->pending_timers );
-@@ -591,7 +598,11 @@ static inline void set_queue_bits( struct msg_queue *queue, unsigned int bits )
+@@ -594,7 +601,11 @@ static inline void set_queue_bits( struct msg_queue *queue, unsigned int bits )
      }
      queue->wake_bits |= bits;
      queue->changed_bits |= bits;
@@ -3580,7 +3579,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  /* clear some queue bits */
-@@ -604,6 +615,8 @@ static inline void clear_queue_bits( struct msg_queue *queue, unsigned int bits
+@@ -607,6 +618,8 @@ static inline void clear_queue_bits( struct msg_queue *queue, unsigned int bits
          if (queue->keystate_lock) unlock_input_keystate( queue->input );
          queue->keystate_lock = 0;
      }
@@ -3589,7 +3588,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  /* check if message is matched by the filter */
-@@ -1082,6 +1095,10 @@ static int is_queue_hung( struct msg_queue *queue )
+@@ -1085,6 +1098,10 @@ static int is_queue_hung( struct msg_queue *queue )
          if (get_wait_queue_thread(entry)->queue == queue)
              return 0;  /* thread is waiting on queue -> not hung */
      }
@@ -3600,7 +3599,7 @@ index cd913ae03e5..7afa1dce898 100644
      return 1;
  }
  
-@@ -1142,6 +1159,17 @@ static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *en
+@@ -1145,6 +1162,17 @@ static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *en
      struct msg_queue *queue = (struct msg_queue *)obj;
      queue->wake_mask = 0;
      queue->changed_mask = 0;
@@ -3618,7 +3617,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  static void msg_queue_destroy( struct object *obj )
-@@ -1181,6 +1209,7 @@ static void msg_queue_destroy( struct object *obj )
+@@ -1184,6 +1212,7 @@ static void msg_queue_destroy( struct object *obj )
      release_object( queue->input );
      if (queue->hooks) release_object( queue->hooks );
      if (queue->fd) release_object( queue->fd );
@@ -3626,7 +3625,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  static void msg_queue_poll_event( struct fd *fd, int event )
-@@ -1191,6 +1220,7 @@ static void msg_queue_poll_event( struct fd *fd, int event )
+@@ -1194,6 +1223,7 @@ static void msg_queue_poll_event( struct fd *fd, int event )
      if (event & (POLLERR | POLLHUP)) set_fd_events( fd, -1 );
      else set_fd_events( queue->fd, 0 );
      wake_up( &queue->obj, 0 );
@@ -3634,7 +3633,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  static void thread_input_dump( struct object *obj, int verbose )
-@@ -2556,8 +2586,20 @@ DECL_HANDLER(set_queue_mask)
+@@ -2682,8 +2712,20 @@ DECL_HANDLER(set_queue_mask)
          if (is_signaled( queue ))
          {
              /* if skip wait is set, do what would have been done in the subsequent wait */
@@ -3657,7 +3656,7 @@ index cd913ae03e5..7afa1dce898 100644
          }
      }
  }
-@@ -2572,6 +2614,8 @@ DECL_HANDLER(get_queue_status)
+@@ -2698,6 +2740,8 @@ DECL_HANDLER(get_queue_status)
          reply->wake_bits    = queue->wake_bits;
          reply->changed_bits = queue->changed_bits;
          queue->changed_bits &= ~req->clear_bits;
@@ -3666,7 +3665,7 @@ index cd913ae03e5..7afa1dce898 100644
      }
      else reply->wake_bits = reply->changed_bits = 0;
  }
-@@ -2753,6 +2797,9 @@ DECL_HANDLER(get_message)
+@@ -2873,6 +2917,9 @@ DECL_HANDLER(get_message)
      if (filter & QS_INPUT) queue->changed_bits &= ~QS_INPUT;
      if (filter & QS_PAINT) queue->changed_bits &= ~QS_PAINT;
  
@@ -3676,7 +3675,7 @@ index cd913ae03e5..7afa1dce898 100644
      /* then check for posted messages */
      if ((filter & QS_POSTMESSAGE) &&
          get_posted_message( queue, get_win, req->get_first, req->get_last, req->flags, reply ))
-@@ -2811,6 +2858,7 @@ DECL_HANDLER(get_message)
+@@ -2931,6 +2978,7 @@ DECL_HANDLER(get_message)
      if (get_win == -1 && current->process->idle_event) set_event( current->process->idle_event );
      queue->wake_mask = req->wake_mask;
      queue->changed_mask = req->changed_mask;
@@ -3684,9 +3683,9 @@ index cd913ae03e5..7afa1dce898 100644
      set_error( STATUS_PENDING );  /* FIXME */
  }
  
-@@ -3508,3 +3556,56 @@ DECL_HANDLER(update_rawinput_devices)
-     process->rawinput_mouse = find_rawinput_device( process, 1, 2 );
-     process->rawinput_kbd = find_rawinput_device( process, 1, 6 );
+@@ -3671,3 +3719,56 @@ DECL_HANDLER(update_rawinput_devices)
+         release_object( desktop );
+     }
  }
 +
 +DECL_HANDLER(fast_select_queue)
@@ -3742,7 +3741,7 @@ index cd913ae03e5..7afa1dce898 100644
 +    release_object( queue );
 +}
 diff --git a/server/registry.c b/server/registry.c
-index da6a6d0982e..83d36580356 100644
+index e88bed1..2afd5ec 100644
 --- a/server/registry.c
 +++ b/server/registry.c
 @@ -192,6 +192,7 @@ static const struct object_ops key_ops =
@@ -3754,7 +3753,7 @@ index da6a6d0982e..83d36580356 100644
      key_destroy              /* destroy */
  };
 diff --git a/server/request.c b/server/request.c
-index 7021741c765..8c50f993d25 100644
+index 7021741..8c50f99 100644
 --- a/server/request.c
 +++ b/server/request.c
 @@ -102,6 +102,7 @@ static const struct object_ops master_socket_ops =
@@ -3766,10 +3765,10 @@ index 7021741c765..8c50f993d25 100644
      master_socket_destroy          /* destroy */
  };
 diff --git a/server/request.h b/server/request.h
-index 89d5a621b16..e255b8206e2 100644
+index 4e7dec4..7f9de15 100644
 --- a/server/request.h
 +++ b/server/request.h
-@@ -403,6 +403,11 @@ DECL_HANDLER(terminate_job);
+@@ -404,6 +404,11 @@ DECL_HANDLER(terminate_job);
  DECL_HANDLER(suspend_process);
  DECL_HANDLER(resume_process);
  DECL_HANDLER(get_next_thread);
@@ -3781,7 +3780,7 @@ index 89d5a621b16..e255b8206e2 100644
  
  #ifdef WANT_REQUEST_HANDLERS
  
-@@ -693,6 +698,11 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
+@@ -695,6 +700,11 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
      (req_handler)req_suspend_process,
      (req_handler)req_resume_process,
      (req_handler)req_get_next_thread,
@@ -3793,7 +3792,7 @@ index 89d5a621b16..e255b8206e2 100644
  };
  
  C_ASSERT( sizeof(abstime_t) == 8 );
-@@ -2336,6 +2346,23 @@ C_ASSERT( FIELD_OFFSET(struct get_next_thread_request, flags) == 28 );
+@@ -2339,6 +2349,23 @@ C_ASSERT( FIELD_OFFSET(struct get_next_thread_request, flags) == 28 );
  C_ASSERT( sizeof(struct get_next_thread_request) == 32 );
  C_ASSERT( FIELD_OFFSET(struct get_next_thread_reply, handle) == 8 );
  C_ASSERT( sizeof(struct get_next_thread_reply) == 16 );
@@ -3818,7 +3817,7 @@ index 89d5a621b16..e255b8206e2 100644
  #endif  /* WANT_REQUEST_HANDLERS */
  
 diff --git a/server/semaphore.c b/server/semaphore.c
-index 53b42a886df..99409198d68 100644
+index 53b42a8..9940919 100644
 --- a/server/semaphore.c
 +++ b/server/semaphore.c
 @@ -55,12 +55,15 @@ struct semaphore
@@ -3881,7 +3880,7 @@ index 53b42a886df..99409198d68 100644
  DECL_HANDLER(create_semaphore)
  {
 diff --git a/server/serial.c b/server/serial.c
-index d665eb7fa35..5c210d10a80 100644
+index d665eb7..5c210d1 100644
 --- a/server/serial.c
 +++ b/server/serial.c
 @@ -97,6 +97,7 @@ static const struct object_ops serial_ops =
@@ -3893,7 +3892,7 @@ index d665eb7fa35..5c210d10a80 100644
      serial_destroy                /* destroy */
  };
 diff --git a/server/signal.c b/server/signal.c
-index 19b76d44c16..e5def3dc899 100644
+index 19b76d4..e5def3d 100644
 --- a/server/signal.c
 +++ b/server/signal.c
 @@ -74,6 +74,7 @@ static const struct object_ops handler_ops =
@@ -3905,7 +3904,7 @@ index 19b76d44c16..e5def3dc899 100644
      handler_destroy           /* destroy */
  };
 diff --git a/server/sock.c b/server/sock.c
-index c34fd3eb5eb..c226d7d0162 100644
+index 3ad1ce3..3fb2e29 100644
 --- a/server/sock.c
 +++ b/server/sock.c
 @@ -465,6 +465,7 @@ static const struct object_ops sock_ops =
@@ -3933,7 +3932,7 @@ index c34fd3eb5eb..c226d7d0162 100644
      no_destroy                  /* destroy */
  };
 diff --git a/server/symlink.c b/server/symlink.c
-index dd28efd3a75..4a7cf68f269 100644
+index dd28efd..4a7cf68 100644
 --- a/server/symlink.c
 +++ b/server/symlink.c
 @@ -83,6 +83,7 @@ static const struct object_ops symlink_ops =
@@ -3945,7 +3944,7 @@ index dd28efd3a75..4a7cf68f269 100644
      symlink_destroy               /* destroy */
  };
 diff --git a/server/thread.c b/server/thread.c
-index 56f57cefd8f..13585ee9d34 100644
+index 56f57ce..13585ee 100644
 --- a/server/thread.c
 +++ b/server/thread.c
 @@ -108,6 +108,7 @@ static const struct object_ops thread_apc_ops =
@@ -4070,10 +4069,10 @@ index 56f57cefd8f..13585ee9d34 100644
 +        reply->handle = alloc_handle( current->process, current->fast_alert_event, SYNCHRONIZE, 0 );
 +}
 diff --git a/server/thread.h b/server/thread.h
-index 8dcf966a90a..9586138640b 100644
+index 766ed78..9bf4b48 100644
 --- a/server/thread.h
 +++ b/server/thread.h
-@@ -90,6 +90,8 @@ struct thread
+@@ -91,6 +91,8 @@ struct thread
      struct list            kernel_object; /* list of kernel object pointers */
      data_size_t            desc_len;      /* thread description length in bytes */
      WCHAR                 *desc;          /* thread description string */
@@ -4083,7 +4082,7 @@ index 8dcf966a90a..9586138640b 100644
  
  extern struct thread *current;
 diff --git a/server/timer.c b/server/timer.c
-index 96dc9d00ca1..854a8e1f7f2 100644
+index 96dc9d0..854a8e1 100644
 --- a/server/timer.c
 +++ b/server/timer.c
 @@ -61,11 +61,13 @@ struct timer
@@ -4161,7 +4160,7 @@ index 96dc9d00ca1..854a8e1f7f2 100644
  
  /* create a timer */
 diff --git a/server/token.c b/server/token.c
-index 4df8d2e0c6e..42562fdf88c 100644
+index 4df8d2e..42562fd 100644
 --- a/server/token.c
 +++ b/server/token.c
 @@ -155,6 +155,7 @@ static const struct object_ops token_ops =
@@ -4173,10 +4172,10 @@ index 4df8d2e0c6e..42562fdf88c 100644
      token_destroy              /* destroy */
  };
 diff --git a/server/trace.c b/server/trace.c
-index 1b65d2b977e..a5a9fec5700 100644
+index 6c9dc24..7259007 100644
 --- a/server/trace.c
 +++ b/server/trace.c
-@@ -4606,6 +4606,47 @@ static void dump_get_next_thread_reply( const struct get_next_thread_reply *req
+@@ -4594,6 +4594,47 @@ static void dump_get_next_thread_reply( const struct get_next_thread_reply *req
      fprintf( stderr, " handle=%04x", req->handle );
  }
  
@@ -4224,7 +4223,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  static const dump_func req_dumpers[REQ_NB_REQUESTS] = {
      (dump_func)dump_new_process_request,
      (dump_func)dump_get_new_process_info_request,
-@@ -4891,6 +4932,11 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] = {
+@@ -4880,6 +4921,11 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] = {
      (dump_func)dump_suspend_process_request,
      (dump_func)dump_resume_process_request,
      (dump_func)dump_get_next_thread_request,
@@ -4236,7 +4235,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  };
  
  static const dump_func reply_dumpers[REQ_NB_REQUESTS] = {
-@@ -5178,6 +5224,11 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] = {
+@@ -5168,6 +5214,11 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] = {
      NULL,
      NULL,
      (dump_func)dump_get_next_thread_reply,
@@ -4248,7 +4247,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  };
  
  static const char * const req_names[REQ_NB_REQUESTS] = {
-@@ -5465,6 +5516,11 @@ static const char * const req_names[REQ_NB_REQUESTS] = {
+@@ -5456,6 +5507,11 @@ static const char * const req_names[REQ_NB_REQUESTS] = {
      "suspend_process",
      "resume_process",
      "get_next_thread",
@@ -4261,7 +4260,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  
  static const struct
 diff --git a/server/window.c b/server/window.c
-index 242e93f303a..8ddf78e54b8 100644
+index 242e93f..8ddf78e 100644
 --- a/server/window.c
 +++ b/server/window.c
 @@ -119,6 +119,7 @@ static const struct object_ops window_ops =
@@ -4273,7 +4272,7 @@ index 242e93f303a..8ddf78e54b8 100644
      window_destroy            /* destroy */
  };
 diff --git a/server/winstation.c b/server/winstation.c
-index 5903497d61e..cabc93fa571 100644
+index 373a1f7..1bb9d68 100644
 --- a/server/winstation.c
 +++ b/server/winstation.c
 @@ -88,6 +88,7 @@ static const struct object_ops winstation_ops =

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index ae5def6a6b1..6848ae65ff9 100755
+index 83a641f..2016c09 100755
 --- a/configure
 +++ b/configure
-@@ -8004,6 +8004,12 @@ if test "x$ac_cv_header_linux_major_h" = xyes
+@@ -7977,6 +7977,12 @@ if test "x$ac_cv_header_linux_major_h" = xyes
  then :
    printf "%s\n" "#define HAVE_LINUX_MAJOR_H 1" >>confdefs.h
  
@@ -16,10 +16,10 @@ index ae5def6a6b1..6848ae65ff9 100755
  ac_fn_c_check_header_compile "$LINENO" "linux/param.h" "ac_cv_header_linux_param_h" "$ac_includes_default"
  if test "x$ac_cv_header_linux_param_h" = xyes
 diff --git a/configure.ac b/configure.ac
-index 475743bc121..f4155253181 100644
+index 64083de..f6c7639 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -425,6 +425,7 @@ AC_CHECK_HEADERS(\
+@@ -402,6 +402,7 @@ AC_CHECK_HEADERS(\
  	linux/input.h \
  	linux/ioctl.h \
  	linux/major.h \
@@ -28,10 +28,10 @@ index 475743bc121..f4155253181 100644
  	linux/serial.h \
  	linux/types.h \
 diff --git a/dlls/kernel32/tests/sync.c b/dlls/kernel32/tests/sync.c
-index 56a9d6e4859..48e4f8d7b4d 100644
+index 25cf75c..50e81aa 100644
 --- a/dlls/kernel32/tests/sync.c
 +++ b/dlls/kernel32/tests/sync.c
-@@ -2841,6 +2841,84 @@ static void test_QueueUserAPC(void)
+@@ -2871,6 +2871,84 @@ static void test_QueueUserAPC(void)
      ok(apc_count == 1, "APC count %u\n", apc_count);
  }
  
@@ -116,7 +116,7 @@ index 56a9d6e4859..48e4f8d7b4d 100644
  START_TEST(sync)
  {
      char **argv;
-@@ -2911,5 +2989,6 @@ START_TEST(sync)
+@@ -2941,5 +3019,6 @@ START_TEST(sync)
      test_srwlock_example();
      test_alertable_wait();
      test_apc_deadlock();
@@ -124,10 +124,10 @@ index 56a9d6e4859..48e4f8d7b4d 100644
      test_crit_section();
  }
 diff --git a/dlls/ntdll/unix/file.c b/dlls/ntdll/unix/file.c
-index ee68e4dee9b..9f2707f9eeb 100644
+index d292d93..17e7266 100644
 --- a/dlls/ntdll/unix/file.c
 +++ b/dlls/ntdll/unix/file.c
-@@ -6344,7 +6344,7 @@ NTSTATUS WINAPI NtLockFile( HANDLE file, HANDLE event, PIO_APC_ROUTINE apc, void
+@@ -6372,7 +6372,7 @@ NTSTATUS WINAPI NtLockFile( HANDLE file, HANDLE event, PIO_APC_ROUTINE apc, void
          }
          if (handle)
          {
@@ -137,10 +137,10 @@ index ee68e4dee9b..9f2707f9eeb 100644
          }
          else  /* Unix lock conflict, sleep a bit and retry */
 diff --git a/dlls/ntdll/unix/process.c b/dlls/ntdll/unix/process.c
-index 71eab55920d..8e4407e7a6d 100644
+index bf24161..30ba4a4 100644
 --- a/dlls/ntdll/unix/process.c
 +++ b/dlls/ntdll/unix/process.c
-@@ -916,7 +916,7 @@ NTSTATUS WINAPI NtCreateUserProcess( HANDLE *process_handle_ptr, HANDLE *thread_
+@@ -921,7 +921,7 @@ NTSTATUS WINAPI NtCreateUserProcess( HANDLE *process_handle_ptr, HANDLE *thread_
  
      /* wait for the new process info to be ready */
  
@@ -150,7 +150,7 @@ index 71eab55920d..8e4407e7a6d 100644
      {
          req->info = wine_server_obj_handle( process_info );
 diff --git a/dlls/ntdll/unix/server.c b/dlls/ntdll/unix/server.c
-index 69e6567c911..c90f8ab4019 100644
+index 88ac955..59ad123 100644
 --- a/dlls/ntdll/unix/server.c
 +++ b/dlls/ntdll/unix/server.c
 @@ -103,7 +103,7 @@ sigset_t server_block_set;  /* signals to block during server calls */
@@ -193,7 +193,7 @@ index 69e6567c911..c90f8ab4019 100644
  
              SERVER_START_REQ( get_apc_result )
              {
-@@ -1774,12 +1789,17 @@ NTSTATUS WINAPI NtDuplicateObject( HANDLE source_process, HANDLE source, HANDLE
+@@ -1773,12 +1788,17 @@ NTSTATUS WINAPI NtDuplicateObject( HANDLE source_process, HANDLE source, HANDLE
          return result.dup_handle.status;
      }
  
@@ -211,7 +211,7 @@ index 69e6567c911..c90f8ab4019 100644
  
      SERVER_START_REQ( dup_handle )
      {
-@@ -1845,12 +1865,16 @@ NTSTATUS WINAPI NtClose( HANDLE handle )
+@@ -1844,12 +1864,16 @@ NTSTATUS WINAPI NtClose( HANDLE handle )
      if (HandleToLong( handle ) >= ~5 && HandleToLong( handle ) <= ~0)
          return STATUS_SUCCESS;
  
@@ -229,7 +229,7 @@ index 69e6567c911..c90f8ab4019 100644
      {
          req->handle = wine_server_obj_handle( handle );
 diff --git a/dlls/ntdll/unix/sync.c b/dlls/ntdll/unix/sync.c
-index bfbcaf4a851..f650d072cd4 100644
+index cde6a0f..a9a0a2c 100644
 --- a/dlls/ntdll/unix/sync.c
 +++ b/dlls/ntdll/unix/sync.c
 @@ -30,9 +30,11 @@
@@ -275,7 +275,7 @@ index bfbcaf4a851..f650d072cd4 100644
  /* return a monotonic time counter, in Win32 ticks */
  static inline ULONGLONG monotonic_counter(void)
  {
-@@ -258,6 +266,908 @@ static unsigned int validate_open_object_attributes( const OBJECT_ATTRIBUTES *at
+@@ -238,6 +246,902 @@ static unsigned int validate_open_object_attributes( const OBJECT_ATTRIBUTES *at
  }
  
  
@@ -372,9 +372,10 @@ index bfbcaf4a851..f650d072cd4 100644
 +
 +static void release_fast_sync_obj( struct fast_sync_cache_entry *cache )
 +{
-+    /* save the handle now; as soon as the refcount hits 0 we cannot access the
-+     * cache anymore */
++    /* save the handle and fd now; as soon as the refcount hits 0 we cannot
++     * access the cache anymore */
 +    HANDLE handle = wine_server_ptr_handle( cache->handle );
++    int fd = cache->fd;
 +    LONG refcount = InterlockedDecrement( &cache->refcount );
 +
 +    assert( refcount >= 0 );
@@ -392,6 +393,7 @@ index bfbcaf4a851..f650d072cd4 100644
 +        SERVER_END_REQ;
 +
 +        assert( !ret );
++        close( fd );
 +    }
 +}
 +
@@ -865,33 +867,6 @@ index bfbcaf4a851..f650d072cd4 100644
 +    return ret;
 +}
 +
-+static __u64 fast_get_timeout( const LARGE_INTEGER *timeout )
-+{
-+    struct timespec now;
-+    timeout_t relative;
-+
-+    if (!timeout || timeout->QuadPart == TIMEOUT_INFINITE)
-+        return ~(__u64)0;
-+
-+    clock_gettime( CLOCK_MONOTONIC, &now );
-+
-+    if (timeout->QuadPart <= 0)
-+    {
-+        relative = -timeout->QuadPart;
-+    }
-+    else
-+    {
-+        LARGE_INTEGER system_now;
-+
-+        /* the system clock is REALTIME, so we need to convert to
-+         * relative time first */
-+        NtQuerySystemTime( &system_now );
-+        relative = timeout->QuadPart - system_now.QuadPart;
-+    }
-+
-+    return (now.tv_sec * 1000000000) + now.tv_nsec + (relative * 100);
-+}
-+
 +static void select_queue( HANDLE queue )
 +{
 +    SERVER_START_REQ( fast_select_queue )
@@ -933,6 +908,10 @@ index bfbcaf4a851..f650d072cd4 100644
 +        if ((ret = get_fast_sync_obj( alert_handle, 0, SYNCHRONIZE, &stack_cache, &cache )))
 +            ERR( "failed to get fast alert obj, status %#x\n", ret );
 +        data->fast_alert_obj = cache->fd;
++        /* Set the fd to -1 so release_fast_sync_obj() won't close it.
++         * Manhandling the cache entry here is fine since we're the only thread
++         * that can access our own alert event. */
++        cache->fd = -1;
 +        release_fast_sync_obj( cache );
 +        NtClose( alert_handle );
 +    }
@@ -945,9 +924,24 @@ index bfbcaf4a851..f650d072cd4 100644
 +{
 +    struct ntsync_wait_args args = {0};
 +    unsigned long request;
++    struct timespec now;
 +    int ret;
 +
-+    args.timeout = fast_get_timeout( timeout );
++    if (!timeout || timeout->QuadPart == TIMEOUT_INFINITE)
++    {
++        args.timeout = ~(__u64)0;
++    }
++    else if (timeout->QuadPart <= 0)
++    {
++        clock_gettime( CLOCK_MONOTONIC, &now );
++        args.timeout = (now.tv_sec * NSECPERSEC) + now.tv_nsec + (-timeout->QuadPart * 100);
++    }
++    else
++    {
++        args.timeout = (timeout->QuadPart * 100) - (SECS_1601_TO_1970 * NSECPERSEC);
++        args.flags |= NTSYNC_WAIT_REALTIME;
++    }
++
 +    args.objs = (uintptr_t)objs;
 +    args.count = count;
 +    args.owner = GetCurrentThreadId();
@@ -1184,7 +1178,7 @@ index bfbcaf4a851..f650d072cd4 100644
  /******************************************************************************
   *              NtCreateSemaphore (NTDLL.@)
   */
-@@ -268,6 +1178,9 @@ NTSTATUS WINAPI NtCreateSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJ
+@@ -248,6 +1152,9 @@ NTSTATUS WINAPI NtCreateSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJ
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1194,7 +1188,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if (max <= 0 || initial < 0 || initial > max) return STATUS_INVALID_PARAMETER;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
-@@ -295,6 +1208,8 @@ NTSTATUS WINAPI NtOpenSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJEC
+@@ -275,6 +1182,8 @@ NTSTATUS WINAPI NtOpenSemaphore( HANDLE *handle, ACCESS_MASK access, const OBJEC
  {
      unsigned int ret;
  
@@ -1203,7 +1197,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -332,6 +1247,12 @@ NTSTATUS WINAPI NtQuerySemaphore( HANDLE handle, SEMAPHORE_INFORMATION_CLASS cla
+@@ -312,6 +1221,12 @@ NTSTATUS WINAPI NtQuerySemaphore( HANDLE handle, SEMAPHORE_INFORMATION_CLASS cla
  
      if (len != sizeof(SEMAPHORE_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
  
@@ -1216,7 +1210,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( query_semaphore )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -354,6 +1275,11 @@ NTSTATUS WINAPI NtReleaseSemaphore( HANDLE handle, ULONG count, ULONG *previous
+@@ -334,6 +1249,11 @@ NTSTATUS WINAPI NtReleaseSemaphore( HANDLE handle, ULONG count, ULONG *previous
  {
      unsigned int ret;
  
@@ -1228,7 +1222,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( release_semaphore )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -378,6 +1304,9 @@ NTSTATUS WINAPI NtCreateEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_
+@@ -358,6 +1278,9 @@ NTSTATUS WINAPI NtCreateEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1238,7 +1232,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if (type != NotificationEvent && type != SynchronizationEvent) return STATUS_INVALID_PARAMETER;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
-@@ -405,6 +1334,8 @@ NTSTATUS WINAPI NtOpenEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
+@@ -385,6 +1308,8 @@ NTSTATUS WINAPI NtOpenEvent( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
  {
      unsigned int ret;
  
@@ -1247,7 +1241,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -430,6 +1361,11 @@ NTSTATUS WINAPI NtSetEvent( HANDLE handle, LONG *prev_state )
+@@ -410,6 +1335,11 @@ NTSTATUS WINAPI NtSetEvent( HANDLE handle, LONG *prev_state )
  {
      unsigned int ret;
  
@@ -1259,7 +1253,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( event_op )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -449,6 +1385,11 @@ NTSTATUS WINAPI NtResetEvent( HANDLE handle, LONG *prev_state )
+@@ -429,6 +1359,11 @@ NTSTATUS WINAPI NtResetEvent( HANDLE handle, LONG *prev_state )
  {
      unsigned int ret;
  
@@ -1271,7 +1265,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( event_op )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -478,6 +1419,11 @@ NTSTATUS WINAPI NtPulseEvent( HANDLE handle, LONG *prev_state )
+@@ -458,6 +1393,11 @@ NTSTATUS WINAPI NtPulseEvent( HANDLE handle, LONG *prev_state )
  {
      unsigned int ret;
  
@@ -1283,7 +1277,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( event_op )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -509,6 +1455,12 @@ NTSTATUS WINAPI NtQueryEvent( HANDLE handle, EVENT_INFORMATION_CLASS class,
+@@ -489,6 +1429,12 @@ NTSTATUS WINAPI NtQueryEvent( HANDLE handle, EVENT_INFORMATION_CLASS class,
  
      if (len != sizeof(EVENT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
  
@@ -1296,7 +1290,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( query_event )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -534,6 +1486,9 @@ NTSTATUS WINAPI NtCreateMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT
+@@ -514,6 +1460,9 @@ NTSTATUS WINAPI NtCreateMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1306,7 +1300,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
  
-@@ -559,6 +1514,8 @@ NTSTATUS WINAPI NtOpenMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT_A
+@@ -539,6 +1488,8 @@ NTSTATUS WINAPI NtOpenMutant( HANDLE *handle, ACCESS_MASK access, const OBJECT_A
  {
      unsigned int ret;
  
@@ -1315,7 +1309,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -584,6 +1541,11 @@ NTSTATUS WINAPI NtReleaseMutant( HANDLE handle, LONG *prev_count )
+@@ -564,6 +1515,11 @@ NTSTATUS WINAPI NtReleaseMutant( HANDLE handle, LONG *prev_count )
  {
      unsigned int ret;
  
@@ -1327,7 +1321,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( release_mutex )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -614,6 +1576,12 @@ NTSTATUS WINAPI NtQueryMutant( HANDLE handle, MUTANT_INFORMATION_CLASS class,
+@@ -594,6 +1550,12 @@ NTSTATUS WINAPI NtQueryMutant( HANDLE handle, MUTANT_INFORMATION_CLASS class,
  
      if (len != sizeof(MUTANT_BASIC_INFORMATION)) return STATUS_INFO_LENGTH_MISMATCH;
  
@@ -1340,7 +1334,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( query_mutex )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -1321,6 +2289,9 @@ NTSTATUS WINAPI NtCreateTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_
+@@ -1301,6 +2263,9 @@ NTSTATUS WINAPI NtCreateTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1350,7 +1344,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if (type != NotificationTimer && type != SynchronizationTimer) return STATUS_INVALID_PARAMETER;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
-@@ -1348,6 +2319,8 @@ NTSTATUS WINAPI NtOpenTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
+@@ -1328,6 +2293,8 @@ NTSTATUS WINAPI NtOpenTimer( HANDLE *handle, ACCESS_MASK access, const OBJECT_AT
  {
      unsigned int ret;
  
@@ -1359,7 +1353,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -1401,6 +2374,8 @@ NTSTATUS WINAPI NtCancelTimer( HANDLE handle, BOOLEAN *state )
+@@ -1381,6 +2348,8 @@ NTSTATUS WINAPI NtCancelTimer( HANDLE handle, BOOLEAN *state )
  {
      unsigned int ret;
  
@@ -1368,7 +1362,7 @@ index bfbcaf4a851..f650d072cd4 100644
      SERVER_START_REQ( cancel_timer )
      {
          req->handle = wine_server_obj_handle( handle );
-@@ -1469,13 +2444,29 @@ NTSTATUS WINAPI NtWaitForMultipleObjects( DWORD count, const HANDLE *handles, BO
+@@ -1449,13 +2418,29 @@ NTSTATUS WINAPI NtWaitForMultipleObjects( DWORD count, const HANDLE *handles, BO
  {
      select_op_t select_op;
      UINT i, flags = SELECT_INTERRUPTIBLE;
@@ -1399,7 +1393,7 @@ index bfbcaf4a851..f650d072cd4 100644
  }
  
  
-@@ -1496,9 +2487,15 @@ NTSTATUS WINAPI NtSignalAndWaitForSingleObject( HANDLE signal, HANDLE wait,
+@@ -1476,9 +2461,15 @@ NTSTATUS WINAPI NtSignalAndWaitForSingleObject( HANDLE signal, HANDLE wait,
  {
      select_op_t select_op;
      UINT flags = SELECT_INTERRUPTIBLE;
@@ -1415,7 +1409,7 @@ index bfbcaf4a851..f650d072cd4 100644
      if (alertable) flags |= SELECT_ALERTABLE;
      select_op.signal_and_wait.op = SELECT_SIGNAL_AND_WAIT;
      select_op.signal_and_wait.wait = wine_server_obj_handle( wait );
-@@ -1721,6 +2718,9 @@ NTSTATUS WINAPI NtCreateKeyedEvent( HANDLE *handle, ACCESS_MASK access,
+@@ -1701,6 +2692,9 @@ NTSTATUS WINAPI NtCreateKeyedEvent( HANDLE *handle, ACCESS_MASK access,
      data_size_t len;
      struct object_attributes *objattr;
  
@@ -1425,7 +1419,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = alloc_object_attributes( attr, &objattr, &len ))) return ret;
  
-@@ -1745,6 +2745,8 @@ NTSTATUS WINAPI NtOpenKeyedEvent( HANDLE *handle, ACCESS_MASK access, const OBJE
+@@ -1725,6 +2719,8 @@ NTSTATUS WINAPI NtOpenKeyedEvent( HANDLE *handle, ACCESS_MASK access, const OBJE
  {
      unsigned int ret;
  
@@ -1434,7 +1428,7 @@ index bfbcaf4a851..f650d072cd4 100644
      *handle = 0;
      if ((ret = validate_open_object_attributes( attr ))) return ret;
  
-@@ -1771,6 +2773,8 @@ NTSTATUS WINAPI NtWaitForKeyedEvent( HANDLE handle, const void *key,
+@@ -1751,6 +2747,8 @@ NTSTATUS WINAPI NtWaitForKeyedEvent( HANDLE handle, const void *key,
      select_op_t select_op;
      UINT flags = SELECT_INTERRUPTIBLE;
  
@@ -1443,7 +1437,7 @@ index bfbcaf4a851..f650d072cd4 100644
      if (!handle) handle = keyed_event;
      if ((ULONG_PTR)key & 1) return STATUS_INVALID_PARAMETER_1;
      if (alertable) flags |= SELECT_ALERTABLE;
-@@ -1790,6 +2794,8 @@ NTSTATUS WINAPI NtReleaseKeyedEvent( HANDLE handle, const void *key,
+@@ -1770,6 +2768,8 @@ NTSTATUS WINAPI NtReleaseKeyedEvent( HANDLE handle, const void *key,
      select_op_t select_op;
      UINT flags = SELECT_INTERRUPTIBLE;
  
@@ -1453,10 +1447,10 @@ index bfbcaf4a851..f650d072cd4 100644
      if ((ULONG_PTR)key & 1) return STATUS_INVALID_PARAMETER_1;
      if (alertable) flags |= SELECT_ALERTABLE;
 diff --git a/dlls/ntdll/unix/thread.c b/dlls/ntdll/unix/thread.c
-index 9e84ec3cc96..d0cb1db090e 100644
+index 6a0f2fa..a5a0490 100644
 --- a/dlls/ntdll/unix/thread.c
 +++ b/dlls/ntdll/unix/thread.c
-@@ -1755,7 +1755,7 @@ NTSTATUS get_thread_context( HANDLE handle, void *context, BOOL *self, USHORT ma
+@@ -1758,7 +1758,7 @@ NTSTATUS get_thread_context( HANDLE handle, void *context, BOOL *self, USHORT ma
  
      if (ret == STATUS_PENDING)
      {
@@ -1466,7 +1460,7 @@ index 9e84ec3cc96..d0cb1db090e 100644
          SERVER_START_REQ( get_thread_context )
          {
 diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
-index 07f2724eac7..e8dd9bbb035 100644
+index b249570..11998df 100644
 --- a/dlls/ntdll/unix/unix_private.h
 +++ b/dlls/ntdll/unix/unix_private.h
 @@ -101,6 +101,7 @@ struct ntdll_thread_data
@@ -1477,8 +1471,8 @@ index 07f2724eac7..e8dd9bbb035 100644
  };
  
  C_ASSERT( sizeof(struct ntdll_thread_data) <= sizeof(((TEB *)0)->GdiTebBatch) );
-@@ -192,6 +193,8 @@ extern NTSTATUS load_main_exe( const WCHAR *name, const char *unix_name, const W
- extern NTSTATUS load_start_exe( WCHAR **image, void **module );
+@@ -194,6 +195,8 @@ extern NTSTATUS load_start_exe( WCHAR **image, void **module );
+ extern ULONG_PTR redirect_arm64ec_rva( void *module, ULONG_PTR rva, const IMAGE_ARM64EC_METADATA *metadata );
  extern void start_server( BOOL debug );
  
 +extern pthread_mutex_t fd_cache_mutex;
@@ -1486,7 +1480,7 @@ index 07f2724eac7..e8dd9bbb035 100644
  extern unsigned int server_call_unlocked( void *req_ptr );
  extern void server_enter_uninterrupted_section( pthread_mutex_t *mutex, sigset_t *sigset );
  extern void server_leave_uninterrupted_section( pthread_mutex_t *mutex, sigset_t *sigset );
-@@ -199,6 +202,7 @@ extern unsigned int server_select( const select_op_t *select_op, data_size_t siz
+@@ -201,6 +204,7 @@ extern unsigned int server_select( const select_op_t *select_op, data_size_t siz
                                     timeout_t abs_timeout, context_t *context, user_apc_t *user_apc );
  extern unsigned int server_wait( const select_op_t *select_op, data_size_t size, UINT flags,
                                   const LARGE_INTEGER *timeout );
@@ -1494,7 +1488,7 @@ index 07f2724eac7..e8dd9bbb035 100644
  extern unsigned int server_queue_process_apc( HANDLE process, const apc_call_t *call,
                                                apc_result_t *result );
  extern int server_get_unix_fd( HANDLE handle, unsigned int wanted_access, int *unix_fd,
-@@ -335,6 +339,8 @@ extern NTSTATUS wow64_wine_spawnvp( void *args );
+@@ -349,6 +353,8 @@ extern NTSTATUS wow64_wine_spawnvp( void *args );
  
  extern void dbg_init(void);
  
@@ -1503,7 +1497,15 @@ index 07f2724eac7..e8dd9bbb035 100644
  extern NTSTATUS call_user_apc_dispatcher( CONTEXT *context_ptr, ULONG_PTR arg1, ULONG_PTR arg2, ULONG_PTR arg3,
                                            PNTAPCFUNC func, NTSTATUS status );
  extern NTSTATUS call_user_exception_dispatcher( EXCEPTION_RECORD *rec, CONTEXT *context );
-@@ -401,7 +407,7 @@ static inline async_data_t server_async( HANDLE handle, struct async_fileio *use
+@@ -357,6 +363,7 @@ extern void call_raise_user_exception_dispatcher(void);
+ #define IMAGE_DLLCHARACTERISTICS_PREFER_NATIVE 0x0010 /* Wine extension */
+ 
+ #define TICKSPERSEC 10000000
++#define NSECPERSEC 1000000000
+ #define SECS_1601_TO_1970  ((369 * 365 + 89) * (ULONGLONG)86400)
+ 
+ static inline ULONGLONG ticks_from_time_t( time_t time )
+@@ -415,7 +422,7 @@ static inline async_data_t server_async( HANDLE handle, struct async_fileio *use
  
  static inline NTSTATUS wait_async( HANDLE handle, BOOL alertable )
  {
@@ -1513,7 +1515,7 @@ index 07f2724eac7..e8dd9bbb035 100644
  
  static inline BOOL in_wow64_call(void)
 diff --git a/dlls/webservices/tests/channel.c b/dlls/webservices/tests/channel.c
-index 4cf39c10732..1fb12297eef 100644
+index 4cf39c1..1fb1229 100644
 --- a/dlls/webservices/tests/channel.c
 +++ b/dlls/webservices/tests/channel.c
 @@ -1214,6 +1214,9 @@ static const char send_record_begin[] = {
@@ -1527,7 +1529,7 @@ index 4cf39c10732..1fb12297eef 100644
  {
      char buf[512], dict_buf[256], body_buf[128], dict_size_buf[5];
 diff --git a/include/config.h.in b/include/config.h.in
-index cda76fcfe2e..16685419788 100644
+index a910b2c..7789dbd 100644
 --- a/include/config.h.in
 +++ b/include/config.h.in
 @@ -174,6 +174,9 @@
@@ -1541,10 +1543,10 @@ index cda76fcfe2e..16685419788 100644
  #undef HAVE_LINUX_PARAM_H
  
 diff --git a/include/wine/server_protocol.h b/include/wine/server_protocol.h
-index 139a7bca69e..9de93637410 100644
+index 34655d1..1f8e10a 100644
 --- a/include/wine/server_protocol.h
 +++ b/include/wine/server_protocol.h
-@@ -5637,6 +5637,88 @@ struct get_next_thread_reply
+@@ -5634,6 +5634,88 @@ struct get_next_thread_reply
  };
  
  
@@ -1633,7 +1635,7 @@ index 139a7bca69e..9de93637410 100644
  enum request
  {
      REQ_new_process,
-@@ -5923,6 +6005,11 @@ enum request
+@@ -5921,6 +6003,11 @@ enum request
      REQ_suspend_process,
      REQ_resume_process,
      REQ_get_next_thread,
@@ -1645,7 +1647,7 @@ index 139a7bca69e..9de93637410 100644
      REQ_NB_REQUESTS
  };
  
-@@ -6214,6 +6301,11 @@ union generic_request
+@@ -6213,6 +6300,11 @@ union generic_request
      struct suspend_process_request suspend_process_request;
      struct resume_process_request resume_process_request;
      struct get_next_thread_request get_next_thread_request;
@@ -1670,7 +1672,7 @@ index 139a7bca69e..9de93637410 100644
  
  /* ### protocol_version begin ### */
 diff --git a/server/Makefile.in b/server/Makefile.in
-index 7b46b924c46..d21bd5541c7 100644
+index 7b46b92..d21bd55 100644
 --- a/server/Makefile.in
 +++ b/server/Makefile.in
 @@ -12,6 +12,7 @@ SOURCES = \
@@ -1682,7 +1684,7 @@ index 7b46b924c46..d21bd5541c7 100644
  	file.c \
  	handle.c \
 diff --git a/server/async.c b/server/async.c
-index 9cb251df5ce..09c5e1ec9a7 100644
+index 80129ac..02fb966 100644
 --- a/server/async.c
 +++ b/server/async.c
 @@ -89,6 +89,7 @@ static const struct object_ops async_ops =
@@ -1693,7 +1695,7 @@ index 9cb251df5ce..09c5e1ec9a7 100644
      no_close_handle,           /* close_handle */
      async_destroy              /* destroy */
  };
-@@ -688,6 +689,7 @@ static const struct object_ops iosb_ops =
+@@ -698,6 +699,7 @@ static const struct object_ops iosb_ops =
      NULL,                     /* unlink_name */
      no_open_file,             /* open_file */
      no_kernel_obj_list,       /* get_kernel_obj_list */
@@ -1702,7 +1704,7 @@ index 9cb251df5ce..09c5e1ec9a7 100644
      iosb_destroy              /* destroy */
  };
 diff --git a/server/atom.c b/server/atom.c
-index ff0799f5880..ba320c4c630 100644
+index ff0799f..ba320c4 100644
 --- a/server/atom.c
 +++ b/server/atom.c
 @@ -91,6 +91,7 @@ static const struct object_ops atom_table_ops =
@@ -1714,7 +1716,7 @@ index ff0799f5880..ba320c4c630 100644
      atom_table_destroy            /* destroy */
  };
 diff --git a/server/change.c b/server/change.c
-index 843e495411c..20b80f98548 100644
+index 843e495..20b80f9 100644
 --- a/server/change.c
 +++ b/server/change.c
 @@ -124,6 +124,7 @@ static const struct object_ops dir_ops =
@@ -1726,7 +1728,7 @@ index 843e495411c..20b80f98548 100644
      dir_destroy               /* destroy */
  };
 diff --git a/server/clipboard.c b/server/clipboard.c
-index 8118a467dd8..de9f84f74d0 100644
+index 8118a46..de9f84f 100644
 --- a/server/clipboard.c
 +++ b/server/clipboard.c
 @@ -88,6 +88,7 @@ static const struct object_ops clipboard_ops =
@@ -1738,7 +1740,7 @@ index 8118a467dd8..de9f84f74d0 100644
      clipboard_destroy             /* destroy */
  };
 diff --git a/server/completion.c b/server/completion.c
-index 6933195e72d..5ec6d209d13 100644
+index 6933195..5ec6d20 100644
 --- a/server/completion.c
 +++ b/server/completion.c
 @@ -61,10 +61,12 @@ struct completion
@@ -1813,7 +1815,7 @@ index 6933195e72d..5ec6d209d13 100644
  
      release_object( completion );
 diff --git a/server/console.c b/server/console.c
-index b64283baf4a..17708df7953 100644
+index b64283b..17708df 100644
 --- a/server/console.c
 +++ b/server/console.c
 @@ -61,6 +61,7 @@ struct console
@@ -2101,7 +2103,7 @@ index b64283baf4a..17708df7953 100644
      release_object( server );
  }
 diff --git a/server/debugger.c b/server/debugger.c
-index 48adb244b09..04172b7e66d 100644
+index c59a0ab..7975fc4 100644
 --- a/server/debugger.c
 +++ b/server/debugger.c
 @@ -71,6 +71,7 @@ struct debug_obj
@@ -2197,7 +2199,7 @@ index 48adb244b09..04172b7e66d 100644
      else
      {
 diff --git a/server/device.c b/server/device.c
-index 436dac6bfe9..698fee63f03 100644
+index 436dac6..698fee6 100644
 --- a/server/device.c
 +++ b/server/device.c
 @@ -78,6 +78,7 @@ static const struct object_ops irp_call_ops =
@@ -2315,7 +2317,7 @@ index 436dac6bfe9..698fee63f03 100644
                  if (irp->file) grab_object( irp );
                  manager->current_call = irp;
 diff --git a/server/directory.c b/server/directory.c
-index 23d7eb0a2b7..8e32abbcff2 100644
+index 23d7eb0..8e32abb 100644
 --- a/server/directory.c
 +++ b/server/directory.c
 @@ -81,6 +81,7 @@ static const struct object_ops object_type_ops =
@@ -2335,7 +2337,7 @@ index 23d7eb0a2b7..8e32abbcff2 100644
      directory_destroy             /* destroy */
  };
 diff --git a/server/event.c b/server/event.c
-index f1b79b1b35e..b750a22487b 100644
+index f1b79b1..b750a22 100644
 --- a/server/event.c
 +++ b/server/event.c
 @@ -56,6 +56,7 @@ struct event
@@ -2474,10 +2476,10 @@ index f1b79b1b35e..b750a22487b 100644
  {
 diff --git a/server/fast_sync.c b/server/fast_sync.c
 new file mode 100644
-index 00000000000..8684eb6dcd7
+index 0000000..51fe32e
 --- /dev/null
 +++ b/server/fast_sync.c
-@@ -0,0 +1,420 @@
+@@ -0,0 +1,417 @@
 +/*
 + * Fast synchronization primitives
 + *
@@ -2635,6 +2637,7 @@ index 00000000000..8684eb6dcd7
 +        return NULL;
 +    }
 +
++    fprintf( stderr, "wine: using fast synchronization.\n" );
 +    linux_device_object = device;
 +    return device;
 +}
@@ -2876,10 +2879,6 @@ index 00000000000..8684eb6dcd7
 +{
 +#ifdef HAVE_LINUX_NTSYNC_H
 +    struct object *obj;
-+    static int once;
-+
-+    if (!once++)
-+        fprintf( stderr, "wine: using fast synchronization.\n" );
 +
 +    if ((obj = get_handle_obj( current->process, req->handle, 0, NULL )))
 +    {
@@ -2899,7 +2898,7 @@ index 00000000000..8684eb6dcd7
 +#endif
 +}
 diff --git a/server/fd.c b/server/fd.c
-index 8576882aaa9..39b94fd283a 100644
+index 8576882..39b94fd 100644
 --- a/server/fd.c
 +++ b/server/fd.c
 @@ -156,6 +156,7 @@ struct fd
@@ -3004,7 +3003,7 @@ index 8576882aaa9..39b94fd283a 100644
  {
      int events = 0;
 diff --git a/server/file.c b/server/file.c
-index 76c687833c9..1191303c35a 100644
+index 76c6878..1191303 100644
 --- a/server/file.c
 +++ b/server/file.c
 @@ -106,6 +106,7 @@ static const struct object_ops file_ops =
@@ -3016,7 +3015,7 @@ index 76c687833c9..1191303c35a 100644
      file_destroy                  /* destroy */
  };
 diff --git a/server/file.h b/server/file.h
-index 39a833cd105..69f5df9b463 100644
+index 7f2d163..2ec50aa 100644
 --- a/server/file.h
 +++ b/server/file.h
 @@ -108,6 +108,7 @@ extern char *dup_fd_name( struct fd *root, const char *name ) __WINE_DEALLOC(fre
@@ -3028,7 +3027,7 @@ index 39a833cd105..69f5df9b463 100644
  extern void default_poll_event( struct fd *fd, int event );
  extern void fd_cancel_async( struct fd *fd, struct async *async );
 diff --git a/server/handle.c b/server/handle.c
-index 0595fdb403b..17d3617f0a3 100644
+index 71cdd2e..e07f32c 100644
 --- a/server/handle.c
 +++ b/server/handle.c
 @@ -138,6 +138,7 @@ static const struct object_ops handle_table_ops =
@@ -3040,7 +3039,7 @@ index 0595fdb403b..17d3617f0a3 100644
      handle_table_destroy             /* destroy */
  };
 diff --git a/server/hook.c b/server/hook.c
-index 5abdf39ad37..5a00699283d 100644
+index 5abdf39..5a00699 100644
 --- a/server/hook.c
 +++ b/server/hook.c
 @@ -92,6 +92,7 @@ static const struct object_ops hook_table_ops =
@@ -3052,7 +3051,7 @@ index 5abdf39ad37..5a00699283d 100644
      hook_table_destroy            /* destroy */
  };
 diff --git a/server/mailslot.c b/server/mailslot.c
-index 2d8697ec9bd..d9807b4ad23 100644
+index 2d8697e..d9807b4 100644
 --- a/server/mailslot.c
 +++ b/server/mailslot.c
 @@ -86,6 +86,7 @@ static const struct object_ops mailslot_ops =
@@ -3088,7 +3087,7 @@ index 2d8697ec9bd..d9807b4ad23 100644
      mailslot_device_file_destroy            /* destroy */
  };
 diff --git a/server/mapping.c b/server/mapping.c
-index f754078acf7..23901aa6f76 100644
+index 6b0de1b..c3cba90 100644
 --- a/server/mapping.c
 +++ b/server/mapping.c
 @@ -79,6 +79,7 @@ static const struct object_ops ranges_ops =
@@ -3116,7 +3115,7 @@ index f754078acf7..23901aa6f76 100644
      mapping_destroy              /* destroy */
  };
 diff --git a/server/mutex.c b/server/mutex.c
-index af0efe72132..167c236e014 100644
+index af0efe7..167c236 100644
 --- a/server/mutex.c
 +++ b/server/mutex.c
 @@ -38,6 +38,8 @@
@@ -3224,7 +3223,7 @@ index af0efe72132..167c236e014 100644
  
  /* create a mutex */
 diff --git a/server/named_pipe.c b/server/named_pipe.c
-index f3404a33c3b..6d8cb3ea350 100644
+index f3404a3..6d8cb3e 100644
 --- a/server/named_pipe.c
 +++ b/server/named_pipe.c
 @@ -131,6 +131,7 @@ static const struct object_ops named_pipe_ops =
@@ -3268,7 +3267,7 @@ index f3404a33c3b..6d8cb3ea350 100644
      named_pipe_device_file_destroy           /* destroy */
  };
 diff --git a/server/object.c b/server/object.c
-index 89e541ffb6b..6c6568e5d24 100644
+index 89e541f..6c6568e 100644
 --- a/server/object.c
 +++ b/server/object.c
 @@ -538,6 +538,12 @@ struct fd *no_get_fd( struct object *obj )
@@ -3285,7 +3284,7 @@ index 89e541ffb6b..6c6568e5d24 100644
  {
      return map_access( access, &obj->ops->type->mapping );
 diff --git a/server/object.h b/server/object.h
-index dfdd691601f..f1f39571136 100644
+index d4d6653..b1147bc 100644
 --- a/server/object.h
 +++ b/server/object.h
 @@ -42,6 +42,7 @@ struct async;
@@ -3324,7 +3323,7 @@ index dfdd691601f..f1f39571136 100644
  
  int get_serial_async_timeout(struct object *obj, int type, int count);
 diff --git a/server/process.c b/server/process.c
-index a0d5ea64d97..f61916d3adf 100644
+index c9ab161..056095e 100644
 --- a/server/process.c
 +++ b/server/process.c
 @@ -94,6 +94,7 @@ static unsigned int process_map_access( struct object *obj, unsigned int access
@@ -3410,15 +3409,15 @@ index a0d5ea64d97..f61916d3adf 100644
  }
  
  static void job_dump( struct object *obj, int verbose )
-@@ -682,6 +702,7 @@ struct process *create_process( int fd, struct process *parent, unsigned int fla
+@@ -683,6 +703,7 @@ struct process *create_process( int fd, struct process *parent, unsigned int fla
      process->rawinput_device_count = 0;
      process->rawinput_mouse  = NULL;
      process->rawinput_kbd    = NULL;
 +    process->fast_sync       = NULL;
      memset( &process->image_info, 0, sizeof(process->image_info) );
+     list_init( &process->rawinput_entry );
      list_init( &process->kernel_object );
-     list_init( &process->thread_list );
-@@ -786,6 +807,8 @@ static void process_destroy( struct object *obj )
+@@ -789,6 +810,8 @@ static void process_destroy( struct object *obj )
      free( process->rawinput_devices );
      free( process->dir_cache );
      free( process->image );
@@ -3427,7 +3426,7 @@ index a0d5ea64d97..f61916d3adf 100644
  }
  
  /* dump a process on stdout for debugging purposes */
-@@ -817,6 +840,16 @@ static struct list *process_get_kernel_obj_list( struct object *obj )
+@@ -820,6 +843,16 @@ static struct list *process_get_kernel_obj_list( struct object *obj )
      return &process->kernel_object;
  }
  
@@ -3444,7 +3443,7 @@ index a0d5ea64d97..f61916d3adf 100644
  static struct security_descriptor *process_get_sd( struct object *obj )
  {
      static struct security_descriptor *process_default_sd;
-@@ -981,6 +1014,7 @@ static void process_killed( struct process *process )
+@@ -984,6 +1017,7 @@ static void process_killed( struct process *process )
      release_job_process( process );
      start_sigkill_timer( process );
      wake_up( &process->obj, 0 );
@@ -3453,11 +3452,11 @@ index a0d5ea64d97..f61916d3adf 100644
  
  /* add a thread to a process running threads list */
 diff --git a/server/process.h b/server/process.h
-index 97e0d455ece..6ec97ae4527 100644
+index 1e73e9d..2140427 100644
 --- a/server/process.h
 +++ b/server/process.h
-@@ -85,6 +85,7 @@ struct process
-     const struct rawinput_device *rawinput_kbd;   /* rawinput keyboard device, if any */
+@@ -86,6 +86,7 @@ struct process
+     struct list          rawinput_entry;  /* entry in the rawinput process list */
      struct list          kernel_object;   /* list of kernel object pointers */
      pe_image_info_t      image_info;      /* main exe image info */
 +    struct fast_sync    *fast_sync;       /* fast synchronization object */
@@ -3465,10 +3464,10 @@ index 97e0d455ece..6ec97ae4527 100644
  
  /* process functions */
 diff --git a/server/protocol.def b/server/protocol.def
-index 5d60e7fcda3..38b0d9d062e 100644
+index fa78e04..0dcd832 100644
 --- a/server/protocol.def
 +++ b/server/protocol.def
-@@ -3884,3 +3884,52 @@ struct handle_info
+@@ -3875,3 +3875,52 @@ struct handle_info
  @REPLY
      obj_handle_t handle;       /* next thread handle */
  @END
@@ -3522,10 +3521,10 @@ index 5d60e7fcda3..38b0d9d062e 100644
 +    obj_handle_t handle;          /* handle to the event */
 +@END
 diff --git a/server/queue.c b/server/queue.c
-index cd913ae03e5..7afa1dce898 100644
+index 4373bd7..5387df4 100644
 --- a/server/queue.c
 +++ b/server/queue.c
-@@ -142,6 +142,8 @@ struct msg_queue
+@@ -145,6 +145,8 @@ struct msg_queue
      struct hook_table     *hooks;           /* hook table */
      timeout_t              last_get_msg;    /* time of last get message call */
      int                    keystate_lock;   /* owns an input keystate lock */
@@ -3534,7 +3533,7 @@ index cd913ae03e5..7afa1dce898 100644
  };
  
  struct hotkey
-@@ -159,6 +161,7 @@ static int msg_queue_add_queue( struct object *obj, struct wait_queue_entry *ent
+@@ -162,6 +164,7 @@ static int msg_queue_add_queue( struct object *obj, struct wait_queue_entry *ent
  static void msg_queue_remove_queue( struct object *obj, struct wait_queue_entry *entry );
  static int msg_queue_signaled( struct object *obj, struct wait_queue_entry *entry );
  static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *entry );
@@ -3542,7 +3541,7 @@ index cd913ae03e5..7afa1dce898 100644
  static void msg_queue_destroy( struct object *obj );
  static void msg_queue_poll_event( struct fd *fd, int event );
  static void thread_input_dump( struct object *obj, int verbose );
-@@ -185,6 +188,7 @@ static const struct object_ops msg_queue_ops =
+@@ -188,6 +191,7 @@ static const struct object_ops msg_queue_ops =
      NULL,                      /* unlink_name */
      no_open_file,              /* open_file */
      no_kernel_obj_list,        /* get_kernel_obj_list */
@@ -3550,7 +3549,7 @@ index cd913ae03e5..7afa1dce898 100644
      no_close_handle,           /* close_handle */
      msg_queue_destroy          /* destroy */
  };
-@@ -222,6 +226,7 @@ static const struct object_ops thread_input_ops =
+@@ -225,6 +229,7 @@ static const struct object_ops thread_input_ops =
      NULL,                         /* unlink_name */
      no_open_file,                 /* open_file */
      no_kernel_obj_list,           /* get_kernel_obj_list */
@@ -3558,7 +3557,7 @@ index cd913ae03e5..7afa1dce898 100644
      no_close_handle,              /* close_handle */
      thread_input_destroy          /* destroy */
  };
-@@ -310,6 +315,8 @@ static struct msg_queue *create_msg_queue( struct thread *thread, struct thread_
+@@ -313,6 +318,8 @@ static struct msg_queue *create_msg_queue( struct thread *thread, struct thread_
          queue->hooks           = NULL;
          queue->last_get_msg    = current_time;
          queue->keystate_lock   = 0;
@@ -3567,7 +3566,7 @@ index cd913ae03e5..7afa1dce898 100644
          list_init( &queue->send_result );
          list_init( &queue->callback_result );
          list_init( &queue->pending_timers );
-@@ -591,7 +598,11 @@ static inline void set_queue_bits( struct msg_queue *queue, unsigned int bits )
+@@ -594,7 +601,11 @@ static inline void set_queue_bits( struct msg_queue *queue, unsigned int bits )
      }
      queue->wake_bits |= bits;
      queue->changed_bits |= bits;
@@ -3580,7 +3579,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  /* clear some queue bits */
-@@ -604,6 +615,8 @@ static inline void clear_queue_bits( struct msg_queue *queue, unsigned int bits
+@@ -607,6 +618,8 @@ static inline void clear_queue_bits( struct msg_queue *queue, unsigned int bits
          if (queue->keystate_lock) unlock_input_keystate( queue->input );
          queue->keystate_lock = 0;
      }
@@ -3589,7 +3588,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  /* check if message is matched by the filter */
-@@ -1082,6 +1095,10 @@ static int is_queue_hung( struct msg_queue *queue )
+@@ -1085,6 +1098,10 @@ static int is_queue_hung( struct msg_queue *queue )
          if (get_wait_queue_thread(entry)->queue == queue)
              return 0;  /* thread is waiting on queue -> not hung */
      }
@@ -3600,7 +3599,7 @@ index cd913ae03e5..7afa1dce898 100644
      return 1;
  }
  
-@@ -1142,6 +1159,17 @@ static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *en
+@@ -1145,6 +1162,17 @@ static void msg_queue_satisfied( struct object *obj, struct wait_queue_entry *en
      struct msg_queue *queue = (struct msg_queue *)obj;
      queue->wake_mask = 0;
      queue->changed_mask = 0;
@@ -3618,7 +3617,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  static void msg_queue_destroy( struct object *obj )
-@@ -1181,6 +1209,7 @@ static void msg_queue_destroy( struct object *obj )
+@@ -1184,6 +1212,7 @@ static void msg_queue_destroy( struct object *obj )
      release_object( queue->input );
      if (queue->hooks) release_object( queue->hooks );
      if (queue->fd) release_object( queue->fd );
@@ -3626,7 +3625,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  static void msg_queue_poll_event( struct fd *fd, int event )
-@@ -1191,6 +1220,7 @@ static void msg_queue_poll_event( struct fd *fd, int event )
+@@ -1194,6 +1223,7 @@ static void msg_queue_poll_event( struct fd *fd, int event )
      if (event & (POLLERR | POLLHUP)) set_fd_events( fd, -1 );
      else set_fd_events( queue->fd, 0 );
      wake_up( &queue->obj, 0 );
@@ -3634,7 +3633,7 @@ index cd913ae03e5..7afa1dce898 100644
  }
  
  static void thread_input_dump( struct object *obj, int verbose )
-@@ -2556,8 +2586,20 @@ DECL_HANDLER(set_queue_mask)
+@@ -2682,8 +2712,20 @@ DECL_HANDLER(set_queue_mask)
          if (is_signaled( queue ))
          {
              /* if skip wait is set, do what would have been done in the subsequent wait */
@@ -3657,7 +3656,7 @@ index cd913ae03e5..7afa1dce898 100644
          }
      }
  }
-@@ -2572,6 +2614,8 @@ DECL_HANDLER(get_queue_status)
+@@ -2698,6 +2740,8 @@ DECL_HANDLER(get_queue_status)
          reply->wake_bits    = queue->wake_bits;
          reply->changed_bits = queue->changed_bits;
          queue->changed_bits &= ~req->clear_bits;
@@ -3666,7 +3665,7 @@ index cd913ae03e5..7afa1dce898 100644
      }
      else reply->wake_bits = reply->changed_bits = 0;
  }
-@@ -2753,6 +2797,9 @@ DECL_HANDLER(get_message)
+@@ -2873,6 +2917,9 @@ DECL_HANDLER(get_message)
      if (filter & QS_INPUT) queue->changed_bits &= ~QS_INPUT;
      if (filter & QS_PAINT) queue->changed_bits &= ~QS_PAINT;
  
@@ -3676,7 +3675,7 @@ index cd913ae03e5..7afa1dce898 100644
      /* then check for posted messages */
      if ((filter & QS_POSTMESSAGE) &&
          get_posted_message( queue, get_win, req->get_first, req->get_last, req->flags, reply ))
-@@ -2811,6 +2858,7 @@ DECL_HANDLER(get_message)
+@@ -2931,6 +2978,7 @@ DECL_HANDLER(get_message)
      if (get_win == -1 && current->process->idle_event) set_event( current->process->idle_event );
      queue->wake_mask = req->wake_mask;
      queue->changed_mask = req->changed_mask;
@@ -3684,9 +3683,9 @@ index cd913ae03e5..7afa1dce898 100644
      set_error( STATUS_PENDING );  /* FIXME */
  }
  
-@@ -3508,3 +3556,56 @@ DECL_HANDLER(update_rawinput_devices)
-     process->rawinput_mouse = find_rawinput_device( process, 1, 2 );
-     process->rawinput_kbd = find_rawinput_device( process, 1, 6 );
+@@ -3671,3 +3719,56 @@ DECL_HANDLER(update_rawinput_devices)
+         release_object( desktop );
+     }
  }
 +
 +DECL_HANDLER(fast_select_queue)
@@ -3742,7 +3741,7 @@ index cd913ae03e5..7afa1dce898 100644
 +    release_object( queue );
 +}
 diff --git a/server/registry.c b/server/registry.c
-index da6a6d0982e..83d36580356 100644
+index e88bed1..2afd5ec 100644
 --- a/server/registry.c
 +++ b/server/registry.c
 @@ -192,6 +192,7 @@ static const struct object_ops key_ops =
@@ -3754,7 +3753,7 @@ index da6a6d0982e..83d36580356 100644
      key_destroy              /* destroy */
  };
 diff --git a/server/request.c b/server/request.c
-index 7021741c765..8c50f993d25 100644
+index 7021741..8c50f99 100644
 --- a/server/request.c
 +++ b/server/request.c
 @@ -102,6 +102,7 @@ static const struct object_ops master_socket_ops =
@@ -3766,10 +3765,10 @@ index 7021741c765..8c50f993d25 100644
      master_socket_destroy          /* destroy */
  };
 diff --git a/server/request.h b/server/request.h
-index 89d5a621b16..e255b8206e2 100644
+index 4e7dec4..7f9de15 100644
 --- a/server/request.h
 +++ b/server/request.h
-@@ -403,6 +403,11 @@ DECL_HANDLER(terminate_job);
+@@ -404,6 +404,11 @@ DECL_HANDLER(terminate_job);
  DECL_HANDLER(suspend_process);
  DECL_HANDLER(resume_process);
  DECL_HANDLER(get_next_thread);
@@ -3781,7 +3780,7 @@ index 89d5a621b16..e255b8206e2 100644
  
  #ifdef WANT_REQUEST_HANDLERS
  
-@@ -693,6 +698,11 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
+@@ -695,6 +700,11 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
      (req_handler)req_suspend_process,
      (req_handler)req_resume_process,
      (req_handler)req_get_next_thread,
@@ -3793,7 +3792,7 @@ index 89d5a621b16..e255b8206e2 100644
  };
  
  C_ASSERT( sizeof(abstime_t) == 8 );
-@@ -2336,6 +2346,23 @@ C_ASSERT( FIELD_OFFSET(struct get_next_thread_request, flags) == 28 );
+@@ -2339,6 +2349,23 @@ C_ASSERT( FIELD_OFFSET(struct get_next_thread_request, flags) == 28 );
  C_ASSERT( sizeof(struct get_next_thread_request) == 32 );
  C_ASSERT( FIELD_OFFSET(struct get_next_thread_reply, handle) == 8 );
  C_ASSERT( sizeof(struct get_next_thread_reply) == 16 );
@@ -3818,7 +3817,7 @@ index 89d5a621b16..e255b8206e2 100644
  #endif  /* WANT_REQUEST_HANDLERS */
  
 diff --git a/server/semaphore.c b/server/semaphore.c
-index 53b42a886df..99409198d68 100644
+index 53b42a8..9940919 100644
 --- a/server/semaphore.c
 +++ b/server/semaphore.c
 @@ -55,12 +55,15 @@ struct semaphore
@@ -3881,7 +3880,7 @@ index 53b42a886df..99409198d68 100644
  DECL_HANDLER(create_semaphore)
  {
 diff --git a/server/serial.c b/server/serial.c
-index d665eb7fa35..5c210d10a80 100644
+index d665eb7..5c210d1 100644
 --- a/server/serial.c
 +++ b/server/serial.c
 @@ -97,6 +97,7 @@ static const struct object_ops serial_ops =
@@ -3893,7 +3892,7 @@ index d665eb7fa35..5c210d10a80 100644
      serial_destroy                /* destroy */
  };
 diff --git a/server/signal.c b/server/signal.c
-index 19b76d44c16..e5def3dc899 100644
+index 19b76d4..e5def3d 100644
 --- a/server/signal.c
 +++ b/server/signal.c
 @@ -74,6 +74,7 @@ static const struct object_ops handler_ops =
@@ -3905,7 +3904,7 @@ index 19b76d44c16..e5def3dc899 100644
      handler_destroy           /* destroy */
  };
 diff --git a/server/sock.c b/server/sock.c
-index c34fd3eb5eb..c226d7d0162 100644
+index 3ad1ce3..3fb2e29 100644
 --- a/server/sock.c
 +++ b/server/sock.c
 @@ -465,6 +465,7 @@ static const struct object_ops sock_ops =
@@ -3933,7 +3932,7 @@ index c34fd3eb5eb..c226d7d0162 100644
      no_destroy                  /* destroy */
  };
 diff --git a/server/symlink.c b/server/symlink.c
-index dd28efd3a75..4a7cf68f269 100644
+index dd28efd..4a7cf68 100644
 --- a/server/symlink.c
 +++ b/server/symlink.c
 @@ -83,6 +83,7 @@ static const struct object_ops symlink_ops =
@@ -3945,7 +3944,7 @@ index dd28efd3a75..4a7cf68f269 100644
      symlink_destroy               /* destroy */
  };
 diff --git a/server/thread.c b/server/thread.c
-index 56f57cefd8f..13585ee9d34 100644
+index 56f57ce..13585ee 100644
 --- a/server/thread.c
 +++ b/server/thread.c
 @@ -108,6 +108,7 @@ static const struct object_ops thread_apc_ops =
@@ -4070,10 +4069,10 @@ index 56f57cefd8f..13585ee9d34 100644
 +        reply->handle = alloc_handle( current->process, current->fast_alert_event, SYNCHRONIZE, 0 );
 +}
 diff --git a/server/thread.h b/server/thread.h
-index 8dcf966a90a..9586138640b 100644
+index 766ed78..9bf4b48 100644
 --- a/server/thread.h
 +++ b/server/thread.h
-@@ -90,6 +90,8 @@ struct thread
+@@ -91,6 +91,8 @@ struct thread
      struct list            kernel_object; /* list of kernel object pointers */
      data_size_t            desc_len;      /* thread description length in bytes */
      WCHAR                 *desc;          /* thread description string */
@@ -4083,7 +4082,7 @@ index 8dcf966a90a..9586138640b 100644
  
  extern struct thread *current;
 diff --git a/server/timer.c b/server/timer.c
-index 96dc9d00ca1..854a8e1f7f2 100644
+index 96dc9d0..854a8e1 100644
 --- a/server/timer.c
 +++ b/server/timer.c
 @@ -61,11 +61,13 @@ struct timer
@@ -4161,7 +4160,7 @@ index 96dc9d00ca1..854a8e1f7f2 100644
  
  /* create a timer */
 diff --git a/server/token.c b/server/token.c
-index 4df8d2e0c6e..42562fdf88c 100644
+index 4df8d2e..42562fd 100644
 --- a/server/token.c
 +++ b/server/token.c
 @@ -155,6 +155,7 @@ static const struct object_ops token_ops =
@@ -4173,10 +4172,10 @@ index 4df8d2e0c6e..42562fdf88c 100644
      token_destroy              /* destroy */
  };
 diff --git a/server/trace.c b/server/trace.c
-index 1b65d2b977e..a5a9fec5700 100644
+index 6c9dc24..7259007 100644
 --- a/server/trace.c
 +++ b/server/trace.c
-@@ -4606,6 +4606,47 @@ static void dump_get_next_thread_reply( const struct get_next_thread_reply *req
+@@ -4594,6 +4594,47 @@ static void dump_get_next_thread_reply( const struct get_next_thread_reply *req
      fprintf( stderr, " handle=%04x", req->handle );
  }
  
@@ -4224,7 +4223,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  static const dump_func req_dumpers[REQ_NB_REQUESTS] = {
      (dump_func)dump_new_process_request,
      (dump_func)dump_get_new_process_info_request,
-@@ -4891,6 +4932,11 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] = {
+@@ -4880,6 +4921,11 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] = {
      (dump_func)dump_suspend_process_request,
      (dump_func)dump_resume_process_request,
      (dump_func)dump_get_next_thread_request,
@@ -4236,7 +4235,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  };
  
  static const dump_func reply_dumpers[REQ_NB_REQUESTS] = {
-@@ -5178,6 +5224,11 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] = {
+@@ -5168,6 +5214,11 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] = {
      NULL,
      NULL,
      (dump_func)dump_get_next_thread_reply,
@@ -4248,7 +4247,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  };
  
  static const char * const req_names[REQ_NB_REQUESTS] = {
-@@ -5465,6 +5516,11 @@ static const char * const req_names[REQ_NB_REQUESTS] = {
+@@ -5456,6 +5507,11 @@ static const char * const req_names[REQ_NB_REQUESTS] = {
      "suspend_process",
      "resume_process",
      "get_next_thread",
@@ -4261,7 +4260,7 @@ index 1b65d2b977e..a5a9fec5700 100644
  
  static const struct
 diff --git a/server/window.c b/server/window.c
-index 242e93f303a..8ddf78e54b8 100644
+index 242e93f..8ddf78e 100644
 --- a/server/window.c
 +++ b/server/window.c
 @@ -119,6 +119,7 @@ static const struct object_ops window_ops =
@@ -4273,7 +4272,7 @@ index 242e93f303a..8ddf78e54b8 100644
      window_destroy            /* destroy */
  };
 diff --git a/server/winstation.c b/server/winstation.c
-index 5903497d61e..cabc93fa571 100644
+index 373a1f7..1bb9d68 100644
 --- a/server/winstation.c
 +++ b/server/winstation.c
 @@ -88,6 +88,7 @@ static const struct object_ops winstation_ops =

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
@@ -7739,13 +7739,13 @@ index 2ce94b4..8f603fc 100644
      thread->system_regs     = 0;
      thread->queue           = NULL;
      thread->wait            = NULL;
-@@ -253,6 +250,8 @@ static inline void init_thread_structure( struct thread *thread )
+@@ -253,6 +250,7 @@ static inline void init_thread_structure( struct thread *thread )
      thread->token           = NULL;
      thread->desc            = NULL;
      thread->desc_len        = 0;
 +    thread->fast_sync       = NULL;
 +    thread->fast_alert_event = NULL;
-     thread->exit_poll       = NULL;
+-    thread->exit_poll       = NULL;
  
      thread->creation_time = current_time;
 @@ -380,12 +379,6 @@ struct thread *create_thread( int fd, struct process *process, const struct secu
@@ -7778,8 +7778,8 @@ index 2ce94b4..8f603fc 100644
  /* cleanup everything that is no longer needed by a dead thread */
  /* used by destroy_thread and kill_thread */
  static void cleanup_thread( struct thread *thread )
-@@ -465,9 +468,8 @@ static void destroy_thread( struct object *obj )
-     if (thread->exit_poll) remove_timeout_user( thread->exit_poll );
+@@ -465,9 +468,7 @@ static void destroy_thread( struct object *obj )
+-    if (thread->exit_poll) remove_timeout_user( thread->exit_poll );
      if (thread->id) free_ptid( thread->id );
      if (thread->token) release_object( thread->token );
 -
@@ -7791,7 +7791,8 @@ index 2ce94b4..8f603fc 100644
  
  /* dump a thread on stdout for debugging purposes */
 @@ -486,13 +488,6 @@ static int thread_signaled( struct object *obj, struct wait_queue_entry *entry )
-     return mythread->state == TERMINATED && !mythread->exit_poll;
+-    return mythread->state == TERMINATED && !mythread->exit_poll;
++    return (mythread->state == TERMINATED);
  }
  
 -static int thread_get_esync_fd( struct object *obj, enum esync_type *type )
@@ -7849,16 +7850,51 @@ index 2ce94b4..8f603fc 100644
      return apc;
  }
  
-@@ -1345,8 +1338,7 @@ void kill_thread( struct thread *thread, int violent_death )
+@@ -1305,26 +1302,6 @@
+     return -1;
+ }
+
+-static void check_terminated( void *arg )
+-{
+-    struct thread *thread = arg;
+-    assert( thread->obj.ops == &thread_ops );
+-    assert( thread->state == TERMINATED );
+-
+-    /* don't wake up until the thread is really dead, to avoid race conditions */
+-    if (thread->unix_tid != -1 && !kill( thread->unix_tid, 0 ))
+-    {
+-        thread->exit_poll = add_timeout_user( -TICKS_PER_SEC / 1000, check_terminated, thread );
+-        return;
+-    }
+-
+-    /* grab reference since object can be destroyed while trying to wake up */
+-    grab_object( &thread->obj );
+-    thread->exit_poll = NULL;
+-    wake_up( &thread->obj, 0 );
+-    release_object( &thread->obj );
+-}
+-
+ /* kill a thread on the spot */
+ void kill_thread( struct thread *thread, int violent_death )
+ {
+@@ -1345,14 +1338,9 @@ void kill_thread( struct thread *thread, int violent_death )
      }
      kill_console_processes( thread, 0 );
      abandon_mutexes( thread );
 -    if (do_esync())
 -        esync_abandon_mutexes( thread );
 +    fast_set_event( thread->fast_sync );
-     if (violent_death)
-     {
-         send_thread_signal( thread, SIGQUIT );
++    wake_up( &thread->obj, 0 );
++    if (violent_death) send_thread_signal( thread, SIGQUIT );
+-    if (violent_death)
+-    {
+-        send_thread_signal( thread, SIGQUIT );
+-        check_terminated( thread );
+-    }
+-    else wake_up( &thread->obj, 0 );
+     cleanup_thread( thread );
+     remove_process_thread( thread->process, thread );
+     release_object( thread );
 @@ -2094,3 +2086,12 @@ DECL_HANDLER(get_next_thread)
      set_error( STATUS_NO_MORE_ENTRIES );
      release_object( process );
@@ -7885,10 +7921,10 @@ index 10e9e28..cb4643a 100644
      unsigned int           system_regs;   /* which system regs have been set */
      struct msg_queue      *queue;         /* message queue */
      struct thread_wait    *wait;          /* current wait condition if sleeping */
-@@ -94,6 +92,8 @@ struct thread
+@@ -94,6 +92,7 @@ struct thread
      data_size_t            desc_len;      /* thread description length in bytes */
      WCHAR                 *desc;          /* thread description string */
-     struct timeout_user   *exit_poll;     /* poll if the thread/process has exited already */
+-    struct timeout_user   *exit_poll;     /* poll if the thread/process has exited already */
 +    struct fast_sync      *fast_sync;     /* fast synchronization object */
 +    struct event          *fast_alert_event; /* fast synchronization alert event */
  };

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
@@ -3752,7 +3752,136 @@ index a53870f..ba0bdbd 100644
 -
  /* Define to 1 if you have the <sys/event.h> header file. */
  #undef HAVE_SYS_EVENT_H
- 
+
+diff --git a/include/wine/server_protocol.h b/include/wine/server_protocol.h
+index 34655d1..1f8e10a 100644
+--- a/include/server_protocol.h
++++ b/include/server_protocol.h
+@@ -5634,6 +5634,88 @@ struct get_next_thread_reply
+ };
+
+
++enum fast_sync_type
++{
++    FAST_SYNC_SEMAPHORE = 1,
++    FAST_SYNC_MUTEX,
++    FAST_SYNC_AUTO_EVENT,
++    FAST_SYNC_MANUAL_EVENT,
++    FAST_SYNC_AUTO_SERVER,
++    FAST_SYNC_MANUAL_SERVER,
++    FAST_SYNC_QUEUE,
++};
++
++
++
++struct get_linux_sync_device_request
++{
++    struct request_header __header;
++    char __pad_12[4];
++};
++struct get_linux_sync_device_reply
++{
++    struct reply_header __header;
++    obj_handle_t handle;
++    char __pad_12[4];
++};
++
++
++
++struct get_linux_sync_obj_request
++{
++    struct request_header __header;
++    obj_handle_t handle;
++};
++struct get_linux_sync_obj_reply
++{
++    struct reply_header __header;
++    obj_handle_t handle;
++    int          type;
++    unsigned int access;
++    char __pad_20[4];
++};
++
++
++
++struct fast_select_queue_request
++{
++    struct request_header __header;
++    obj_handle_t handle;
++};
++struct fast_select_queue_reply
++{
++    struct reply_header __header;
++};
++
++
++
++struct fast_unselect_queue_request
++{
++    struct request_header __header;
++    obj_handle_t handle;
++    int          signaled;
++    char __pad_20[4];
++};
++struct fast_unselect_queue_reply
++{
++    struct reply_header __header;
++};
++
++
++
++struct get_fast_alert_event_request
++{
++    struct request_header __header;
++    char __pad_12[4];
++};
++struct get_fast_alert_event_reply
++{
++    struct reply_header __header;
++    obj_handle_t handle;
++    char __pad_12[4];
++};
++
++
+ enum request
+ {
+     REQ_new_process,
+@@ -5921,6 +6003,11 @@ enum request
+     REQ_suspend_process,
+     REQ_resume_process,
+     REQ_get_next_thread,
++    REQ_get_linux_sync_device,
++    REQ_get_linux_sync_obj,
++    REQ_fast_select_queue,
++    REQ_fast_unselect_queue,
++    REQ_get_fast_alert_event,
+     REQ_NB_REQUESTS
+ };
+
+@@ -6213,6 +6300,11 @@ union generic_request
+     struct suspend_process_request suspend_process_request;
+     struct resume_process_request resume_process_request;
+     struct get_next_thread_request get_next_thread_request;
++    struct get_linux_sync_device_request get_linux_sync_device_request;
++    struct get_linux_sync_obj_request get_linux_sync_obj_request;
++    struct fast_select_queue_request fast_select_queue_request;
++    struct fast_unselect_queue_request fast_unselect_queue_request;
++    struct get_fast_alert_event_request get_fast_alert_event_request;
+ };
+ union generic_reply
+ {
+@@ -6503,6 +6595,11 @@ union generic_reply
+     struct suspend_process_reply suspend_process_reply;
+     struct resume_process_reply resume_process_reply;
+     struct get_next_thread_reply get_next_thread_reply;
++    struct get_linux_sync_device_reply get_linux_sync_device_reply;
++    struct get_linux_sync_obj_reply get_linux_sync_obj_reply;
++    struct fast_select_queue_reply fast_select_queue_reply;
++    struct fast_unselect_queue_reply fast_unselect_queue_reply;
++    struct get_fast_alert_event_reply get_fast_alert_event_reply;
+ };
+
+ /* ### protocol_version begin ### */
 diff --git a/server/Makefile.in b/server/Makefile.in
 index b164193..b30df66 100644
 --- a/server/Makefile.in

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
@@ -3755,8 +3755,8 @@ index a53870f..ba0bdbd 100644
 
 diff --git a/include/wine/server_protocol.h b/include/wine/server_protocol.h
 index 34655d1..1f8e10a 100644
---- a/include/server_protocol.h
-+++ b/include/server_protocol.h
+--- a/include/wine/server_protocol.h
++++ b/include/wine/server_protocol.h
 @@ -5634,6 +5634,88 @@ struct get_next_thread_reply
  };
 

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
@@ -3846,10 +3846,15 @@ index 34655d1..1f8e10a 100644
  enum request
  {
      REQ_new_process,
-@@ -5921,6 +6003,11 @@ enum request
+@@ -5921,11 +6003,11 @@ enum request
      REQ_suspend_process,
      REQ_resume_process,
      REQ_get_next_thread,
+-    REQ_create_esync,
+-    REQ_open_esync,
+-    REQ_get_esync_fd,
+-    REQ_esync_msgwait,
+-    REQ_get_esync_apc_fd,
 +    REQ_get_linux_sync_device,
 +    REQ_get_linux_sync_obj,
 +    REQ_fast_select_queue,
@@ -3858,10 +3863,15 @@ index 34655d1..1f8e10a 100644
      REQ_NB_REQUESTS
  };
 
-@@ -6213,6 +6300,11 @@ union generic_request
+@@ -6213,11 +6300,11 @@ union generic_request
      struct suspend_process_request suspend_process_request;
      struct resume_process_request resume_process_request;
      struct get_next_thread_request get_next_thread_request;
+-    struct create_esync_request create_esync_request;
+-    struct open_esync_request open_esync_request;
+-    struct get_esync_fd_request get_esync_fd_request;
+-    struct esync_msgwait_request esync_msgwait_request;
+-    struct get_esync_apc_fd_request get_esync_apc_fd_request;
 +    struct get_linux_sync_device_request get_linux_sync_device_request;
 +    struct get_linux_sync_obj_request get_linux_sync_obj_request;
 +    struct fast_select_queue_request fast_select_queue_request;
@@ -3870,10 +3880,15 @@ index 34655d1..1f8e10a 100644
  };
  union generic_reply
  {
-@@ -6503,6 +6595,11 @@ union generic_reply
+@@ -6503,11 +6595,11 @@ union generic_reply
      struct suspend_process_reply suspend_process_reply;
      struct resume_process_reply resume_process_reply;
      struct get_next_thread_reply get_next_thread_reply;
+-    struct create_esync_reply create_esync_reply;
+-    struct open_esync_reply open_esync_reply;
+-    struct get_esync_fd_reply get_esync_fd_reply;
+-    struct esync_msgwait_reply esync_msgwait_reply;
+-    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_linux_sync_device_reply get_linux_sync_device_reply;
 +    struct get_linux_sync_obj_reply get_linux_sync_obj_reply;
 +    struct fast_select_queue_reply fast_select_queue_reply;

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -3834,10 +3834,15 @@ index 34655d1..1f8e10a 100644
  enum request
  {
      REQ_new_process,
-@@ -5921,6 +6003,11 @@ enum request
+@@ -5921,11 +6003,11 @@ enum request
      REQ_suspend_process,
      REQ_resume_process,
      REQ_get_next_thread,
+-    REQ_create_esync,
+-    REQ_open_esync,
+-    REQ_get_esync_fd,
+-    REQ_esync_msgwait,
+-    REQ_get_esync_apc_fd,
 +    REQ_get_linux_sync_device,
 +    REQ_get_linux_sync_obj,
 +    REQ_fast_select_queue,
@@ -3846,10 +3851,15 @@ index 34655d1..1f8e10a 100644
      REQ_NB_REQUESTS
  };
 
-@@ -6213,6 +6300,11 @@ union generic_request
+@@ -6213,11 +6300,11 @@ union generic_request
      struct suspend_process_request suspend_process_request;
      struct resume_process_request resume_process_request;
      struct get_next_thread_request get_next_thread_request;
+-    struct create_esync_request create_esync_request;
+-    struct open_esync_request open_esync_request;
+-    struct get_esync_fd_request get_esync_fd_request;
+-    struct esync_msgwait_request esync_msgwait_request;
+-    struct get_esync_apc_fd_request get_esync_apc_fd_request;
 +    struct get_linux_sync_device_request get_linux_sync_device_request;
 +    struct get_linux_sync_obj_request get_linux_sync_obj_request;
 +    struct fast_select_queue_request fast_select_queue_request;
@@ -3858,10 +3868,15 @@ index 34655d1..1f8e10a 100644
  };
  union generic_reply
  {
-@@ -6503,6 +6595,11 @@ union generic_reply
+@@ -6503,11 +6595,11 @@ union generic_reply
      struct suspend_process_reply suspend_process_reply;
      struct resume_process_reply resume_process_reply;
      struct get_next_thread_reply get_next_thread_reply;
+-    struct create_esync_reply create_esync_reply;
+-    struct open_esync_reply open_esync_reply;
+-    struct get_esync_fd_reply get_esync_fd_reply;
+-    struct esync_msgwait_reply esync_msgwait_reply;
+-    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_linux_sync_device_reply get_linux_sync_device_reply;
 +    struct get_linux_sync_obj_reply get_linux_sync_obj_reply;
 +    struct fast_select_queue_reply fast_select_queue_reply;

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -3740,7 +3740,136 @@ index a53870f..ba0bdbd 100644
 -
  /* Define to 1 if you have the <sys/event.h> header file. */
  #undef HAVE_SYS_EVENT_H
- 
+
+diff --git a/include/wine/server_protocol.h b/include/wine/server_protocol.h
+index 34655d1..1f8e10a 100644
+--- a/include/server_protocol.h
++++ b/include/server_protocol.h
+@@ -5634,6 +5634,88 @@ struct get_next_thread_reply
+ };
+
+
++enum fast_sync_type
++{
++    FAST_SYNC_SEMAPHORE = 1,
++    FAST_SYNC_MUTEX,
++    FAST_SYNC_AUTO_EVENT,
++    FAST_SYNC_MANUAL_EVENT,
++    FAST_SYNC_AUTO_SERVER,
++    FAST_SYNC_MANUAL_SERVER,
++    FAST_SYNC_QUEUE,
++};
++
++
++
++struct get_linux_sync_device_request
++{
++    struct request_header __header;
++    char __pad_12[4];
++};
++struct get_linux_sync_device_reply
++{
++    struct reply_header __header;
++    obj_handle_t handle;
++    char __pad_12[4];
++};
++
++
++
++struct get_linux_sync_obj_request
++{
++    struct request_header __header;
++    obj_handle_t handle;
++};
++struct get_linux_sync_obj_reply
++{
++    struct reply_header __header;
++    obj_handle_t handle;
++    int          type;
++    unsigned int access;
++    char __pad_20[4];
++};
++
++
++
++struct fast_select_queue_request
++{
++    struct request_header __header;
++    obj_handle_t handle;
++};
++struct fast_select_queue_reply
++{
++    struct reply_header __header;
++};
++
++
++
++struct fast_unselect_queue_request
++{
++    struct request_header __header;
++    obj_handle_t handle;
++    int          signaled;
++    char __pad_20[4];
++};
++struct fast_unselect_queue_reply
++{
++    struct reply_header __header;
++};
++
++
++
++struct get_fast_alert_event_request
++{
++    struct request_header __header;
++    char __pad_12[4];
++};
++struct get_fast_alert_event_reply
++{
++    struct reply_header __header;
++    obj_handle_t handle;
++    char __pad_12[4];
++};
++
++
+ enum request
+ {
+     REQ_new_process,
+@@ -5921,6 +6003,11 @@ enum request
+     REQ_suspend_process,
+     REQ_resume_process,
+     REQ_get_next_thread,
++    REQ_get_linux_sync_device,
++    REQ_get_linux_sync_obj,
++    REQ_fast_select_queue,
++    REQ_fast_unselect_queue,
++    REQ_get_fast_alert_event,
+     REQ_NB_REQUESTS
+ };
+
+@@ -6213,6 +6300,11 @@ union generic_request
+     struct suspend_process_request suspend_process_request;
+     struct resume_process_request resume_process_request;
+     struct get_next_thread_request get_next_thread_request;
++    struct get_linux_sync_device_request get_linux_sync_device_request;
++    struct get_linux_sync_obj_request get_linux_sync_obj_request;
++    struct fast_select_queue_request fast_select_queue_request;
++    struct fast_unselect_queue_request fast_unselect_queue_request;
++    struct get_fast_alert_event_request get_fast_alert_event_request;
+ };
+ union generic_reply
+ {
+@@ -6503,6 +6595,11 @@ union generic_reply
+     struct suspend_process_reply suspend_process_reply;
+     struct resume_process_reply resume_process_reply;
+     struct get_next_thread_reply get_next_thread_reply;
++    struct get_linux_sync_device_reply get_linux_sync_device_reply;
++    struct get_linux_sync_obj_reply get_linux_sync_obj_reply;
++    struct fast_select_queue_reply fast_select_queue_reply;
++    struct fast_unselect_queue_reply fast_unselect_queue_reply;
++    struct get_fast_alert_event_reply get_fast_alert_event_reply;
+ };
+
+ /* ### protocol_version begin ### */
 diff --git a/server/Makefile.in b/server/Makefile.in
 index b164193..b30df66 100644
 --- a/server/Makefile.in

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -7727,13 +7727,13 @@ index 2ce94b4..8f603fc 100644
      thread->system_regs     = 0;
      thread->queue           = NULL;
      thread->wait            = NULL;
-@@ -253,6 +250,8 @@ static inline void init_thread_structure( struct thread *thread )
+@@ -253,6 +250,7 @@ static inline void init_thread_structure( struct thread *thread )
      thread->token           = NULL;
      thread->desc            = NULL;
      thread->desc_len        = 0;
 +    thread->fast_sync       = NULL;
 +    thread->fast_alert_event = NULL;
-     thread->exit_poll       = NULL;
+-    thread->exit_poll       = NULL;
  
      thread->creation_time = current_time;
 @@ -380,12 +379,6 @@ struct thread *create_thread( int fd, struct process *process, const struct secu
@@ -7766,8 +7766,8 @@ index 2ce94b4..8f603fc 100644
  /* cleanup everything that is no longer needed by a dead thread */
  /* used by destroy_thread and kill_thread */
  static void cleanup_thread( struct thread *thread )
-@@ -465,9 +468,8 @@ static void destroy_thread( struct object *obj )
-     if (thread->exit_poll) remove_timeout_user( thread->exit_poll );
+@@ -465,9 +468,7 @@ static void destroy_thread( struct object *obj )
+-    if (thread->exit_poll) remove_timeout_user( thread->exit_poll );
      if (thread->id) free_ptid( thread->id );
      if (thread->token) release_object( thread->token );
 -
@@ -7779,7 +7779,8 @@ index 2ce94b4..8f603fc 100644
  
  /* dump a thread on stdout for debugging purposes */
 @@ -486,13 +488,6 @@ static int thread_signaled( struct object *obj, struct wait_queue_entry *entry )
-     return mythread->state == TERMINATED && !mythread->exit_poll;
+-    return mythread->state == TERMINATED && !mythread->exit_poll;
++    return (mythread->state == TERMINATED);
  }
  
 -static int thread_get_esync_fd( struct object *obj, enum esync_type *type )
@@ -7837,16 +7838,51 @@ index 2ce94b4..8f603fc 100644
      return apc;
  }
  
-@@ -1345,8 +1338,7 @@ void kill_thread( struct thread *thread, int violent_death )
+@@ -1305,26 +1302,6 @@
+     return -1;
+ }
+
+-static void check_terminated( void *arg )
+-{
+-    struct thread *thread = arg;
+-    assert( thread->obj.ops == &thread_ops );
+-    assert( thread->state == TERMINATED );
+-
+-    /* don't wake up until the thread is really dead, to avoid race conditions */
+-    if (thread->unix_tid != -1 && !kill( thread->unix_tid, 0 ))
+-    {
+-        thread->exit_poll = add_timeout_user( -TICKS_PER_SEC / 1000, check_terminated, thread );
+-        return;
+-    }
+-
+-    /* grab reference since object can be destroyed while trying to wake up */
+-    grab_object( &thread->obj );
+-    thread->exit_poll = NULL;
+-    wake_up( &thread->obj, 0 );
+-    release_object( &thread->obj );
+-}
+-
+ /* kill a thread on the spot */
+ void kill_thread( struct thread *thread, int violent_death )
+ {
+@@ -1345,14 +1338,9 @@ void kill_thread( struct thread *thread, int violent_death )
      }
      kill_console_processes( thread, 0 );
      abandon_mutexes( thread );
 -    if (do_esync())
 -        esync_abandon_mutexes( thread );
 +    fast_set_event( thread->fast_sync );
-     if (violent_death)
-     {
-         send_thread_signal( thread, SIGQUIT );
++    wake_up( &thread->obj, 0 );
++    if (violent_death) send_thread_signal( thread, SIGQUIT );
+-    if (violent_death)
+-    {
+-        send_thread_signal( thread, SIGQUIT );
+-        check_terminated( thread );
+-    }
+-    else wake_up( &thread->obj, 0 );
+     cleanup_thread( thread );
+     remove_process_thread( thread->process, thread );
+     release_object( thread );
 @@ -2094,3 +2086,12 @@ DECL_HANDLER(get_next_thread)
      set_error( STATUS_NO_MORE_ENTRIES );
      release_object( process );
@@ -7873,10 +7909,10 @@ index 10e9e28..cb4643a 100644
      unsigned int           system_regs;   /* which system regs have been set */
      struct msg_queue      *queue;         /* message queue */
      struct thread_wait    *wait;          /* current wait condition if sleeping */
-@@ -94,6 +92,8 @@ struct thread
+@@ -94,6 +92,7 @@ struct thread
      data_size_t            desc_len;      /* thread description length in bytes */
      WCHAR                 *desc;          /* thread description string */
-     struct timeout_user   *exit_poll;     /* poll if the thread/process has exited already */
+-    struct timeout_user   *exit_poll;     /* poll if the thread/process has exited already */
 +    struct fast_sync      *fast_sync;     /* fast synchronization object */
 +    struct event          *fast_alert_event; /* fast synchronization alert event */
  };

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -3743,8 +3743,8 @@ index a53870f..ba0bdbd 100644
 
 diff --git a/include/wine/server_protocol.h b/include/wine/server_protocol.h
 index 34655d1..1f8e10a 100644
---- a/include/server_protocol.h
-+++ b/include/server_protocol.h
+--- a/include/wine/server_protocol.h
++++ b/include/wine/server_protocol.h
 @@ -5634,6 +5634,88 @@ struct get_next_thread_reply
  };
 


### PR DESCRIPTION
Change ntsync5 non-staging version because is based on slighly older version
Also fix the staging version by adding the "server_protocol.h" file to the patch files