### PR TITLE
Add clarification

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -70,7 +70,7 @@ _use_fastsync="false"
 # !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!
 # !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
 # !! Not compatible with Valve trees !!
-# Set to ntsync7 when using ntsync5 v7 kernel driver (Available in linux-cachyos 6.12.6)
+# Set to ntsync7 when using ntsync5 v7 kernel driver (Available in linux-cachyos and linux-zen, since 6.12.6)
 _use_ntsync="false"
 
 # esync - Enable with WINEESYNC=1 envvar - Set to true to enable esync support on plain wine or wine-staging <4.6 (it got merged in wine-staging 4.6). The option is ignored on wine-staging 4.6+


### PR DESCRIPTION
ntsync5 v7 also in linux-zen, since 6.12.6

https://github.com/zen-kernel/zen-kernel/releases/tag/v6.12.6-zen1

No API/ABI mismatches found in compiling/running wine-10.0rc3.r0.gf10d2d04