### PR TITLE
ntsync5: Fix mainline and protonify patch

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-mainline.patch
@@ -1764,15 +1764,23 @@ diff --git a/server/completion.c b/server/completion.c
 index 6933195..5ec6d20 100644
 --- a/server/completion.c
 +++ b/server/completion.c
-@@ -61,6 +61,7 @@ struct completion
+@@ -77,6 +77,7 @@
      struct list    wait_queue;
      unsigned int   depth;
      int            closed;
 +    struct fast_sync *fast_sync;
  };
-
+ 
  static void completion_wait_dump( struct object*, int );
-@@ -75,11 +77,16 @@ static const struct object_ops completion_ops =
+@@ -104,6 +105,7 @@
+     NULL,                           /* unlink_name */
+     no_open_file,                   /* open_file */
+     no_kernel_obj_list,             /* get_kernel_obj_list */
++    no_get_fast_sync,               /* get_fast_sync */
+     no_close_handle,                /* close_handle */
+     completion_wait_destroy         /* destroy */
+ };
+@@ -149,12 +151,17 @@
      msg = LIST_ENTRY( msg_entry, struct comp_msg, queue_entry );
      --wait->completion->depth;
      list_remove( &msg->queue_entry );
@@ -1789,7 +1797,8 @@ index 6933195..5ec6d20 100644
 +static struct fast_sync *completion_get_fast_sync( struct object *obj );
  static int completion_close_handle( struct object *obj, struct process *process, obj_handle_t handle );
  static void completion_destroy( struct object * );
-@@ -87,6 +89,7 @@ static const struct object_ops completion_ops =
+ 
+@@ -178,6 +185,7 @@
      default_unlink_name,       /* unlink_name */
      no_open_file,              /* open_file */
      no_kernel_obj_list,        /* get_kernel_obj_list */
@@ -1797,7 +1806,7 @@ index 6933195..5ec6d20 100644
      completion_close_handle,   /* close_handle */
      completion_destroy         /* destroy */
  };
-@@ -109,6 +112,7 @@ static void completion_destroy( struct object *obj)
+@@ -191,6 +199,7 @@
      {
          free( tmp );
      }
@@ -1805,8 +1814,8 @@ index 6933195..5ec6d20 100644
  }
  
  static void completion_dump( struct object *obj, int verbose )
-@@ -126,6 +130,16 @@ static int completion_signaled( struct object *obj, struct wait_queue_entry *ent
-     return !list_empty( &completion->queue );
+@@ -261,6 +270,16 @@
+     return wait;
  }
  
 +static struct fast_sync *completion_get_fast_sync( struct object *obj )
@@ -1822,15 +1831,15 @@ index 6933195..5ec6d20 100644
  static struct completion *create_completion( struct object *root, const struct unicode_str *name,
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
-@@ -138,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
-             list_init( &completion->queue );
+@@ -275,6 +294,7 @@
+             list_init( &completion->wait_queue );
              completion->depth = 0;
              completion->closed = 0;
 +            completion->fast_sync = NULL;
          }
      }
  
-@@ -165,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
+@@ -308,6 +328,7 @@
          if (list_empty( &completion->queue )) return;
      }
      if (!list_empty( &completion->queue )) wake_up( &completion->obj, 0 );
@@ -1838,7 +1847,7 @@ index 6933195..5ec6d20 100644
  }
  
  /* create a completion */
-@@ -231,6 +247,8 @@ DECL_HANDLER(remove_completion)
+@@ -404,6 +425,8 @@
          reply->information = msg->information;
          free( msg );
          reply->wait_handle = 0;

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/ntsync5-protonify.patch
@@ -1764,7 +1764,7 @@ diff --git a/server/completion.c b/server/completion.c
 index 6933195..5ec6d20 100644
 --- a/server/completion.c
 +++ b/server/completion.c
-@@ -61,6 +61,7 @@ struct completion
+@@ -77,6 +77,7 @@
      struct list    wait_queue;
      unsigned int   depth;
      int            closed;
@@ -1772,7 +1772,15 @@ index 6933195..5ec6d20 100644
  };
  
  static void completion_wait_dump( struct object*, int );
-@@ -75,11 +77,16 @@ static const struct object_ops completion_ops =
+@@ -104,6 +105,7 @@
+     NULL,                           /* unlink_name */
+     no_open_file,                   /* open_file */
+     no_kernel_obj_list,             /* get_kernel_obj_list */
++    no_get_fast_sync,               /* get_fast_sync */
+     no_close_handle,                /* close_handle */
+     completion_wait_destroy         /* destroy */
+ };
+@@ -149,12 +151,17 @@
      msg = LIST_ENTRY( msg_entry, struct comp_msg, queue_entry );
      --wait->completion->depth;
      list_remove( &msg->queue_entry );
@@ -1789,7 +1797,8 @@ index 6933195..5ec6d20 100644
 +static struct fast_sync *completion_get_fast_sync( struct object *obj );
  static int completion_close_handle( struct object *obj, struct process *process, obj_handle_t handle );
  static void completion_destroy( struct object * );
-@@ -87,6 +89,7 @@ static const struct object_ops completion_ops =
+ 
+@@ -178,6 +185,7 @@
      default_unlink_name,       /* unlink_name */
      no_open_file,              /* open_file */
      no_kernel_obj_list,        /* get_kernel_obj_list */
@@ -1797,7 +1806,7 @@ index 6933195..5ec6d20 100644
      completion_close_handle,   /* close_handle */
      completion_destroy         /* destroy */
  };
-@@ -109,6 +112,7 @@ static void completion_destroy( struct object *obj)
+@@ -191,6 +199,7 @@
      {
          free( tmp );
      }
@@ -1805,8 +1814,8 @@ index 6933195..5ec6d20 100644
  }
  
  static void completion_dump( struct object *obj, int verbose )
-@@ -126,6 +130,16 @@ static int completion_signaled( struct object *obj, struct wait_queue_entry *ent
-     return !list_empty( &completion->queue );
+@@ -261,6 +270,16 @@
+     return wait;
  }
  
 +static struct fast_sync *completion_get_fast_sync( struct object *obj )
@@ -1822,15 +1831,15 @@ index 6933195..5ec6d20 100644
  static struct completion *create_completion( struct object *root, const struct unicode_str *name,
                                               unsigned int attr, unsigned int concurrent,
                                               const struct security_descriptor *sd )
-@@ -139,6 +152,7 @@ static struct completion *create_completion( struct object *root, const struct u
-         {
-             list_init( &completion->queue );
+@@ -275,6 +294,7 @@
+             list_init( &completion->wait_queue );
              completion->depth = 0;
              completion->closed = 0;
 +            completion->fast_sync = NULL;
          }
      }
-@@ -165,6 +180,7 @@ void add_completion( struct completion *completion, apc_param_t ckey, apc_param_
+ 
+@@ -308,6 +328,7 @@
          if (list_empty( &completion->queue )) return;
      }
      if (!list_empty( &completion->queue )) wake_up( &completion->obj, 0 );
@@ -1838,7 +1847,7 @@ index 6933195..5ec6d20 100644
  }
  
  /* create a completion */
-@@ -231,6 +247,8 @@ DECL_HANDLER(remove_completion)
+@@ -404,6 +425,8 @@
          reply->information = msg->information;
          free( msg );
          reply->wait_handle = 0;


### PR DESCRIPTION
This patches doesn`t have code for completion.c which cause wineserver crash in Battle.Net

Should fix this #1327 and possibly this #1322