### PR TITLE
Fix `incompatible-pointer-types` error in CSMT-toggle patchset (for GCC 14+)

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/CSMT-toggle/CSMT-toggle.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/CSMT-toggle/CSMT-toggle.patch
@@ -71,7 +71,7 @@ index 00000000..6ff97674
 ++    else
 ++    {
 ++        // FALSE, we remove the csmt key letting wine use its default
-++        set_reg_key(config_key, "Direct3D", L"csmt", NULL);
+++        set_reg_key(config_key, L"Direct3D", L"csmt", NULL);
 ++    }
 + }
 + 


### PR DESCRIPTION
Fixes #1349.

With this patch, I can build wine-staging successfully using GCC 14.2.1 (without additional error suppression flags).