### PR TITLE
prepare: Add NTsync version tag

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -1150,11 +1150,14 @@ _polish() {
 	  else
 	    _version_tags+=(Plain)
 	  fi
-	  if [ "$_use_esync" = "true" ] || [ "$_staging_esync" = "true" ] && [[ "$_custom_wine_source" != *"ValveSoftware"* ]]; then
+	  if [ "$_use_esync" = "true" ] || [ "$_staging_esync" = "true" ] && [ "$_use_ntsync" != "true" ] && [[ "$_custom_wine_source" != *"ValveSoftware"* ]]; then
 	   _version_tags+=(Esync)
 	  fi
 	  if [ "$_use_fsync" = "true" ] && [ "$_staging_esync" = "true" ] && [[ "$_custom_wine_source" != *"ValveSoftware"* ]]; then
 	    _version_tags+=(Fsync)
+	  fi
+	  if [ "$_use_ntsync" = "true" ] && [[ "$_custom_wine_source" != *"ValveSoftware"* ]]; then
+	    _version_tags+=(NTsync)
 	  fi
 	  if [ "$_use_pba" = "true" ] && [ "$_pba_version" != "none" ] && [[ "$_custom_wine_source" != *"ValveSoftware"* ]]; then
 	    _version_tags+=(PBA)


### PR DESCRIPTION
The Wine version tag with ntsync on is currently "TkG Plain" for mainline and "TkG Staging Esync" for staging builds.

"TkG Plain NTsync" and "TkG Staging NTsync" seem better.

Note that "Esync" shouldn't appear in the tag for staging ntsync builds. It happens because _use_staging="true" also forces _staging_esync="true", which then results in "Esync" being added to the tag even though the staging impl of esync is patched in only temporarily.