### PR TITLE
hotfixes: Add new shm_esync_fsync hotfix to workaround high CPU usage

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -45,6 +45,7 @@ if [ "$_unfrog" != "true" ]; then
   _hotfix="NosTale" _hotfix_boundary="" _hotfix_import
   _hotfix="battlenet" _hotfix_boundary="" _hotfix_import
   _hotfix="legacy_ntdll_writecopy" _hotfix_boundary="" _hotfix_import
+  _hotfix="shm_esync_fsync" _hotfix_boundary="" _hotfix_import
 
   # Custom hotfix patches with a commit boundary
   _hotfix="fd799297" _hotfix_boundary="1f6423f778f7036a3875613e10b9c8c3b84584f0" _hotfix_import

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/shm_esync_fsync/HACK-user32-Always-call-get_message-request-after-waiting.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/shm_esync_fsync/HACK-user32-Always-call-get_message-request-after-waiting.mypatch
@@ -1,0 +1,101 @@
+From 9ceae59cebd111f0fb06d63ad1495ea1becd714b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Tue, 5 Dec 2023 15:03:25 +0100
+Subject: [PATCH] HACK: user32: Always call get_message request after
+ waiting.
+
+Because with esync and fsync the wait happens on the client-side, so
+we need to make the request to do the server side effects.
+---
+ dlls/win32u/input.c          |  2 +-
+ dlls/win32u/message.c        | 12 ++++++------
+ dlls/win32u/ntuser_private.h |  2 +-
+ 3 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/dlls/win32u/input.c b/dlls/win32u/input.c
+index 11111111111..11111111111 100644
+--- a/dlls/win32u/input.c
++++ b/dlls/win32u/input.c
+@@ -804,7 +804,7 @@ static void check_for_events( UINT flags )
+     if (!user_driver->pProcessEvents( flags ))
+         flush_window_surfaces( TRUE );
+ 
+-    peek_message( &msg, &filter );
++    peek_message( &msg, &filter, FALSE );
+ }
+ 
+ /**********************************************************************
+diff --git a/dlls/win32u/message.c b/dlls/win32u/message.c
+index 11111111111..11111111111 100644
+--- a/dlls/win32u/message.c
++++ b/dlls/win32u/message.c
+@@ -2694,7 +2694,7 @@ static BOOL check_queue_bits( UINT wake_mask, UINT changed_mask, UINT signal_bit
+  * available; -1 on error.
+  * All pending sent messages are processed before returning.
+  */
+-int peek_message( MSG *msg, const struct peek_message_filter *filter )
++int peek_message( MSG *msg, const struct peek_message_filter *filter, BOOL waited )
+ {
+     LRESULT result;
+     HWND hwnd = filter->hwnd;
+@@ -2734,7 +2734,7 @@ int peek_message( MSG *msg, const struct peek_message_filter *filter )
+         thread_info->client_info.msg_source = prev_source;
+         wake_mask = filter->mask & (QS_SENDMESSAGE | QS_SMRESULT);
+ 
+-        if (NtGetTickCount() - thread_info->last_getmsg_time < 3000 && /* avoid hung queue */
++        if ((!waited && (NtGetTickCount() - thread_info->last_getmsg_time < 3000)) && /* avoid hung queue */
+             check_queue_bits( wake_mask, filter->mask, wake_mask | signal_bits, filter->mask | clear_bits,
+                               &wake_bits, &changed_bits ))
+             res = STATUS_PENDING;
+@@ -2935,7 +2935,7 @@ int peek_message( MSG *msg, const struct peek_message_filter *filter )
+                         .mask = filter->mask,
+                         .internal = filter->internal,
+                     };
+-                    peek_message( msg, &new_filter );
++                    peek_message( msg, &new_filter, TRUE );
+                 }
+                 continue;
+             }
+@@ -3000,7 +3000,7 @@ static void process_sent_messages(void)
+ {
+     struct peek_message_filter filter = {.flags = PM_REMOVE | PM_QS_SENDMESSAGE};
+     MSG msg;
+-    peek_message( &msg, &filter );
++    peek_message( &msg, &filter, FALSE );
+ }
+ 
+ /***********************************************************************
+@@ -3234,7 +3234,7 @@ BOOL WINAPI NtUserPeekMessage( MSG *msg_out, HWND hwnd, UINT first, UINT last, U
+     user_check_not_lock();
+     check_for_driver_events();
+ 
+-    if ((ret = peek_message( &msg, &filter )) <= 0)
++    if ((ret = peek_message( &msg, &filter, FALSE )) <= 0)
+     {
+         if (!ret)
+         {
+@@ -3285,7 +3285,7 @@ BOOL WINAPI NtUserGetMessage( MSG *msg, HWND hwnd, UINT first, UINT last )
+ 
+     filter.mask = mask;
+     filter.flags = PM_REMOVE | (mask << 16);
+-    while (!(ret = peek_message( msg, &filter )))
++    while (!(ret = peek_message( msg, &filter, TRUE )))
+     {
+         wait_objects( 1, &server_queue, INFINITE, mask & (QS_SENDMESSAGE | QS_SMRESULT), mask, 0 );
+     }
+diff --git a/dlls/win32u/ntuser_private.h b/dlls/win32u/ntuser_private.h
+index 11111111111..11111111111 100644
+--- a/dlls/win32u/ntuser_private.h
++++ b/dlls/win32u/ntuser_private.h
+@@ -235,7 +235,7 @@ struct peek_message_filter
+     BOOL internal;
+ };
+ 
+-extern int peek_message( MSG *msg, const struct peek_message_filter *filter );
++extern int peek_message( MSG *msg, const struct peek_message_filter *filter, BOOL waited );
+ 
+ /* systray.c */
+ extern LRESULT system_tray_call( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam, void *data );
+-- 
+0.0.0
+

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/shm_esync_fsync/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/shm_esync_fsync/hotfixes
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Rebase of this Proton patch to work around peek_message + shared memory: https://github.com/ValveSoftware/wine/commit/9ceae59cebd111f0fb06d63ad1495ea1becd714b
+if { [ "$_use_esync" = "true" ] || [ "$_use_fsync" = "true" ] ; } && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 54ca1ab607d3ff22a1f57a9561430f64c75f0916 HEAD ); then
+  warning "Hotfix: Fix for high CPU usage with esync/fsync"
+  _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/shm_esync_fsync/HACK-user32-Always-call-get_message-request-after-waiting)
+fi


### PR DESCRIPTION
And enable it if esync/fsync is used on trees containing Wine commit [54ca1ab607d3ff22a1f57a9561430f64c75f0916](https://gitlab.winehq.org/wine/wine/-/commit/54ca1ab607d3ff22a1f57a9561430f64c75f0916).
The patch is just a rebase of [this](https://github.com/ValveSoftware/wine/commit/9ceae59cebd111f0fb06d63ad1495ea1becd714b), which was made to work around the same issue in Proton.

Somebody should make a bug report for wine-staging about this, since it affects non-tkg staging esync as well...

Fixes #1278