### PR TITLE
CI: Set XDG_CACHE_HOME envvar for Wine builds on Arch

### DIFF
--- a/.github/workflows/wine-arch.yml
+++ b/.github/workflows/wine-arch.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Compile
+        env:
+          XDG_CACHE_HOME: /tmp/.cache
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           pacman -Syu --noconfirm base-devel sudo


### PR DESCRIPTION
Since Wine 4db7ed25b9 ("winevulkan: Cache downloaded files in make_vulkan."), Wine builds with Vulkan enabled fail on Arch runners due to insufficient permissions when dlls/winevulkan/make_vulkan attempts to create a cache directory at /home/user/.cache/wine.

Fix the build failure by setting the currently unused XDG_CACHE_HOME envvar to force the cache directory to be created somewhere inside /tmp instead.

This additionally fixes build failures that would otherwise arise in dlls/opencl/make_opencl, dlls/opengl32/make_opengl, and tools/make_unicode, all of which use that envvar to derive the same cache directory path and attempt to create it at build time if it doesn't exist.

Note that dlls/appwiz.cpl/addons.c also references that envvar, but setting it during build time should not affect anything during runtime.