### PR TITLE
ntsync5: Rebase for wine-staging cd2cce2

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/01-non-patch-hotfixes/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/01-non-patch-hotfixes/hotfixes
@@ -22,11 +22,6 @@ if ( cd "${srcdir}"/"${_stgsrcdir}" && [ "$(git rev-parse HEAD)" = "5117eec7bfbd
   _hotfix_stagingreverts+=(5117eec7bfbda434fbe72d19ba75ec23ddccf846)
 fi
 
-# Revert changes in esync for ntsync5 because i am lazy
-if [ "$_use_staging" = "true" ] && [ "$_use_ntsync" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor cd2cce28ccd2791d0a7ab02bb02b804551ee4095 HEAD ); then
-  warning "Revert esync patchset to fix ntsync5"
-  _hotfix_stagingreverts+=(cd2cce28ccd2791d0a7ab02bb02b804551ee4095)
-fi
 # 7b233f3032e4850b0f387faef4aae5ed6d5175de breaks at least Among Us - Revert - https://github.com/Frogging-Family/wine-tkg-git/issues/709
 # Fixed along the way, possibly with 1b9d48a (not bisected)
 if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 7b233f3032e4850b0f387faef4aae5ed6d5175de HEAD && ! git merge-base --is-ancestor 1b9d48a7b01e2b715af46bc1f8d5fe6f1529782c HEAD ); then

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
@@ -101,8 +101,10 @@
 		  _patchname='ntsync-config.h.in-alt.patch' && _patchmsg="Using alternative config.h.in patchset for ntsync5" && nonuser_patcher
 		fi
         if [ "$_protonify" = "true" ]; then
-		  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 1dfac2a252d0036c3bae08bf47f00582343a80fb HEAD ); then
+		  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor d7ec9d3f95f67d49eef8fecc0640e952668b3759 HEAD ); then
 	      _patchname='ntsync5-staging-protonify.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher
+		  elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 1dfac2a252d0036c3bae08bf47f00582343a80fb HEAD ); then
+	      _patchname='ntsync5-staging-protonify-d7ec9d3.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher
 		  elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor f41c434b88c63984082ad9d4627bef5d51434871 HEAD ); then
 	      _patchname='ntsync5-staging-protonify-1dfac2a.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher
 	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fd3de9005ef504a810aeb828c5b491a7bebd7888 HEAD ); then
@@ -113,8 +115,10 @@
 	      _patchname='ntsync5-staging-protonify-7eb72b7b.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher
 	      fi
         else
-		  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 1dfac2a252d0036c3bae08bf47f00582343a80fb HEAD ); then
+		  if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor d7ec9d3f95f67d49eef8fecc0640e952668b3759 HEAD ); then
 	      _patchname='ntsync5-staging.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher
+		  elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 1dfac2a252d0036c3bae08bf47f00582343a80fb HEAD ); then
+	      _patchname='ntsync5-staging-d7ec9d3.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher
 		  elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor f41c434b88c63984082ad9d4627bef5d51434871 HEAD ); then
 	      _patchname='ntsync5-staging-1dfac2a.patch' && _patchmsg="Using ntsync patchset" && nonuser_patcher
 	      elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fd3de9005ef504a810aeb828c5b491a7bebd7888 HEAD ); then

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-d7ec9d3.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-d7ec9d3.patch
@@ -755,7 +755,7 @@ deleted file mode 100644
 index edfeb03..0000000
 --- a/dlls/ntdll/unix/esync.c
 +++ /dev/null
-@@ -1,1337 +0,0 @@
+@@ -1,1325 +0,0 @@
 -/*
 - * eventfd-based synchronization objects
 - *
@@ -831,29 +831,29 @@ index edfeb03..0000000
 -
 -struct esync
 -{
--    LONG type;
+-    enum esync_type type;
 -    int fd;
 -    void *shm;
 -};
 -
 -struct semaphore
 -{
--    LONG max;
--    LONG count;
+-    int max;
+-    int count;
 -};
 -C_ASSERT(sizeof(struct semaphore) == 8);
 -
 -struct mutex
 -{
--    LONG tid;
--    LONG count;    /* recursion count */
+-    DWORD tid;
+-    int count;    /* recursion count */
 -};
 -C_ASSERT(sizeof(struct mutex) == 8);
 -
 -struct event
 -{
--    LONG signaled;
--    LONG locked;
+-    int signaled;
+-    int locked;
 -};
 -C_ASSERT(sizeof(struct event) == 8);
 -
