### PR TITLE
Clarify build requirements for NTSync5 in .cfg files

### DIFF
--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -79,7 +79,9 @@ _use_GE_patches="true"
 _use_fastsync="false"
 
 # NTsync5 - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/ntsync5
-# !! For building and using requires ntsync module and headers (see the three packages https://aur.archlinux.org/pkgbase/ntsync) !!
+# !! For building, requires full ntsync kernel UAPI header (if applicable, replace broken ntsync.h from mainline >= 6.10) !!
+# !! For using, requires ntsync kernel module (from special linux-tkg build, or separately built against kernel >= 6.8 from NTsync5 patchset) !!
+# !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!
 # !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
 # !! Not compatible with Valve trees !!
 _use_ntsync="false"

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -65,7 +65,9 @@ _staging_version=""
 _use_fastsync="false"
 
 # NTsync5 - https://repo.or.cz/wine/zf.git/shortlog/refs/heads/ntsync5
-# !! For building and using requires ntsync module and headers (see the three packages https://aur.archlinux.org/pkgbase/ntsync) !!
+# !! For building, requires full ntsync kernel UAPI header (if applicable, replace broken ntsync.h from mainline >= 6.10) !!
+# !! For using, requires ntsync kernel module (from special linux-tkg build, or separately built against kernel >= 6.8 from NTsync5 patchset) !!
+# !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!
 # !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
 # !! Not compatible with Valve trees !!
 _use_ntsync="false"


### PR DESCRIPTION
ntsync is part of the kernel UAPI, so the presence of the ntsync module on the build host is not required to build Wine with ntsync support. A complete ntsync header file at /usr/include/linux/ntsync.h (replacing, if applicable, the incomplete stub mainlined in kernel 6.10) is sufficient.

Note also that the proposed ntsync patchset targets kernels >= 6.8, but builds still work if the build host is running an earlier kernel. This is most immediately relevant for CI, as the ubuntu-latest GitHub Actions runner has kernel 6.5.