### PR TITLE
ntsync5: fix crash wineserver

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
@@ -3309,6 +3309,22 @@ diff --git a/server/object.c b/server/object.c
 index 89e541f..6c6568e 100644
 --- a/server/object.c
 +++ b/server/object.c
+@@ -120,6 +120,7 @@ static const struct object_ops apc_reserve_ops =
+     default_unlink_name,        /* unlink_name */
+     no_open_file,               /* open_file */
+     no_kernel_obj_list,         /* get_kernel_obj_list */
++    no_get_fast_sync,
+     no_close_handle,            /* close_handle */
+     no_destroy                  /* destroy */
+ };
+@@ -144,6 +145,7 @@ static const struct object_ops completion_reserve_ops =
+     default_unlink_name,       /* unlink_name */
+     no_open_file,              /* open_file */
+     no_kernel_obj_list,        /* get_kernel_obj_list */
++    no_get_fast_sync,
+     no_close_handle,           /* close_handle */
+     no_destroy                 /* destroy */
+ };
 @@ -538,6 +538,12 @@ struct fd *no_get_fd( struct object *obj )
      return NULL;
  }

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
@@ -3309,6 +3309,22 @@ diff --git a/server/object.c b/server/object.c
 index 89e541f..6c6568e 100644
 --- a/server/object.c
 +++ b/server/object.c
+@@ -120,6 +120,7 @@ static const struct object_ops apc_reserve_ops =
+     default_unlink_name,        /* unlink_name */
+     no_open_file,               /* open_file */
+     no_kernel_obj_list,         /* get_kernel_obj_list */
++    no_get_fast_sync,
+     no_close_handle,            /* close_handle */
+     no_destroy                  /* destroy */
+ };
+@@ -144,6 +145,7 @@ static const struct object_ops completion_reserve_ops =
+     default_unlink_name,       /* unlink_name */
+     no_open_file,              /* open_file */
+     no_kernel_obj_list,        /* get_kernel_obj_list */
++    no_get_fast_sync,
+     no_close_handle,           /* close_handle */
+     no_destroy                 /* destroy */
+ };
 @@ -538,6 +538,12 @@ struct fd *no_get_fd( struct object *obj )
      return NULL;
  }

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -6723,6 +6723,48 @@ diff --git a/server/object.c b/server/object.c
 index 29f1ea9..33fc18c 100644
 --- a/server/object.c
 +++ b/server/object.c
+@@ -120,19 +120,19 @@ static const struct object_ops apc_reserve_ops =
+     no_add_queue,               /* add_queue */
+     NULL,                       /* remove_queue */
+     NULL,                       /* signaled */
+-    NULL,                       /* get_esync_fd */
+     no_satisfied,               /* satisfied */
+     no_signal,                  /* signal */
+     no_get_fd,                  /* get_fd */
+     default_map_access,         /* map_access */
+     default_get_sd,             /* get_sd */
+     default_set_sd,             /* set_sd */
+     default_get_full_name,      /* get_full_name */
+     no_lookup_name,             /* lookup_name */
+     directory_link_name,        /* link_name */
+     default_unlink_name,        /* unlink_name */
+     no_open_file,               /* open_file */
+     no_kernel_obj_list,         /* get_kernel_obj_list */
++    no_get_fast_sync,
+     no_close_handle,            /* close_handle */
+     no_destroy                  /* destroy */
+ };
+@@ -144,19 +145,19 @@ static const struct object_ops completion_reserve_ops =
+     no_add_queue,              /* add_queue */
+     NULL,                      /* remove_queue */
+     NULL,                      /* signaled */
+-    NULL,                      /* get_esync_fd */
+     no_satisfied,              /* satisfied */
+     no_signal,                 /* signal */
+     no_get_fd,                 /* get_fd */
+     default_map_access,        /* map_access */
+     default_get_sd,            /* get_sd */
+     default_set_sd,            /* set_sd */
+     default_get_full_name,     /* get_full_name */
+     no_lookup_name,            /* lookup_name */
+     directory_link_name,       /* link_name */
+     default_unlink_name,       /* unlink_name */
+     no_open_file,              /* open_file */
+     no_kernel_obj_list,        /* get_kernel_obj_list */
++    no_get_fast_sync,
+     no_close_handle,           /* close_handle */
+     no_destroy                 /* destroy */
+ };
 @@ -538,6 +538,12 @@ struct fd *no_get_fd( struct object *obj )
      return NULL;
  }


### PR DESCRIPTION
Adds no_get_fast_sync in object.c which I only added in the protonify-staging patch