### PR TITLE
Remove unnecessary dependency (jxrlib)

### DIFF
--- a/proton-tkg/PKGBUILD
+++ b/proton-tkg/PKGBUILD
@@ -32,7 +32,7 @@ depends=(
     'libpcap'               'lib32-libpcap'
     'desktop-file-utils'    'tk'
     'vulkan-icd-loader'     'lib32-vulkan-icd-loader'
-    'jxrlib'                'gst-plugins-ugly'
+    'gst-plugins-ugly'
 )
 makedepends=(
     'git'                   'autoconf'

--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -78,7 +78,7 @@ depends=(
     'gettext'     'freetype2'
     'glu'         'libsm'
     'gcc-libs'    'libpcap'
-    'jxrlib'      'desktop-file-utils'
+    'desktop-file-utils'
     $_user_deps
 )
 


### PR DESCRIPTION
Wine uses builtin jxrlib for a while now: https://gitlab.winehq.org/wine/wine/-/commit/cfc8f154e5a7a3231db5045d5eac129da1cb638e