### PR TITLE
Add -ntsync in Wine build pkgname

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -434,15 +434,17 @@ _pkgnaming() {
       msg2 "Using staging patchset"
     fi
 
-    if [ "$_use_esync" = "true" ]; then
-      if [ "$_use_fsync" = "true" ]; then
-        pkgname+="-fsync"
-        msg2 "Using fsync patchset"
-      else
-        pkgname+="-esync"
-        msg2 "Using esync patchset"
-      fi
+    if [ "$_use_ntsync" = "true" ] && [ "$_use_fsync" != "true" ]; then
+      pkgname+="-ntsync"
+      msg2 "Using ntsync patchset"
+    elif [ "$_use_fsync" = "true" ] && [ "$_use_esync" = "true" ]; then
+      pkgname+="-fsync"
+      msg2 "Using fsync patchset"
+    elif [ "$_use_esync" = "true" ]; then
+      pkgname+="-esync"
+      msg2 "Using esync patchset"
     fi
+
     if [ "$_use_legacy_gallium_nine" = "true" ]; then
       pkgname+="-nine"
       msg2 "Using gallium nine patchset (legacy)"


### PR DESCRIPTION
Also rework the logic for adding -esync and -fsync to make various conditions for adding these three pkgname components clearer. For example, ntsync can (theoretically) coexist with esync; in that case we would add just -ntsync, not -esync-ntsync (cf. esync and fsync coexistence).