### PR TITLE
ntsync5: fix ntsync5-staging and legacy patch

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-ac1ff67c.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/legacy/ntsync5-staging-ac1ff67c.patch
@@ -3878,12 +3878,12 @@ index 34655d1..1f8e10a 100644
 -    struct open_esync_reply open_esync_reply;
 -    struct get_esync_fd_reply get_esync_fd_reply;
 -    struct esync_msgwait_reply esync_msgwait_reply;
-     struct set_keyboard_repeat_reply set_keyboard_repeat_reply;
--    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_linux_sync_device_reply get_linux_sync_device_reply;
 +    struct get_linux_sync_obj_reply get_linux_sync_obj_reply;
 +    struct fast_select_queue_reply fast_select_queue_reply;
 +    struct fast_unselect_queue_reply fast_unselect_queue_reply;
+     struct set_keyboard_repeat_reply set_keyboard_repeat_reply;
+-    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_fast_alert_event_reply get_fast_alert_event_reply;
  };
 
@@ -6729,6 +6729,22 @@ index a90ec60..6d8cb3e 100644
 +    default_fd_get_fast_sync,                /* get_fast_sync */
      no_close_handle,                         /* close_handle */
      named_pipe_device_file_destroy           /* destroy */
+ };
+@@ -344,7 +344,6 @@
+     add_queue,                               /* add_queue */
+     remove_queue,                            /* remove_queue */
+     default_fd_signaled,                     /* signaled */
+-    NULL,                                    /* get_esync_fd */
+     no_satisfied,                            /* satisfied */
+     no_signal,                               /* signal */
+     named_pipe_dir_get_fd,                   /* get_fd */
+@@ -357,6 +356,7 @@
+     NULL,                                    /* unlink_name */
+     named_pipe_dir_open_file,                /* open_file */
+     no_kernel_obj_list,                      /* get_kernel_obj_list */
++    default_fd_get_fast_sync,                /* get_fast_sync */
+     no_close_handle,                         /* close_handle */
+     named_pipe_dir_destroy                   /* destroy */
  };
 diff --git a/server/object.c b/server/object.c
 index 29f1ea9..33fc18c 100644

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-staging.patch
@@ -3878,12 +3878,12 @@ index 34655d1..1f8e10a 100644
 -    struct open_esync_reply open_esync_reply;
 -    struct get_esync_fd_reply get_esync_fd_reply;
 -    struct esync_msgwait_reply esync_msgwait_reply;
-     struct set_keyboard_repeat_reply set_keyboard_repeat_reply;
--    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_linux_sync_device_reply get_linux_sync_device_reply;
 +    struct get_linux_sync_obj_reply get_linux_sync_obj_reply;
 +    struct fast_select_queue_reply fast_select_queue_reply;
 +    struct fast_unselect_queue_reply fast_unselect_queue_reply;
+     struct set_keyboard_repeat_reply set_keyboard_repeat_reply;
+-    struct get_esync_apc_fd_reply get_esync_apc_fd_reply;
 +    struct get_fast_alert_event_reply get_fast_alert_event_reply;
  };
 
@@ -6729,6 +6729,22 @@ index a90ec60..6d8cb3e 100644
 +    default_fd_get_fast_sync,                /* get_fast_sync */
      no_close_handle,                         /* close_handle */
      named_pipe_device_file_destroy           /* destroy */
+ };
+@@ -344,7 +344,6 @@
+     add_queue,                               /* add_queue */
+     remove_queue,                            /* remove_queue */
+     default_fd_signaled,                     /* signaled */
+-    NULL,                                    /* get_esync_fd */
+     no_satisfied,                            /* satisfied */
+     no_signal,                               /* signal */
+     named_pipe_dir_get_fd,                   /* get_fd */
+@@ -357,6 +356,7 @@
+     NULL,                                    /* unlink_name */
+     named_pipe_dir_open_file,                /* open_file */
+     no_kernel_obj_list,                      /* get_kernel_obj_list */
++    default_fd_get_fast_sync,                /* get_fast_sync */
+     no_close_handle,                         /* close_handle */
+     named_pipe_dir_destroy                   /* destroy */
  };
 diff --git a/server/object.c b/server/object.c
 index 29f1ea9..33fc18c 100644


### PR DESCRIPTION
Should fix this: #1322 