@@ -940,7 +940,7 @@ index edfeb03..0000000
 -        }
 -    }
 -
--    if (!InterlockedCompareExchange( &esync_list[entry][idx].type, type, 0 ))
+-    if (!InterlockedCompareExchange( (int *)&esync_list[entry][idx].type, type, 0 ))
 -    {
 -        esync_list[entry][idx].fd = fd;
 -        esync_list[entry][idx].shm = shm;
@@ -964,7 +964,7 @@ index edfeb03..0000000
 - * message queue, etc.) */
 -static NTSTATUS get_object( HANDLE handle, struct esync **obj )
 -{
--    int ret = STATUS_SUCCESS;
+-    NTSTATUS ret = STATUS_SUCCESS;
 -    enum esync_type type = 0;
 -    unsigned int shm_idx = 0;
 -    obj_handle_t fd_handle;
@@ -1032,7 +1032,7 @@ index edfeb03..0000000
 -
 -    if (entry < ESYNC_LIST_ENTRIES && esync_list[entry])
 -    {
--        if (InterlockedExchange(&esync_list[entry][idx].type, 0))
+-        if (InterlockedExchange((int *)&esync_list[entry][idx].type, 0))
 -        {
 -            close( esync_list[entry][idx].fd );
 -            return STATUS_SUCCESS;
@@ -1128,7 +1128,7 @@ index edfeb03..0000000
 -}
 -
 -extern NTSTATUS esync_create_semaphore(HANDLE *handle, ACCESS_MASK access,
--    const OBJECT_ATTRIBUTES *attr, int initial, int max)
+-    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max)
 -{
 -    TRACE("name %s, initial %d, max %d.\n",
 -        attr ? debugstr_us(attr->ObjectName) : "<no name>", initial, max);
@@ -1144,7 +1144,7 @@ index edfeb03..0000000
 -    return open_esync( ESYNC_SEMAPHORE, handle, access, attr );
 -}
 -
--NTSTATUS esync_release_semaphore( HANDLE handle, unsigned int count, ULONG *prev )
+-NTSTATUS esync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev )
 -{
 -    struct esync *obj;
 -    struct semaphore *semaphore;
@@ -1558,7 +1558,7 @@ index edfeb03..0000000
 -
 -/* A value of STATUS_NOT_IMPLEMENTED returned from this function means that we
 - * need to delegate to server_select(). */
--static NTSTATUS __esync_wait_objects( unsigned int count, const HANDLE *handles, BOOLEAN wait_any,
+-static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEAN wait_any,
 -                             BOOLEAN alertable, const LARGE_INTEGER *timeout )
 -{
 -    static const LARGE_INTEGER zero;
@@ -1908,22 +1908,10 @@ index edfeb03..0000000
 -                        {
 -                            /* We were too slow. Put everything back. */
 -                            value = 1;
--                            for (j = i - 1; j >= 0; j--)
+-                            for (j = i; j >= 0; j--)
 -                            {
--                                struct esync *obj = objs[j];
--
--                                if (obj->type == ESYNC_MUTEX)
--                                {
--                                    struct mutex *mutex = obj->shm;
--
--                                    if (mutex->tid == GetCurrentThreadId())
--                                        continue;
--                                }
--                                if (write( fds[j].fd, &value, sizeof(value) ) == -1)
--                                {
--                                    ERR("write failed.\n");
+-                                if (write( obj->fd, &value, sizeof(value) ) == -1)
 -                                    return errno_to_status( errno );
--                                }
 -                            }
 -
 -                            goto tryagain;  /* break out of two loops and a switch */
@@ -2124,11 +2112,11 @@ index 59f8809..0000000
 -extern NTSTATUS esync_close( HANDLE handle );
 -
 -extern NTSTATUS esync_create_semaphore(HANDLE *handle, ACCESS_MASK access,
--    const OBJECT_ATTRIBUTES *attr, int initial, int max);
+-    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max);
 -extern NTSTATUS esync_open_semaphore( HANDLE *handle, ACCESS_MASK access,
 -    const OBJECT_ATTRIBUTES *attr );
 -extern NTSTATUS esync_query_semaphore( HANDLE handle, void *info, ULONG *ret_len );
--extern NTSTATUS esync_release_semaphore( HANDLE handle, unsigned int count, ULONG *prev );
+-extern NTSTATUS esync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev );
 -
 -extern NTSTATUS esync_create_event( HANDLE *handle, ACCESS_MASK access,
 -    const OBJECT_ATTRIBUTES *attr, EVENT_TYPE type, BOOLEAN initial );
@@ -3872,12 +3860,12 @@ index 34655d1..1f8e10a 100644
 -    struct open_esync_reply open_esync_reply;
 -    struct get_esync_fd_reply get_esync_fd_reply;
 -    struct esync_msgwait_reply esync_msgwait_reply;
+     struct set_keyboard_repeat_reply set_keyboard_repeat_reply;
+-    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_linux_sync_device_reply get_linux_sync_device_reply;
 +    struct get_linux_sync_obj_reply get_linux_sync_obj_reply;
 +    struct fast_select_queue_reply fast_select_queue_reply;
 +    struct fast_unselect_queue_reply fast_unselect_queue_reply;
-     struct set_keyboard_repeat_reply set_keyboard_repeat_reply;
--    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_fast_alert_event_reply get_fast_alert_event_reply;
  };
 
