### PR TITLE
ci: bump workflow actions to latest version

### DIFF
--- a/.github/workflows/proton-arch-nopackage.yml
+++ b/.github/workflows/proton-arch-nopackage.yml
@@ -11,7 +11,7 @@ jobs:
     container: archlinux:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compile
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
@@ -30,7 +30,7 @@ jobs:
           touch tarplz
           yes|./proton-tkg.sh
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: proton-tkg-build
           path: proton-tkg/built/*.tar

--- a/.github/workflows/proton-ubuntu-nopackage.yml
+++ b/.github/workflows/proton-ubuntu-nopackage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compile
         run: |
           sudo dpkg --add-architecture i386
@@ -24,7 +24,7 @@ jobs:
           touch tarplz
           yes|./proton-tkg.sh
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: proton-tkg-build
           path: proton-tkg/built/*.tar

--- a/.github/workflows/proton-valvexbe-arch-nopackage.yml
+++ b/.github/workflows/proton-valvexbe-arch-nopackage.yml
@@ -11,7 +11,7 @@ jobs:
     container: archlinux:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compile
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
@@ -29,7 +29,7 @@ jobs:
           touch tarplz
           yes|./proton-tkg.sh
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: proton-tkg-build
           path: proton-tkg/built/*.tar

--- a/.github/workflows/wine-arch-ow2test.yml
+++ b/.github/workflows/wine-arch-ow2test.yml
@@ -9,7 +9,7 @@ jobs:
     container: archlinux:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compile
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
@@ -23,7 +23,7 @@ jobs:
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wine-tkg-build
           path: /tmp/wine-tkg

--- a/.github/workflows/wine-arch.yml
+++ b/.github/workflows/wine-arch.yml
@@ -11,7 +11,7 @@ jobs:
     container: archlinux:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compile
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
@@ -24,7 +24,7 @@ jobs:
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wine-tkg-build
           path: /tmp/wine-tkg

--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -11,7 +11,7 @@ jobs:
     container: fedora:latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compilation
         run: |
           sudo dnf -y -q upgrade --refresh
@@ -21,7 +21,7 @@ jobs:
           touch tarplz
           yes|./non-makepkg-build.sh
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wine-tkg-build
           path: wine-tkg-git/non-makepkg-builds

--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compilation
         run: |
           sudo dpkg --add-architecture i386 && sudo apt update
@@ -24,7 +24,7 @@ jobs:
           touch tarplz
           yes|./non-makepkg-build.sh
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wine-tkg-build
           path: wine-tkg-git/non-makepkg-builds

--- a/.github/workflows/wine-valvexbe-pacman.yml
+++ b/.github/workflows/wine-valvexbe-pacman.yml
@@ -11,7 +11,7 @@ jobs:
     container: archlinux:latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compile
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
@@ -25,7 +25,7 @@ jobs:
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wine-tkg-build
           path: /tmp/wine-tkg

--- a/.github/workflows/wine-valvexbe.yml
+++ b/.github/workflows/wine-valvexbe.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Compilation
         run: |
           sudo dpkg --add-architecture i386 && sudo apt update
@@ -25,7 +25,7 @@ jobs:
           touch tarplz
           yes|./non-makepkg-build.sh
       - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wine-tkg-build
           path: wine-tkg-git/non-makepkg-builds


### PR DESCRIPTION
This PR bumps the workflow actions to the latest version. This is done to ensure that the workflows are using the latest features. Older versions of the actions may not be supported in the future and may cause the workflows to fail.

I have compared the CI outputs on my end, and they are the same, some outputs even have better compression ratios for the artifact tarball. You can also verify it from actions results on my fork: https://github.com/SoulHarsh007/wine-tkg-git/actions/