### PR TITLE
ntsync5: Proper support wait on completion ports

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
@@ -1764,7 +1764,7 @@ diff --git a/server/completion.c b/server/completion.c
 index 6933195..5ec6d20 100644
 --- a/server/completion.c
 +++ b/server/completion.c
-@@ -61,11 +61,13 @@ struct completion
+@@ -61,6 +61,7 @@ struct completion
      struct list    wait_queue;
      unsigned int   depth;
      int            closed;
@@ -1772,12 +1772,23 @@ index 6933195..5ec6d20 100644
  };
 
  static void completion_wait_dump( struct object*, int );
- static int completion_wait_signaled( struct object *obj, struct wait_queue_entry *entry );
- static void completion_wait_satisfied( struct object *obj, struct wait_queue_entry *entry );
-+static struct fast_sync *completion_get_fast_sync( struct object *obj );
- static void completion_wait_destroy( struct object * );
+@@ -75,11 +77,16 @@ static const struct object_ops completion_ops =
+     msg = LIST_ENTRY( msg_entry, struct comp_msg, queue_entry );
+     --wait->completion->depth;
+     list_remove( &msg->queue_entry );
++    if (list_empty( &wait->completion->queue ))
++    {
++        fast_reset_event( wait->completion->fast_sync );
++    }
+     if (wait->msg) free( wait->msg );
+     wait->msg = msg;
+ }
  
- static const struct object_ops completion_wait_ops =
+ static void completion_dump( struct object*, int );
+ static int completion_signaled( struct object *obj, struct wait_queue_entry *entry );
++static struct fast_sync *completion_get_fast_sync( struct object *obj );
+ static int completion_close_handle( struct object *obj, struct process *process, obj_handle_t handle );
+ static void completion_destroy( struct object * );
 @@ -87,6 +89,7 @@ static const struct object_ops completion_ops =
      default_unlink_name,       /* unlink_name */
      no_open_file,              /* open_file */

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
@@ -1764,20 +1764,31 @@ diff --git a/server/completion.c b/server/completion.c
 index 6933195..5ec6d20 100644
 --- a/server/completion.c
 +++ b/server/completion.c
-@@ -61,11 +61,13 @@ struct completion
+@@ -61,6 +61,7 @@ struct completion
      struct list    wait_queue;
      unsigned int   depth;
      int            closed;
 +    struct fast_sync *fast_sync;
  };
-
- static void completion_wait_dump( struct object*, int );
- static int completion_wait_signaled( struct object *obj, struct wait_queue_entry *entry );
- static void completion_wait_satisfied( struct object *obj, struct wait_queue_entry *entry );
-+static struct fast_sync *completion_get_fast_sync( struct object *obj );
- static void completion_wait_destroy( struct object * );
  
- static const struct object_ops completion_wait_ops =
+ static void completion_wait_dump( struct object*, int );
+@@ -75,11 +77,16 @@ static const struct object_ops completion_ops =
+     msg = LIST_ENTRY( msg_entry, struct comp_msg, queue_entry );
+     --wait->completion->depth;
+     list_remove( &msg->queue_entry );
++    if (list_empty( &wait->completion->queue ))
++    {
++        fast_reset_event( wait->completion->fast_sync );
++    }
+     if (wait->msg) free( wait->msg );
+     wait->msg = msg;
+ }
+ 
+ static void completion_dump( struct object*, int );
+ static int completion_signaled( struct object *obj, struct wait_queue_entry *entry );
++static struct fast_sync *completion_get_fast_sync( struct object *obj );
+ static int completion_close_handle( struct object *obj, struct process *process, obj_handle_t handle );
+ static void completion_destroy( struct object * );
 @@ -87,6 +89,7 @@ static const struct object_ops completion_ops =
      default_unlink_name,       /* unlink_name */
      no_open_file,              /* open_file */
@@ -1811,13 +1822,13 @@ index 6933195..5ec6d20 100644
  static struct completion *create_completion( struct object *root, const struct unicode_str *name,
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
-@@ -138,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
-             list_init( &completion->queue );
-             completion->depth = 0;
-             completion->closed = 0;
-+            completion->fast_sync = NULL;
+@@ -139,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
          }
      }
+ 
++    completion->fast_sync = NULL;
+     return completion;
+ }
  
 @@ -165,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
          if (list_empty( &completion->queue )) return;

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
@@ -1823,13 +1823,13 @@ index 6933195..5ec6d20 100644
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
 @@ -139,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