@@ -7054,7 +7042,7 @@ index 4983691..7bc4208 100644
  @REPLY
      int enable;                /* previous state of auto-repeat enable */
  @END
- 
+
 -/* Retrieve the fd to wait on for user APCs. */
 -@REQ(get_esync_apc_fd)
 +
@@ -7128,7 +7116,7 @@ index fee3a8d..287a56e 100644
      no_close_handle,              /* close_handle */
      thread_input_destroy          /* destroy */
  };
-@@ -321,33 +320,30 @@ static struct msg_queue *create_msg_queue( struct thread *thread, struct thread_
+@@ -321,32 +320,29 @@ static struct msg_queue *create_msg_queue( struct thread *thread, struct thread_
          queue->last_get_msg    = current_time;
          queue->keystate_lock   = 0;
          queue->ignore_post_msg = 0;
@@ -7162,9 +7150,8 @@ index fee3a8d..287a56e 100644
 -            queue->esync_fd = esync_create_fd( 0, 0 );
 -
          thread->queue = queue;
-     }
- 
-@@ -606,7 +602,11 @@ static inline void set_queue_bits( struct msg_queue *queue, unsigned int bits )
+  
+@@ -607,7 +603,11 @@ static inline void set_queue_bits( struct msg_queue *queue, unsigned int bits )
      }
      SHARED_WRITE_END;
  
@@ -7277,7 +7264,8 @@ index fee3a8d..287a56e 100644
 -            esync_clear( queue->esync_fd );
      }
  }
-@@ -2867,8 +2880,8 @@ DECL_HANDLER(get_queue_status)
+@@ -2867,9 +2880,9 @@ DECL_HANDLER(get_queue_status)
+             shared->changed_bits &= ~req->clear_bits;
          }
          SHARED_WRITE_END;
  
@@ -7299,7 +7287,6 @@ index fee3a8d..287a56e 100644
      if ((filter & QS_POSTMESSAGE) &&
          get_posted_message( queue, queue->ignore_post_msg, get_win, req->get_first, req->get_last, req->flags, reply ))
 @@ -3119,11 +3134,8 @@ DECL_HANDLER(get_message)
-         shared->changed_mask = req->changed_mask;
      }
      SHARED_WRITE_END;
  
