### PR TITLE
hotfix: Revert win32u changes when _wayland_driver set to true

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/01-non-patch-hotfixes/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/01-non-patch-hotfixes/hotfixes
@@ -141,3 +141,9 @@ if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor bd27af974a2
   _hotfix_mainlinereverts+=(b54199101fd307199c481709d4b1358ba4bcce58 dedda40e5d7b5a3bcf67eea95145810da283d7d9 bd27af974a21085cd0dc78b37b715bbcc3cfab69)
   #_hotfixes+=("$_where"/wine-tkg-patches/hotfixes/bd27af9/bd27af9)
 fi
+
+# Wine freeze when run with wine wayland driver - Reverting win32u changes fixes it
+if [ "$_wayland_driver" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fe7e94d58c2596c23b407c5a0cd11b57f001d4dd HEAD ); then
+  warning "Hotfix: Revert win32u changes to fix wine freeze when run with wayland driver"
+  _hotfix_mainlinereverts+=( 6eac284201b4f8b2ecf78ad5623bf0fcebcd57bb c7287cc73499a53077a510bcdae9885547c8d031 eca7068ab3f74a0b3ef4d2599c0239932fc952bf 71ff81bc2b14dc90110e97ac71e5eee042644fed 2a2637743b82031d0039698e116a0d1daf18dc1d 5b3bf77b1689b2b02f777309f57480949ee570b8 10e4a6819c0e3905f4179f6ffe2003f1a62bc97e fe7e94d58c2596c23b407c5a0cd11b57f001d4dd )
+fi

--- a/wine-tkg-git/wine-tkg-patches/misc/childwindow/childwindow-proton
+++ b/wine-tkg-git/wine-tkg-patches/misc/childwindow/childwindow-proton
@@ -2,7 +2,7 @@
 
 	# Standalone child window support for vk - Fixes World of Final Fantasy and others - https://bugs.winehq.org/show_bug.cgi?id=45277 - legacy patchset for older trees applied at an earlier stage in the script
 	if ( [ "$_childwindow_fix" = "true" ] && [ "$_proton_fs_hack" != "true" ] && [ "$_use_staging" = "true" ] ); then
-	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD; then
+	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD && [ "$_wayland_driver" = "false" ]; then
 	    _patchname='childwindow-proton.patch' && _patchmsg="Applied child window for vk patch" && nonuser_patcher
 	  elif git merge-base --is-ancestor 8ba51a6f711c5466e060a5958cc15c31b2b2ac7d HEAD; then
 	    _patchname='childwindow-proton-2a263774.patch' && _patchmsg="Applied child window for vk patch" && nonuser_patcher
@@ -48,7 +48,7 @@
 	fi
 
 	if ( [ "$_childwindow_fix" = "true" ] && [ "$_proton_fs_hack" != "true" ] && [ "$_use_staging" != "true" ] ); then
-	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD; then
+	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD && [ "$_wayland_driver" = "false" ]; then
             _patchname='childwindow-proton-mainline.patch' && _patchmsg="Applied child window for vk patch (mainline)" && nonuser_patcher
 	  elif git merge-base --is-ancestor 8ba51a6f711c5466e060a5958cc15c31b2b2ac7d HEAD; then
             _patchname='childwindow-proton-mainline-2a263774.patch' && _patchmsg="Applied child window for vk patch (mainline)" && nonuser_patcher


### PR DESCRIPTION
This PR: https://gitlab.winehq.org/wine/wine/-/merge_requests/5833 was merged caused a regression of winewayland.drv causing a complete freeze when started with DISPLAY= . Also update childwindow-proton script to apply legacy patch when _wayland_driver is set to true