### PR TITLE
hotfixes: Add new hotfix patch to fix winewayland.drv regression

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/01-non-patch-hotfixes/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/01-non-patch-hotfixes/hotfixes
@@ -141,9 +141,3 @@ if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor bd27af974a2
   _hotfix_mainlinereverts+=(b54199101fd307199c481709d4b1358ba4bcce58 dedda40e5d7b5a3bcf67eea95145810da283d7d9 bd27af974a21085cd0dc78b37b715bbcc3cfab69)
   #_hotfixes+=("$_where"/wine-tkg-patches/hotfixes/bd27af9/bd27af9)
 fi
-
-# Wine freeze when run with wine wayland driver - Reverting win32u changes fixes it
-if [ "$_wayland_driver" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fe7e94d58c2596c23b407c5a0cd11b57f001d4dd HEAD ); then
-  warning "Hotfix: Revert win32u changes to fix wine freeze when run with wayland driver"
-  _hotfix_mainlinereverts+=( 6eac284201b4f8b2ecf78ad5623bf0fcebcd57bb c7287cc73499a53077a510bcdae9885547c8d031 eca7068ab3f74a0b3ef4d2599c0239932fc952bf 71ff81bc2b14dc90110e97ac71e5eee042644fed 2a2637743b82031d0039698e116a0d1daf18dc1d 5b3bf77b1689b2b02f777309f57480949ee570b8 10e4a6819c0e3905f4179f6ffe2003f1a62bc97e fe7e94d58c2596c23b407c5a0cd11b57f001d4dd )
-fi

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -43,7 +43,6 @@ if [ "$_unfrog" != "true" ]; then
   _hotfix="ow2" _hotfix_boundary="" _hotfix_import
   _hotfix="autoconf-opencl-hotfix" _hotfix_boundary="" _hotfix_import
   _hotfix="NosTale" _hotfix_boundary="" _hotfix_import
-  _hotfix="winewayland" _hotfix_boundary="" _hotfix_import
 
   # Custom hotfix patches with a commit boundary
   _hotfix="fd799297" _hotfix_boundary="1f6423f778f7036a3875613e10b9c8c3b84584f0" _hotfix_import
@@ -66,6 +65,7 @@ if [ "$_unfrog" != "true" ]; then
   _hotfix="1e35966" _hotfix_boundary="7b51216198237c04a8994cda1bdb45fdb4482b32" _hotfix_import
   _hotfix="staging_aeddc19_SOURCES" _hotfix_boundary="137638e185e9302602bcd9cc796d7bcfa03caee5" _hotfix_import
   _hotfix="rdr2" _hotfix_boundary="ce2ae79f9d9c64bbac54701e6538cd9dca1b8ae7" _hotfix_import
+  _hotfix="winewayland" _hotfix_boundary="1e701a6b3798ecfd688ad1ff405dbb62b3d214c6" _hotfix_import
 else
   _hotfix="valve" _hotfix_boundary="" _hotfix_import
   _hotfix="GE" _hotfix_boundary="" _hotfix_import

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -43,6 +43,7 @@ if [ "$_unfrog" != "true" ]; then
   _hotfix="ow2" _hotfix_boundary="" _hotfix_import
   _hotfix="autoconf-opencl-hotfix" _hotfix_boundary="" _hotfix_import
   _hotfix="NosTale" _hotfix_boundary="" _hotfix_import
+  _hotfix="winewayland" _hotfix_boundary="" _hotfix_import
 
   # Custom hotfix patches with a commit boundary
   _hotfix="fd799297" _hotfix_boundary="1f6423f778f7036a3875613e10b9c8c3b84584f0" _hotfix_import

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/hotfixes
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Fix wine freeze when run with wine wayland driver
+if [ "$_wayland_driver" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fe7e94d58c2596c23b407c5a0cd11b57f001d4dd HEAD ); then
+  _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/winewayland/winewayland-avoid-crashing)
+  warning "Hotfix: Fix wayland driver crash"
+fi

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/winewayland-avoid-crashing.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/winewayland-avoid-crashing.mypatch
@@ -1,0 +1,31 @@
+From c1c5307199f0edc7fb0fe405aa2c59ee3866a0e8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Sat, 15 Jun 2024 18:36:50 +0200
+Subject: [PATCH] winewayland: Avoid crashing when the dummy window surface is
+ chosen.
+
+---
+ dlls/winewayland.drv/window_surface.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winewayland.drv/window_surface.c b/dlls/winewayland.drv/window_surface.c
+index fb3b8750001..888fa74c085 100644
+--- a/dlls/winewayland.drv/window_surface.c
++++ b/dlls/winewayland.drv/window_surface.c
+@@ -489,8 +489,12 @@
+ void wayland_window_surface_update_wayland_surface(struct window_surface *window_surface,
+                                                    struct wayland_surface *wayland_surface)
+ {
+-    struct wayland_window_surface *wws = wayland_window_surface_cast(window_surface);
++    struct wayland_window_surface *wws;
++
++    /* ignore calls with the dummy surface */
++    if (window_surface->funcs != &wayland_window_surface_funcs) return;
+ 
++    wws = wayland_window_surface_cast(window_surface);
+     window_surface_lock(window_surface);
+ 
+     TRACE("surface=%p hwnd=%p wayland_surface=%p\n", wws, window_surface->hwnd, wayland_surface);
+-- 
+GitLab
+

--- a/wine-tkg-git/wine-tkg-patches/misc/childwindow/childwindow-proton
+++ b/wine-tkg-git/wine-tkg-patches/misc/childwindow/childwindow-proton
@@ -2,7 +2,7 @@
 
 	# Standalone child window support for vk - Fixes World of Final Fantasy and others - https://bugs.winehq.org/show_bug.cgi?id=45277 - legacy patchset for older trees applied at an earlier stage in the script
 	if ( [ "$_childwindow_fix" = "true" ] && [ "$_proton_fs_hack" != "true" ] && [ "$_use_staging" = "true" ] ); then
-	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD && [ "$_wayland_driver" = "false" ]; then
+	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD; then
 	    _patchname='childwindow-proton.patch' && _patchmsg="Applied child window for vk patch" && nonuser_patcher
 	  elif git merge-base --is-ancestor 8ba51a6f711c5466e060a5958cc15c31b2b2ac7d HEAD; then
 	    _patchname='childwindow-proton-2a263774.patch' && _patchmsg="Applied child window for vk patch" && nonuser_patcher
@@ -48,7 +48,7 @@
 	fi
 
 	if ( [ "$_childwindow_fix" = "true" ] && [ "$_proton_fs_hack" != "true" ] && [ "$_use_staging" != "true" ] ); then
-	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD && [ "$_wayland_driver" = "false" ]; then
+	  if git merge-base --is-ancestor 2a2637743b82031d0039698e116a0d1daf18dc1d HEAD; then
             _patchname='childwindow-proton-mainline.patch' && _patchmsg="Applied child window for vk patch (mainline)" && nonuser_patcher
 	  elif git merge-base --is-ancestor 8ba51a6f711c5466e060a5958cc15c31b2b2ac7d HEAD; then
             _patchname='childwindow-proton-mainline-2a263774.patch' && _patchmsg="Applied child window for vk patch (mainline)" && nonuser_patcher


### PR DESCRIPTION
This patch should fix a problem with winewayland caused by changes in win32u

Also reverse old commit: https://github.com/Frogging-Family/wine-tkg-git/commit/014d66774d5884491b6328075e6cff0d3aa05d3d as it is no longer needed