@@ -7312,6 +7299,76 @@ index fee3a8d..287a56e 100644
      return;
  
  found_msg:
+@@ -4020,21 +4020,60 @@ DECL_HANDLER(update_rawinput_devices)
+     }
+ }
+ 
+-DECL_HANDLER(esync_msgwait)
++DECL_HANDLER(fast_select_queue)
+ {
+-    struct msg_queue *queue = get_current_queue();
++    struct msg_queue *queue;
+     const queue_shm_t *queue_shm;
+ 
+-    if (!queue) return;
++    if (!(queue = (struct msg_queue *)get_handle_obj( current->process, req->handle,
++                                                      SYNCHRONIZE, &msg_queue_ops )))
++        return;
+     queue_shm = queue->shared;
+-    queue->esync_in_msgwait = req->in_msgwait;
++    /* a thread can only wait on its own queue */
++    if (current->queue != queue || queue->in_fast_wait)
++    {
++        set_error( STATUS_ACCESS_DENIED );
++    }
++    else
++    {
++        if (current->process->idle_event && !(queue_shm->wake_mask & QS_SMRESULT))
++            set_event( current->process->idle_event );
++
++        if (queue->fd)
++            set_fd_events( queue->fd, POLLIN );
+ 
+-    if (current->process->idle_event && !(queue_shm->wake_mask & QS_SMRESULT))
+-        set_event( current->process->idle_event );
++        queue->in_fast_wait = 1;
++    }
+ 
+-    /* and start/stop waiting on the driver */
+-    if (queue->fd)
+-        set_fd_events( queue->fd, req->in_msgwait ? POLLIN : 0 );
++    release_object( queue );
++}
++
++DECL_HANDLER(fast_unselect_queue)
++{
++    struct msg_queue *queue;
++    const queue_shm_t *queue_shm;
++
++    if (!(queue = (struct msg_queue *)get_handle_obj( current->process, req->handle,
++                                                      SYNCHRONIZE, &msg_queue_ops )))
++        return;
++
++    queue_shm = queue->shared;
++    if (current->queue != queue || !queue->in_fast_wait)
++    {
++        set_error( STATUS_ACCESS_DENIED );
++    }
++    else
++    {
++        if (queue->fd)
++            set_fd_events( queue->fd, 0 );
++
++        if (req->signaled)
++            msg_queue_satisfied( &queue->obj, NULL );
++
++        queue->in_fast_wait = 0;
++    }
++
++    release_object( queue );
+ }
+ 
+ DECL_HANDLER(set_keyboard_repeat)
 diff --git a/server/registry.c b/server/registry.c
 index 4454de3..dd5c556 100644
 --- a/server/registry.c
