### PR TITLE
build.sh: Add _new_makefiles check in _package_makepkg().

### DIFF
--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -379,7 +379,12 @@ _package_makepkg() {
 
 	# External install
 	if [ "$_EXTERNAL_INSTALL" = "true" ]; then
-		_lib32name="lib" && _lib64name="lib64"
+		if [ "$_new_makefiles" = "true" ]; then
+			_lib32name="lib" && _lib64name="lib"
+		else
+			_lib32name="lib" && _lib64name="lib64"
+		fi
+
 		if [ "$_EXTERNAL_NOVER" = "true" ]; then
 			_prefix="$_DEFAULT_EXTERNAL_PATH/$pkgname"
 		else

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -370,7 +370,7 @@ _package_nomakepkg() {
 
 _package_makepkg() {
 	local _prefix=/usr
-	if (cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8c3f205696571558a6fae42314370fbd7cc14a12 HEAD); then
+	if [ "$_new_makefiles" = "true" ]; then
 		local _lib32name="lib"
 	else
 		local _lib32name="lib32"


### PR DESCRIPTION
Fixes https://github.com/Frogging-Family/wine-tkg-git/issues/1374 for external install with makepkg builds.