### PR TITLE
ntsync5: Fix apply patch when config.h.in is different from upstream

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
@@ -93,6 +93,12 @@
 	  fi
 
       if [ "$_use_staging" = "true" ]; then
+		# Check config.h.in for a difference with the repository
+		if ( grep "Define to 1 if you have the \`prctl' function." "${srcdir}"/"${_winesrcdir}"/include/config.h.in >> /dev/null ); then
+		  _patchname='ntsync-config.h.in-org.patch' && _patchmsg="Using original config.h.in patchset for ntsync5" && nonuser_patcher
+		else
+		  _patchname='ntsync-config.h.in-alt.patch' && _patchmsg="Using alternative config.h.in patchset for ntsync5" && nonuser_patcher
+		fi
         if [ "$_protonify" = "true" ]; then
 		  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 7eb72b7bb3d3ea771efddcb5273e8a69456548ff HEAD ); then
 	      _patchname='ntsync5-staging-protonify.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-7eb72b7b.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-7eb72b7b.patch
@@ -3711,26 +3711,6 @@ index a53870f..ba0bdbd 100644
  /* Define to 1 if you have the <linux/param.h> header file. */
  #undef HAVE_LINUX_PARAM_H
  
-@@ -315,9 +318,6 @@
- /* Define to 1 if you have the `posix_fallocate' function. */
- #undef HAVE_POSIX_FALLOCATE
- 
--/* Define to 1 if you have the `ppoll' function. */
--#undef HAVE_PPOLL
--
- /* Define to 1 if you have the `prctl' function. */
- #undef HAVE_PRCTL
- 
-@@ -384,9 +384,6 @@
- /* Define to 1 if `interface_id' is a member of `sg_io_hdr_t'. */
- #undef HAVE_SG_IO_HDR_T_INTERFACE_ID
- 
--/* Define to 1 if you have the `shm_open' function. */
--#undef HAVE_SHM_OPEN
--
- /* Define to 1 if `si_fd' is a member of `siginfo_t'. */
- #undef HAVE_SIGINFO_T_SI_FD
- 
 @@ -522,9 +519,6 @@
  /* Define to 1 if you have the <sys/epoll.h> header file. */
  #undef HAVE_SYS_EPOLL_H

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-protonify-7eb72b7b.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-protonify-7eb72b7b.patch
@@ -3723,26 +3723,6 @@ index a53870f..ba0bdbd 100644
  /* Define to 1 if you have the <linux/param.h> header file. */
  #undef HAVE_LINUX_PARAM_H
  