@@ -8157,7 +8214,7 @@ index af96565..c027f4b 100644
  };
  
  static const char * const req_names[REQ_NB_REQUESTS] = {
-@@ -5549,11 +5538,11 @@ static const char * const req_names[REQ_NB_REQUESTS] = {
+@@ -5549,11 +5538,12 @@ static const char * const req_names[REQ_NB_REQUESTS] = {
      "suspend_process",
      "resume_process",
      "get_next_thread",
@@ -8231,89 +8288,3 @@ index 4ef21d9..2719c9e 100644
      desktop_close_handle,         /* close_handle */
      desktop_destroy               /* destroy */
  };
-From 9c4c5779b6f87c27e73a4cb5a0973896c26c8d31 Mon Sep 17 00:00:00 2001
-From: Kirill Artemev <artewar6767@gmail.com>
-Date: Wed, 3 Jul 2024 18:39:15 +0500
-Subject: [PATCH] test3
-
-Signed-off-by: Kirill Artemev <artewar6767@gmail.com>
----
- server/queue.c | 55 +++++++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 46 insertions(+), 9 deletions(-)
-
-diff --git a/server/queue.c b/server/queue.c
-index 0c9c043d68f..c911ae3e574 100644
---- a/server/queue.c
-+++ b/server/queue.c
-@@ -4020,21 +4020,60 @@ DECL_HANDLER(update_rawinput_devices)
-     }
- }
- 
--DECL_HANDLER(esync_msgwait)
-+DECL_HANDLER(fast_select_queue)
- {
--    struct msg_queue *queue = get_current_queue();
-+    struct msg_queue *queue;
-     const queue_shm_t *queue_shm;
- 
--    if (!queue) return;
-+    if (!(queue = (struct msg_queue *)get_handle_obj( current->process, req->handle,
-+                                                      SYNCHRONIZE, &msg_queue_ops )))
-+        return;
-     queue_shm = queue->shared;
--    queue->esync_in_msgwait = req->in_msgwait;
-+    /* a thread can only wait on its own queue */
-+    if (current->queue != queue || queue->in_fast_wait)
-+    {
-+        set_error( STATUS_ACCESS_DENIED );
-+    }
-+    else
-+    {
-+        if (current->process->idle_event && !(queue_shm->wake_mask & QS_SMRESULT))
-+            set_event( current->process->idle_event );
-+
-+        if (queue->fd)
-+            set_fd_events( queue->fd, POLLIN );
- 
--    if (current->process->idle_event && !(queue_shm->wake_mask & QS_SMRESULT))
--        set_event( current->process->idle_event );
-+        queue->in_fast_wait = 1;
-+    }
- 
--    /* and start/stop waiting on the driver */
--    if (queue->fd)
--        set_fd_events( queue->fd, req->in_msgwait ? POLLIN : 0 );
-+    release_object( queue );
-+}
-+
-+DECL_HANDLER(fast_unselect_queue)
-+{
-+    struct msg_queue *queue;
-+    const queue_shm_t *queue_shm;
-+
-+    if (!(queue = (struct msg_queue *)get_handle_obj( current->process, req->handle,
-+                                                      SYNCHRONIZE, &msg_queue_ops )))
-+        return;
-+
-+    queue_shm = queue->shared;
-+    if (current->queue != queue || !queue->in_fast_wait)
-+    {
-+        set_error( STATUS_ACCESS_DENIED );
-+    }
-+    else
-+    {
-+        if (queue->fd)
-+            set_fd_events( queue->fd, 0 );
-+
-+        if (req->signaled)
-+            msg_queue_satisfied( &queue->obj, NULL );
-+
-+        queue->in_fast_wait = 0;
-+    }
-+
-+    release_object( queue );
- }
- 
- DECL_HANDLER(set_keyboard_repeat)
--- 
-2.45.2

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-protonify-d7ec9d3.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-protonify-d7ec9d3.patch
@@ -831,29 +831,29 @@ index edfeb03..0000000
 -
 -struct esync
 -{
--    LONG type;
+-    enum esync_type type;
 -    int fd;
 -    void *shm;
 -};
 -
 -struct semaphore
 -{
--    LONG max;
--    LONG count;
+-    int max;
+-    int count;
 -};
 -C_ASSERT(sizeof(struct semaphore) == 8);
 -
 -struct mutex
 -{
--    LONG tid;
--    LONG count;    /* recursion count */
+-    DWORD tid;
+-    int count;    /* recursion count */
 -};
 -C_ASSERT(sizeof(struct mutex) == 8);
 -
 -struct event
 -{
--    LONG signaled;
--    LONG locked;
+-    int signaled;
+-    int locked;
 -};
 -C_ASSERT(sizeof(struct event) == 8);
 -
@@ -940,7 +940,7 @@ index edfeb03..0000000
 -        }
 -    }
 -
