### PR TITLE
childwindow-proton: Skip patch

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/childwindow/childwindow-proton
+++ b/wine-tkg-git/wine-tkg-patches/misc/childwindow/childwindow-proton
@@ -2,7 +2,9 @@
 
 	# Standalone child window support for vk - Fixes World of Final Fantasy and others - https://bugs.winehq.org/show_bug.cgi?id=45277 - legacy patchset for older trees applied at an earlier stage in the script
 	if ( [ "$_childwindow_fix" = "true" ] && [ "$_proton_fs_hack" != "true" ] && [ "$_use_staging" = "true" ] ); then
-	  if git merge-base --is-ancestor cb1c03b926ca01619be02f835f382c1dd7d4a478 HEAD; then
+	  if git merge-base --is-ancestor 21a0c158b94bfc65d4baa95095307a1db396db0c HEAD; then
+	    warning "Child window support have been merged in upstream"
+	  elif git merge-base --is-ancestor cb1c03b926ca01619be02f835f382c1dd7d4a478 HEAD; then
 	    _patchname='childwindow-proton.patch' && _patchmsg="Applied child window for vk patch" && nonuser_patcher
 	  elif git merge-base --is-ancestor c2d46eaa1ef07a2921e5711212e9c5c354f58112 HEAD; then
 	    _patchname='childwindow-proton-cb1c03b9.patch' && _patchmsg="Applied child window for vk patch" && nonuser_patcher
@@ -54,7 +56,9 @@
 	fi
 
 	if ( [ "$_childwindow_fix" = "true" ] && [ "$_proton_fs_hack" != "true" ] && [ "$_use_staging" != "true" ] ); then
-	  if git merge-base --is-ancestor cb1c03b926ca01619be02f835f382c1dd7d4a478 HEAD; then
+	  if git merge-base --is-ancestor 21a0c158b94bfc65d4baa95095307a1db396db0c HEAD; then
+	    warning "Child window support have been merged in upstream"
+	  elif git merge-base --is-ancestor cb1c03b926ca01619be02f835f382c1dd7d4a478 HEAD; then
             _patchname='childwindow-proton-mainline.patch' && _patchmsg="Applied child window for vk patch (mainline)" && nonuser_patcher
 	  elif git merge-base --is-ancestor c2d46eaa1ef07a2921e5711212e9c5c354f58112 HEAD; then
             _patchname='childwindow-proton-mainline-cb1c03b9.patch' && _patchmsg="Applied child window for vk patch (mainline)" && nonuser_patcher


### PR DESCRIPTION
Child window support has been merged into upstream so the patch is no longer needed: https://gitlab.winehq.org/wine/wine/-/merge_requests/6467