### PR TITLE
gstreamer.sh: Fix building cause by GCC 14 and FFmpeg

### DIFF
--- a/proton-tkg/proton_template/gstreamer.sh
+++ b/proton-tkg/proton_template/gstreamer.sh
@@ -28,7 +28,7 @@
   git reset --hard HEAD
   git clean -xdf
   git pull origin master
-  #git checkout a77521c
+  git checkout c947731
   cd ..
 
   if [ "$_build_faudio" = "true" ]; then

--- a/proton-tkg/proton_template/gstreamer.sh
+++ b/proton-tkg/proton_template/gstreamer.sh
@@ -47,9 +47,9 @@
 
   rm -rf "$_nowhere"/Proton/build/gst*
 
-  unset CFLAGS
+  export CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types"
   unset CPPFLAGS
-  unset CXXFLAGS
+  export CXXFLAGS="-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types"
   unset LDFLAGS
 
   ##### 64


### PR DESCRIPTION
Fixing a gstreamer build with two commits
1: Adding parameters for CFLAGS and CXXFLAGS for GCC 14
2: Using an older version of FFmpeg caused by removing a needed function: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3378
https://github.com/FFmpeg/FFmpeg/commit/9ee59b63f5ea37700916815538c32dbcadc4a512