--    if (!InterlockedCompareExchange( &esync_list[entry][idx].type, type, 0 ))
+-    if (!InterlockedCompareExchange( (int *)&esync_list[entry][idx].type, type, 0 ))
 -    {
 -        esync_list[entry][idx].fd = fd;
 -        esync_list[entry][idx].shm = shm;
@@ -964,7 +964,7 @@ index edfeb03..0000000
 - * message queue, etc.) */
 -static NTSTATUS get_object( HANDLE handle, struct esync **obj )
 -{
--    int ret = STATUS_SUCCESS;
+-    NTSTATUS ret = STATUS_SUCCESS;
 -    enum esync_type type = 0;
 -    unsigned int shm_idx = 0;
 -    obj_handle_t fd_handle;
@@ -1032,7 +1032,7 @@ index edfeb03..0000000
 -
 -    if (entry < ESYNC_LIST_ENTRIES && esync_list[entry])
 -    {
--        if (InterlockedExchange(&esync_list[entry][idx].type, 0))
+-        if (InterlockedExchange((int *)&esync_list[entry][idx].type, 0))
 -        {
 -            close( esync_list[entry][idx].fd );
 -            return STATUS_SUCCESS;
@@ -1128,7 +1128,7 @@ index edfeb03..0000000
 -}
 -
 -extern NTSTATUS esync_create_semaphore(HANDLE *handle, ACCESS_MASK access,
--    const OBJECT_ATTRIBUTES *attr, int initial, int max)
+-    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max)
 -{
 -    TRACE("name %s, initial %d, max %d.\n",
 -        attr ? debugstr_us(attr->ObjectName) : "<no name>", initial, max);
@@ -1144,7 +1144,7 @@ index edfeb03..0000000
 -    return open_esync( ESYNC_SEMAPHORE, handle, access, attr );
 -}
 -
--NTSTATUS esync_release_semaphore( HANDLE handle, unsigned int count, ULONG *prev )
+-NTSTATUS esync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev )
 -{
 -    struct esync *obj;
 -    struct semaphore *semaphore;
@@ -1558,7 +1558,7 @@ index edfeb03..0000000
 -
 -/* A value of STATUS_NOT_IMPLEMENTED returned from this function means that we
 - * need to delegate to server_select(). */
--static NTSTATUS __esync_wait_objects( unsigned int count, const HANDLE *handles, BOOLEAN wait_any,
+-static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEAN wait_any,
 -                             BOOLEAN alertable, const LARGE_INTEGER *timeout )
 -{
 -    static const LARGE_INTEGER zero;
@@ -2124,11 +2124,11 @@ index 59f8809..0000000
 -extern NTSTATUS esync_close( HANDLE handle );
 -
 -extern NTSTATUS esync_create_semaphore(HANDLE *handle, ACCESS_MASK access,
--    const OBJECT_ATTRIBUTES *attr, int initial, int max);
+-    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max);
 -extern NTSTATUS esync_open_semaphore( HANDLE *handle, ACCESS_MASK access,
 -    const OBJECT_ATTRIBUTES *attr );
 -extern NTSTATUS esync_query_semaphore( HANDLE handle, void *info, ULONG *ret_len );
--extern NTSTATUS esync_release_semaphore( HANDLE handle, unsigned int count, ULONG *prev );
+-extern NTSTATUS esync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev );
 -
 -extern NTSTATUS esync_create_event( HANDLE *handle, ACCESS_MASK access,
 -    const OBJECT_ATTRIBUTES *attr, EVENT_TYPE type, BOOLEAN initial );

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -831,29 +831,29 @@ index edfeb03..0000000
 -
 -struct esync
 -{
--    enum esync_type type;
+-    LONG type;
 -    int fd;
 -    void *shm;
 -};
 -
 -struct semaphore
 -{
--    int max;
--    int count;
+-    LONG max;
+-    LONG count;
 -};
 -C_ASSERT(sizeof(struct semaphore) == 8);
 -
 -struct mutex
 -{
--    DWORD tid;
--    int count;    /* recursion count */
+-    LONG tid;
+-    LONG count;    /* recursion count */
 -};
 -C_ASSERT(sizeof(struct mutex) == 8);
 -
 -struct event
 -{
--    int signaled;
--    int locked;
+-    LONG signaled;
+-    LONG locked;
 -};
 -C_ASSERT(sizeof(struct event) == 8);
 -
@@ -940,7 +940,7 @@ index edfeb03..0000000
 -        }
 -    }
 -