+         {
+             list_init( &completion->queue );
+             completion->depth = 0;
+             completion->closed = 0;
++            completion->fast_sync = NULL;
          }
      }
- 
-+    completion->fast_sync = NULL;
-     return completion;
- }
- 
 @@ -165,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
          if (list_empty( &completion->queue )) return;
      }

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
@@ -4109,13 +4109,13 @@ index 3d4be86..5ec6d20 100644
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
 @@ -139,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
+         {
+             list_init( &completion->queue );
+             completion->depth = 0;
+             completion->closed = 0;
++            completion->fast_sync = NULL;
          }
      }
- 
-+    completion->fast_sync = NULL;
-     return completion;
- }
- 
 @@ -166,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
          if (list_empty( &completion->queue )) return;
      }

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging-protonify.patch
@@ -4045,7 +4045,18 @@ index 3d4be86..5ec6d20 100644
  };
  
  static void completion_wait_destroy( struct object *obj )
-@@ -75,17 +77,17 @@ static const struct object_ops completion_ops =
+@@ -75,24 +77,28 @@ static const struct object_ops completion_ops =
+     msg = LIST_ENTRY( msg_entry, struct comp_msg, queue_entry );
+     --wait->completion->depth;
+     list_remove( &msg->queue_entry );
++    if (list_empty( &wait->completion->queue ))
++    {
++        fast_reset_event( wait->completion->fast_sync );
++    }
+     if (wait->msg) free( wait->msg );
+     wait->msg = msg;
+ }
+ 
  static void completion_dump( struct object*, int );
  static int completion_signaled( struct object *obj, struct wait_queue_entry *entry );
 +static struct fast_sync *completion_get_fast_sync( struct object *obj );
@@ -4098,13 +4109,13 @@ index 3d4be86..5ec6d20 100644
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
 @@ -139,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
-         {
-             list_init( &completion->queue );
-             completion->depth = 0;
-             completion->closed = 0;
-+            completion->fast_sync = NULL;
          }
      }
+ 
++    completion->fast_sync = NULL;
+     return completion;
+ }
+ 
 @@ -166,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
          if (list_empty( &completion->queue )) return;
      }

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -4033,7 +4033,18 @@ index 3d4be86..5ec6d20 100644
  };
  
  static void completion_wait_destroy( struct object *obj )
-@@ -75,17 +77,17 @@ static const struct object_ops completion_ops =
+@@ -75,24 +77,28 @@ static const struct object_ops completion_ops =
+     msg = LIST_ENTRY( msg_entry, struct comp_msg, queue_entry );
+     --wait->completion->depth;
+     list_remove( &msg->queue_entry );
++    if (list_empty( &wait->completion->queue ))
++    {
++        fast_reset_event( wait->completion->fast_sync );
++    }
+     if (wait->msg) free( wait->msg );
+     wait->msg = msg;
+ }
+ 
  static void completion_dump( struct object*, int );
  static int completion_signaled( struct object *obj, struct wait_queue_entry *entry );
 +static struct fast_sync *completion_get_fast_sync( struct object *obj );
@@ -4086,13 +4097,13 @@ index 3d4be86..5ec6d20 100644
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
 @@ -139,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
-         {
-             list_init( &completion->queue );
-             completion->depth = 0;
-             completion->closed = 0;
-+            completion->fast_sync = NULL;
          }
      }
+ 
++    completion->fast_sync = NULL;
+     return completion;
+ }
+ 
 @@ -166,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
          if (list_empty( &completion->queue )) return;
      }

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -4097,13 +4097,13 @@ index 3d4be86..5ec6d20 100644
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
 @@ -139,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
+         {
+             list_init( &completion->queue );
+             completion->depth = 0;
+             completion->closed = 0;
++            completion->fast_sync = NULL;
          }
      }
- 
-+    completion->fast_sync = NULL;
-     return completion;
- }
- 
 @@ -166,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
          if (list_empty( &completion->queue )) return;
      }


### PR DESCRIPTION
Based on this merge request from proton https://github.com/ValveSoftware/wine/commit/95b1cb1311588bf7d9ff556008bd6fd9c6bb0d90. I was able to make a more correct support wait on completion ports for ntsync5

