### PR TITLE
Add new patch: enable_dynamic_wow64_def

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/enable_dynamic_wow64_def/enable_dynamic_wow64_def
+++ b/wine-tkg-git/wine-tkg-patches/misc/enable_dynamic_wow64_def/enable_dynamic_wow64_def
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+	# Enable new dynamic WINEARCH=wow64 by default
+	if [ "$_NOLIB32" = "wow64" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 765ea3470ad96dfcbd8ce4c239225206ea41be8a HEAD ); then
+	  _patchname='enable_dynamic_wow64_def.patch' && _patchmsg="Enable WINEARCH=wow64 by default" && nonuser_patcher
+	fi

--- a/wine-tkg-git/wine-tkg-patches/misc/enable_dynamic_wow64_def/enable_dynamic_wow64_def.patch
+++ b/wine-tkg-git/wine-tkg-patches/misc/enable_dynamic_wow64_def/enable_dynamic_wow64_def.patch
@@ -1,0 +1,11 @@
+--- a/dlls/ntdll/unix/loader.c	2025-02-23 02:31:43.695646158 +0500
++++ b/dlls/ntdll/unix/loader.c	2025-02-23 04:17:16.924362254 +0500
+@@ -542,7 +542,7 @@
+ char *get_alternate_wineloader( WORD machine )
+ {
+     const char *arch;
+-    BOOL force_wow64 = (arch = getenv( "WINEARCH" )) && !strcmp( arch, "wow64" );
++    BOOL force_wow64 = !(arch = getenv( "WINEARCH" )) || !strcmp( arch, "wow64" );
+     char *ret = NULL;
+ 
+     if (is_win64)

--- a/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
+++ b/wine-tkg-git/wine-tkg-profiles/advanced-customization.cfg
@@ -66,6 +66,7 @@ _log_errors_to_file="false"
 
 # Set to "true" to disable usage of 32-bit unix libs and disable 32-bit apps support.
 # Set to "wow64" to use Wine 8.0+ experimental WoW64 (32on64) for 32-bit apps.
+# For wine 10.2 and higher "wow64" also enable WINEARCH=wow64 by default
 # Default is "false".
 _NOLIB32="false"
 

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -1000,6 +1000,7 @@ _prepare() {
                    "$_where/wine-tkg-patches/game-specific/mtga/mtga"
                    "$_where/wine-tkg-patches/proton/proton_mf_hacks/proton_mf_hacks"
                    "$_where/wine-tkg-patches/misc/enable_stg_shared_mem_def/enable_stg_shared_mem_def"
+		   "$_where/wine-tkg-patches/misc/enable_dynamic_wow64_def/enable_dynamic_wow64_def"
                    "$_where/wine-tkg-patches/misc/nvidia-hate/nvidia-hate"
                    "$_where/wine-tkg-patches/misc/kernelbase-reverts/kernelbase-reverts"
                    "$_where/wine-tkg-patches/proton/LAA/LAA"


### PR DESCRIPTION
This patch apply when enable wow64 on wine 10.2 and higher. This make WINEARCH=wow64 enable by default