-@@ -315,9 +318,6 @@
- /* Define to 1 if you have the `posix_fallocate' function. */
- #undef HAVE_POSIX_FALLOCATE
- 
--/* Define to 1 if you have the `ppoll' function. */
--#undef HAVE_PPOLL
--
- /* Define to 1 if you have the `prctl' function. */
- #undef HAVE_PRCTL
- 
-@@ -384,9 +384,6 @@
- /* Define to 1 if `interface_id' is a member of `sg_io_hdr_t'. */
- #undef HAVE_SG_IO_HDR_T_INTERFACE_ID
- 
--/* Define to 1 if you have the `shm_open' function. */
--#undef HAVE_SHM_OPEN
--
- /* Define to 1 if `si_fd' is a member of `siginfo_t'. */
- #undef HAVE_SIGINFO_T_SI_FD
- 
 @@ -522,9 +519,6 @@
  /* Define to 1 if you have the <sys/epoll.h> header file. */
  #undef HAVE_SYS_EPOLL_H

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync-config.h.in-alt.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync-config.h.in-alt.patch
@@ -1,0 +1,24 @@
+diff --git a/include/config.h.in b/include/config.h.in
+index a53870f..ba0bdbd 100644
+--- a/include/config.h.in
++++ b/include/config.h.in
+@@ -315,9 +318,6 @@
+ /* Define to 1 if you have the 'posix_fallocate' function. */
+ #undef HAVE_POSIX_FALLOCATE
+ 
+-/* Define to 1 if you have the 'ppoll' function. */
+-#undef HAVE_PPOLL
+-
+ /* Define to 1 if you have the 'prctl' function. */
+ #undef HAVE_PRCTL
+ 
+@@ -384,9 +384,6 @@
+ /* Define to 1 if 'interface_id' is a member of 'sg_io_hdr_t'. */
+ #undef HAVE_SG_IO_HDR_T_INTERFACE_ID
+ 
+-/* Define to 1 if you have the `shm_open' function. */
+-#undef HAVE_SHM_OPEN
+-
+ /* Define to 1 if 'si_fd' is a member of 'siginfo_t'. */
+ #undef HAVE_SIGINFO_T_SI_FD
+ 

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync-config.h.in-org.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync-config.h.in-org.patch
@@ -1,0 +1,24 @@
+diff --git a/include/config.h.in b/include/config.h.in
+index a53870f..ba0bdbd 100644
+--- a/include/config.h.in
++++ b/include/config.h.in
+@@ -315,9 +318,6 @@
+ /* Define to 1 if you have the `posix_fallocate' function. */
+ #undef HAVE_POSIX_FALLOCATE
+ 
+-/* Define to 1 if you have the `ppoll' function. */
+-#undef HAVE_PPOLL
+-
+ /* Define to 1 if you have the `prctl' function. */
+ #undef HAVE_PRCTL
+ 
+@@ -384,9 +384,6 @@
+ /* Define to 1 if `interface_id' is a member of `sg_io_hdr_t'. */
+ #undef HAVE_SG_IO_HDR_T_INTERFACE_ID
+ 
+-/* Define to 1 if you have the `shm_open' function. */
+-#undef HAVE_SHM_OPEN
+-
+ /* Define to 1 if `si_fd' is a member of `siginfo_t'. */
+ #undef HAVE_SIGINFO_T_SI_FD
+ 

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
@@ -3723,26 +3723,6 @@ index a53870f..ba0bdbd 100644
  /* Define to 1 if you have the <linux/param.h> header file. */
  #undef HAVE_LINUX_PARAM_H
  
-@@ -315,9 +318,6 @@
- /* Define to 1 if you have the `posix_fallocate' function. */
- #undef HAVE_POSIX_FALLOCATE
- 
--/* Define to 1 if you have the `ppoll' function. */
--#undef HAVE_PPOLL
--
- /* Define to 1 if you have the `prctl' function. */
- #undef HAVE_PRCTL
- 
-@@ -384,9 +384,6 @@
- /* Define to 1 if `interface_id' is a member of `sg_io_hdr_t'. */
- #undef HAVE_SG_IO_HDR_T_INTERFACE_ID
- 
--/* Define to 1 if you have the `shm_open' function. */
--#undef HAVE_SHM_OPEN
--
- /* Define to 1 if 'si_fd' is a member of `siginfo_t'. */
- #undef HAVE_SIGINFO_T_SI_FD
- 
 @@ -522,9 +519,6 @@
  /* Define to 1 if you have the <sys/epoll.h> header file. */
  #undef HAVE_SYS_EPOLL_H

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -3711,26 +3711,6 @@ index a53870f..ba0bdbd 100644
  /* Define to 1 if you have the <linux/param.h> header file. */
  #undef HAVE_LINUX_PARAM_H
  
-@@ -315,9 +318,6 @@
- /* Define to 1 if you have the `posix_fallocate' function. */
- #undef HAVE_POSIX_FALLOCATE
- 
--/* Define to 1 if you have the `ppoll' function. */
--#undef HAVE_PPOLL
--
- /* Define to 1 if you have the `prctl' function. */
- #undef HAVE_PRCTL
- 
-@@ -384,9 +384,6 @@
- /* Define to 1 if `interface_id' is a member of `sg_io_hdr_t'. */
- #undef HAVE_SG_IO_HDR_T_INTERFACE_ID
- 
--/* Define to 1 if you have the `shm_open' function. */
--#undef HAVE_SHM_OPEN
--
- /* Define to 1 if `si_fd' is a member of `siginfo_t'. */
- #undef HAVE_SIGINFO_T_SI_FD
- 
 @@ -522,9 +519,6 @@
  /* Define to 1 if you have the <sys/epoll.h> header file. */
  #undef HAVE_SYS_EPOLL_H


### PR DESCRIPTION
For some reason autoconf is modifying several files, including config.h.in, which causes an error when applying the ntsync5 patch. I added two new patches, ntsync-config.h.in-alt and ntsync-config.h.in-org, which apply the changes depending on the line in config.h.in