### PR TITLE
CI: Remove outdated steps from workflows

### DIFF
--- a/.github/workflows/proton-arch-nopackage.yml
+++ b/.github/workflows/proton-arch-nopackage.yml
@@ -21,7 +21,6 @@ jobs:
           chown user -R /tmp
           export CARGO_HOME="$PWD"
           cd proton-tkg
-          sed -i 's/distro=""/distro="archlinux"/' proton-tkg.cfg
           sed -i 's/uninstaller="false"/uninstaller="true"/' proton-tkg.cfg
           sed -i 's/autoinstall="false"/autoinstall="true"/' proton-tkg.cfg
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="none"/' proton-tkg.cfg

--- a/.github/workflows/proton-ubuntu-nopackage.yml
+++ b/.github/workflows/proton-ubuntu-nopackage.yml
@@ -16,7 +16,6 @@ jobs:
           export CARGO_HOME="$PWD"
           rustup target add i686-unknown-linux-gnu
           cd proton-tkg
-          sed -i 's/distro=""/distro="debuntu"/' proton-tkg.cfg
           sed -i 's/uninstaller="false"/uninstaller="true"/' proton-tkg.cfg
           sed -i 's/autoinstall="false"/autoinstall="true"/' proton-tkg.cfg
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="none"/' proton-tkg.cfg

--- a/.github/workflows/proton-valvexbe-arch-nopackage.yml
+++ b/.github/workflows/proton-valvexbe-arch-nopackage.yml
@@ -21,7 +21,6 @@ jobs:
           chown user -R /tmp
           export CARGO_HOME="$PWD"
           cd proton-tkg
-          sed -i 's/distro=""/distro="archlinux"/' proton-tkg.cfg
           sed -i 's/uninstaller="false"/uninstaller="true"/' proton-tkg.cfg
           sed -i 's/autoinstall="false"/autoinstall="true"/' proton-tkg.cfg
           sed -i 's/build_gstreamer="false"/build_gstreamer="true"/' proton-tkg.cfg

--- a/.github/workflows/wine-arch-ow2test.yml
+++ b/.github/workflows/wine-arch-ow2test.yml
@@ -16,9 +16,6 @@ jobs:
           pacman -Syu --noconfirm base-devel sudo
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R . && cd wine-tkg-git
-          # Workaround for jack&jack2 conflict https://github.com/Frogging-Family/wine-tkg-git/issues/237
-          sed -i "/'jack2'                 'lib32-jack2'/d" PKGBUILD
-          sed -i "/'gst-plugins-good'      'lib32-gst-plugins-good'/d" PKGBUILD
           echo '_OW2_fix="true"' >> customization.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 

--- a/.github/workflows/wine-arch.yml
+++ b/.github/workflows/wine-arch.yml
@@ -18,9 +18,6 @@ jobs:
           pacman -Syu --noconfirm base-devel sudo
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R . && cd wine-tkg-git
-          # Workaround for jack&jack2 conflict https://github.com/Frogging-Family/wine-tkg-git/issues/237
-          sed -i "/'jack2'                 'lib32-jack2'/d" PKGBUILD
-          sed -i "/'gst-plugins-good'      'lib32-gst-plugins-good'/d" PKGBUILD 
           sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 

--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -16,7 +16,6 @@ jobs:
         run: |
           sudo dnf -y -q upgrade --refresh
           cd wine-tkg-git 
-          sed -i 's/distro=""/distro="fedora"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz

--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -18,7 +18,6 @@ jobs:
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
           cd wine-tkg-git 
-          sed -i 's/distro=""/distro="debuntu"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz

--- a/.github/workflows/wine-valvexbe-pacman.yml
+++ b/.github/workflows/wine-valvexbe-pacman.yml
@@ -18,9 +18,6 @@ jobs:
           pacman -Syu --noconfirm base-devel sudo
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R . && cd wine-tkg-git
-          # Workaround for jack&jack2 conflict https://github.com/Frogging-Family/wine-tkg-git/issues/237
-          sed -i "/'jack2'                 'lib32-jack2'/d" PKGBUILD
-          sed -i "/'gst-plugins-good'      'lib32-gst-plugins-good'/d" PKGBUILD
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="valve-exp-bleeding"/' customization.cfg
           sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"

--- a/.github/workflows/wine-valvexbe.yml
+++ b/.github/workflows/wine-valvexbe.yml
@@ -18,7 +18,6 @@ jobs:
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
           cd wine-tkg-git
-          sed -i 's/distro=""/distro="debuntu"/' customization.cfg
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="valve-exp-bleeding"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg


### PR DESCRIPTION
As part of implementing better dependency autoresolution, a9d0a33afe ("[IMPROVE] Better deps resolver (#1138)") and ff45a43dd5 ("proton: Enable dependency autoresolver") removed the _nomakepkg_dep_resolution_distro option from customization.cfg and proton-tkg.cfg. However, CI workflows for non-makepkg builds of Wine and Proton still expect to set this option.

In addition, the workflow for Arch makepkg builds of Wine contains a workaround for Frogging-Family/wine-tkg-git#237 that was obviated in part by 37ce946749 ("fix pipewire-jack not providing jack2 anymore on arch linux anymore (#675)") and in part by 4971465b39 ("makepkg: Only grab lib32 deps when _NOLIB32 is set to "false").

Update the currently maintained CI workflows to remove these outdated steps. This shouldn't affect anything, as the steps being removed were already doing nothing.