### PR TITLE
battlenet-fix: Don`t apply patch on staging commit

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -129,9 +129,6 @@ _kof98_2002_BGM_fix="false"
 # This patchset breaks Genshin Impact
 _quake_champions_fix="false"
 
-# Fix for Battle.Net Launcher - https://bugs.winehq.org/show_bug.cgi?id=29384
-_battlenet_fix="true"
-
 #### OTHER PATCHES ####
 
 # launch with dedicated gpu desktop entry patch - makes an additional desktop entry which launches app with DRI_PRIME set to 1 (only for switchable graphics with mesa drivers)

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/battlenet/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/battlenet/hotfixes
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fix for battle.net launcher
-if [ "$_battlenet_fix" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 65124f15acc5705eb159d5d920877f0ac4835d27 HEAD ); then
+if [ "$_battlenet_fix" = "true" ] && [ "$_use_staging" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor c901884ac0af17eeeac309269693d959cfb45e0b HEAD && ! git merge-base --is-ancestor e68e4dbb7529295dc4fde320689f80b1215a0419 HEAD); then
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/battlenet/battlenet)
   warning "Hotfix: Fix for Battle.Net launcher"
 fi

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/battlenet/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/battlenet/hotfixes
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fix for battle.net launcher
-if [ "$_battlenet_fix" = "true" ] && [ "$_use_staging" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor c901884ac0af17eeeac309269693d959cfb45e0b HEAD && ! git merge-base --is-ancestor e68e4dbb7529295dc4fde320689f80b1215a0419 HEAD); then
+if [ "$_use_staging" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor c901884ac0af17eeeac309269693d959cfb45e0b HEAD && ! git merge-base --is-ancestor e68e4dbb7529295dc4fde320689f80b1215a0419 HEAD); then
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/battlenet/battlenet)
   warning "Hotfix: Fix for Battle.Net launcher"
 fi


### PR DESCRIPTION
In wine-staging, patches to make Battle.net work have been returned: https://gitlab.winehq.org/wine/wine-staging/-/commit/e68e4dbb7529295dc4fde320689f80b1215a0419
The battle-fix patch will not be applied if we are on this commit

I've also redesigned the script to accept the patch only if staging patches are enabled and removed the _battle_fix variable, I think it's better to just apply the patch automatically, considering that it was only removed for two weeks

