### PR TITLE
Update customization.cfg and proton-tkg-cfg

### DIFF
--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -78,8 +78,18 @@ _use_GE_patches="true"
 # !! For plain Wine required disabling esync and fsync patches applying !!
 _use_fastsync="false"
 
+# NTsync5 - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/ntsync5
+# !! For building and using requires ntsync module and headers (see the three packages https://aur.archlinux.org/pkgbase/ntsync) !!
+# !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
+# !! Not compatible with Valve trees !!
+_use_ntsync="false"
+
 _use_esync="true"
 _use_fsync="true"
+
+# Set to true to pass --with-wayland --with-vulkan configure arguments
+# !! Requires a compatible wine tree (9.0+ recommended) !!
+_wayland_driver="false"
 
 _plain_version=""
 _use_staging="true"

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -66,7 +66,7 @@ _use_fastsync="false"
 
 # NTsync5 - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/ntsync5
 # !! For building and using requires ntsync module and headers (see the three packages https://aur.archlinux.org/pkgbase/ntsync) !!
-# !! Not compatible with _protonify, _use_staging, nor any of _use_esync, _use_fsync or _use_fastsync options at this time !!
+# !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
 # !! Not compatible with Valve trees !!
 _use_ntsync="false"
 


### PR DESCRIPTION
Remove obsolete information from customization.cfg about the incompatibility of ntsync5 with _use_staging and _protonify. Also add two options: _ntsync5 and _wayland_driver for proton-tkg.cfg