### PR TITLE
Hotfixes: Update NosTale hotfix for 0bfdac7

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/NosTale/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/NosTale/hotfixes
@@ -8,8 +8,10 @@
     fi
   elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 879ef36148b489f82a3d99d2113b01eb7eb985a1 HEAD ); then
     warning "Hotfix: Fix NosTale mouse bug"
-    if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5127bedd54716a773fe079e19a4e38891b939671 HEAD ); then
+    if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 0bfdac7f6585f9bfce1d37335f53d2ed307d073b HEAD ); then
       _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/NosTale/nostale_mouse_fix)
+    elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 5127bedd54716a773fe079e19a4e38891b939671 HEAD ); then
+      _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/NosTale/nostale_mouse_fix-0bfdac7)
     else
       _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/NosTale/nostale_mouse_fix-5127bed)
     fi

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/NosTale/nostale_mouse_fix-0bfdac7.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/NosTale/nostale_mouse_fix-0bfdac7.mypatch
@@ -1,10 +1,10 @@
 --- a/dlls/user32/Makefile.in
 +++ b/dlls/user32/Makefile.in
 @@ -4,6 +4,7 @@ IMPORTLIB = user32
- IMPORTS   = $(PNG_PE_LIBS) gdi32 sechost advapi32 kernelbase win32u uuid
+ IMPORTS   = $(PNG_PE_LIBS) gdi32 version sechost advapi32 kernelbase win32u
  EXTRAINCL = $(PNG_PE_CFLAGS)
- DELAYIMPORTS = imm32 combase
+ DELAYIMPORTS = imm32
 +i386_EXTRADLLFLAGS = -Wl,--image-base,0x7e410000
 
- SOURCES = \
+ C_SRCS = \
  	button.c \


### PR DESCRIPTION
Fix broken builds since Wine upstream 0bfdac7f65
("win32u: Move the PE side DND callbacks to user32.").

Fixes Frogging-Family#1288.