### PR TITLE
proton-tkg: Add forgoten patch for mainline

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/proton-tkg.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton-tkg/mainline/proton-tkg.patch
@@ -803,38 +803,6 @@ index 5a97590dbce..a5563498cdd 100644
      return hr;
  }
  
-From c619409f235cf660cdd4fd3295d5e04ec628daa1 Mon Sep 17 00:00:00 2001
-From: Alexey Prokhin <alexey@prokhin.ru>
-Date: Thu, 23 Apr 2020 12:29:55 +0300
-Subject: [PATCH] kernelbase: Set the proper error code in
- GetQueuedCompletionStatus{Ex} when the handle is closed.
-
-Planet Zoo relies on it being ERROR_ABANDONED_WAIT_0.
----
- dlls/kernelbase/sync.c | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/dlls/kernelbase/sync.c b/dlls/kernelbase/sync.c
-index 0ae3aadde92..e95ede8aed5 100644
---- a/dlls/kernelbase/sync.c
-+++ b/dlls/kernelbase/sync.c
-@@ -960,6 +960,7 @@ BOOL WINAPI DECLSPEC_HOTPATCH GetQueuedCompletionStatus( HANDLE port, LPDWORD co
-     }
- 
-     if (status == STATUS_TIMEOUT) SetLastError( WAIT_TIMEOUT );
-+    else if (status == ERROR_WAIT_NO_CHILDREN) SetLastError( ERROR_ABANDONED_WAIT_0 );
-     else SetLastError( RtlNtStatusToDosError(status) );
-     return FALSE;
- }
-@@ -981,6 +982,7 @@ BOOL WINAPI DECLSPEC_HOTPATCH GetQueuedCompletionStatusEx( HANDLE port, OVERLAPP
-     if (ret == STATUS_SUCCESS) return TRUE;
-     else if (ret == STATUS_TIMEOUT) SetLastError( WAIT_TIMEOUT );
-     else if (ret == STATUS_USER_APC) SetLastError( WAIT_IO_COMPLETION );
-+    else if (ret == ERROR_WAIT_NO_CHILDREN) SetLastError( ERROR_ABANDONED_WAIT_0 );
-     else SetLastError( RtlNtStatusToDosError(ret) );
-     return FALSE;
- }
-
 From 0255dbc3afd3ff673fa701e7802474483252fcb2 Mon Sep 17 00:00:00 2001
 From: Paul Gofman <pgofman@codeweavers.com>
 Date: Mon, 13 Jul 2020 10:21:49 -0500


### PR DESCRIPTION
When rebasing patches I forgot to add the patch for mailline
Should fix this #1296 