--    if (!InterlockedCompareExchange( (int *)&esync_list[entry][idx].type, type, 0 ))
+-    if (!InterlockedCompareExchange( &esync_list[entry][idx].type, type, 0 ))
 -    {
 -        esync_list[entry][idx].fd = fd;
 -        esync_list[entry][idx].shm = shm;
@@ -964,7 +964,7 @@ index edfeb03..0000000
 - * message queue, etc.) */
 -static NTSTATUS get_object( HANDLE handle, struct esync **obj )
 -{
--    NTSTATUS ret = STATUS_SUCCESS;
+-    int ret = STATUS_SUCCESS;
 -    enum esync_type type = 0;
 -    unsigned int shm_idx = 0;
 -    obj_handle_t fd_handle;
@@ -1032,7 +1032,7 @@ index edfeb03..0000000
 -
 -    if (entry < ESYNC_LIST_ENTRIES && esync_list[entry])
 -    {
--        if (InterlockedExchange((int *)&esync_list[entry][idx].type, 0))
+-        if (InterlockedExchange(&esync_list[entry][idx].type, 0))
 -        {
 -            close( esync_list[entry][idx].fd );
 -            return STATUS_SUCCESS;
@@ -1128,7 +1128,7 @@ index edfeb03..0000000
 -}
 -
 -extern NTSTATUS esync_create_semaphore(HANDLE *handle, ACCESS_MASK access,
--    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max)
+-    const OBJECT_ATTRIBUTES *attr, int initial, int max)
 -{
 -    TRACE("name %s, initial %d, max %d.\n",
 -        attr ? debugstr_us(attr->ObjectName) : "<no name>", initial, max);
@@ -1144,7 +1144,7 @@ index edfeb03..0000000
 -    return open_esync( ESYNC_SEMAPHORE, handle, access, attr );
 -}
 -
--NTSTATUS esync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev )
+-NTSTATUS esync_release_semaphore( HANDLE handle, unsigned int count, ULONG *prev )
 -{
 -    struct esync *obj;
 -    struct semaphore *semaphore;
@@ -1558,7 +1558,7 @@ index edfeb03..0000000
 -
 -/* A value of STATUS_NOT_IMPLEMENTED returned from this function means that we
 - * need to delegate to server_select(). */
--static NTSTATUS __esync_wait_objects( DWORD count, const HANDLE *handles, BOOLEAN wait_any,
+-static NTSTATUS __esync_wait_objects( unsigned int count, const HANDLE *handles, BOOLEAN wait_any,
 -                             BOOLEAN alertable, const LARGE_INTEGER *timeout )
 -{
 -    static const LARGE_INTEGER zero;
@@ -2112,11 +2112,11 @@ index 59f8809..0000000
 -extern NTSTATUS esync_close( HANDLE handle );
 -
 -extern NTSTATUS esync_create_semaphore(HANDLE *handle, ACCESS_MASK access,
--    const OBJECT_ATTRIBUTES *attr, LONG initial, LONG max);
+-    const OBJECT_ATTRIBUTES *attr, int initial, int max);
 -extern NTSTATUS esync_open_semaphore( HANDLE *handle, ACCESS_MASK access,
 -    const OBJECT_ATTRIBUTES *attr );
 -extern NTSTATUS esync_query_semaphore( HANDLE handle, void *info, ULONG *ret_len );
--extern NTSTATUS esync_release_semaphore( HANDLE handle, ULONG count, ULONG *prev );
+-extern NTSTATUS esync_release_semaphore( HANDLE handle, unsigned int count, ULONG *prev );
 -
 -extern NTSTATUS esync_create_event( HANDLE *handle, ACCESS_MASK access,
 -    const OBJECT_ATTRIBUTES *attr, EVENT_TYPE type, BOOLEAN initial );


### PR DESCRIPTION
Rebase ntsync5 patches broken by wine-staging cd2cce28cc ("eventfd_synchronization: Fix compile warnings.").

Also revert the existing hotfix stopgap ecd65dc53a ("staging_fixes: Revert esync patchset for ntsync5 (#1242)").