### PR TITLE
scripts: Package all lib files in one forder

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -410,8 +410,14 @@ build() {
   _prebuild_common
 
   local _prefix=/usr
-  local _lib32name="lib32"
   local _lib64name="lib"
+  if (cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8c3f205696571558a6fae42314370fbd7cc14a12 HEAD); then
+    local _new_makefiles="true"
+    local _lib32name="lib"
+  else
+    local _new_makefiles="false"
+    local _lib32name="lib32"
+  fi
 
   # configure args
   if [ -n "$_configure_userargs64" ]; then
@@ -423,7 +429,11 @@ build() {
 
   # External install
   if [ "$_EXTERNAL_INSTALL" = "true" ]; then
+  if [ "$_new_makefiles" = "true" ]; then
+    _lib32name="lib" && _lib64name="lib"
+  else
     _lib32name="lib" && _lib64name="lib64"
+  fi
     if [ "$_EXTERNAL_NOVER" = "true" ]; then
       _prefix="$_DEFAULT_EXTERNAL_PATH/$pkgname"
     else

--- a/wine-tkg-git/non-makepkg-build.sh
+++ b/wine-tkg-git/non-makepkg-build.sh
@@ -282,6 +282,12 @@ build_wine_tkg() {
     ## prepare step end
   fi
 
+  if (cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8c3f205696571558a6fae42314370fbd7cc14a12 HEAD); then
+    local _new_makefiles="true"
+  else
+    local _new_makefiles="false"
+  fi
+
   pkgver=$(pkgver)
 
   _polish
@@ -303,10 +309,18 @@ build_wine_tkg() {
     local _lib32name="lib"
     local _lib64name="lib"
   elif [ -e /lib ] && [ -e /lib64 ] && [ -d /usr/lib ] && [ -d /usr/lib32 ] && [ "$_EXTERNAL_INSTALL" != "proton" ]; then
-    local _lib32name="lib32"
+    if [ "$_new_makefiles" = "true" ]; then
+      local _lib32name="lib"
+    else
+      local _lib32name="lib32"
+    fi
     local _lib64name="lib"
   else
-    local _lib32name="lib"
+    if [ "$_new_makefiles" = "true" ]; then
+      local _lib32name="lib64"
+    else
+      local _lib32name="lib"
+    fi
     local _lib64name="lib64"
   fi
 

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -278,13 +278,15 @@ _package_nomakepkg() {
 	fi
 
 	# This fix for new makefiles. Should work for old wine
-	if [ "$_NOLIB32" = "false" ]; then
-		cd "$_prefix"/"$_lib32name"/wine/
+	if [ "$_EXTERNAL_INSTALL" = "proton" ] && [ "$_NOLIB32" != "true" ] && [ "$_new_makefiles" = "true" ]; then
+		mkdir -v "$_prefix"/lib/ && mkdir -v "$_prefix"/lib/wine
+		cd "$_prefix"/lib/wine/
 		ln -s ../../"$_lib64name"/wine/x86_64-windows ./
   		ln -s ../../"$_lib64name"/wine/x86_64-unix ./
-		cd "$_prefix"/"$_lib64name"/wine/
-		ln -s ../../"$_lib32name"/wine/i386-windows ./
-		ln -s ../../"$_lib32name"/wine/i386-unix ./
+		ln -s ../../"$_lib64name"/wine/i386-windows ./
+		if [ "$_NOLIB32" != "wow64" ]; then
+			ln -s ../../"$_lib64name"/wine/i386-unix ./
+		fi
 	fi
 
 	# strip

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -211,10 +211,18 @@ _package_nomakepkg() {
 		local _lib32name="lib"
 		local _lib64name="lib"
 	elif [ -e /lib ] && [ -e /lib64 ] && [ -d /usr/lib ] && [ -d /usr/lib32 ] && [ "$_EXTERNAL_INSTALL" != "proton" ]; then
-		local _lib32name="lib32"
+		if [ "$_new_makefiles" = "true" ]; then
+			local _lib32name="lib"
+		else
+			local _lib32name="lib32"
+		fi
 		local _lib64name="lib"
 	else
-		local _lib32name="lib"
+		if [ "$_new_makefiles" = "true" ]; then
+			local _lib32name="lib64"
+		else
+			local _lib32name="lib"
+		fi
 		local _lib64name="lib64"
 	fi
 
@@ -372,12 +380,20 @@ _package_nomakepkg() {
 
 _package_makepkg() {
 	local _prefix=/usr
-	local _lib32name="lib32"
+	if [ "$_new_makefiles" = "true" ]; then
+		local _lib32name="lib"
+	else
+		local _lib32name="lib32"
+	fi
 	local _lib64name="lib"
 
 	# External install
 	if [ "$_EXTERNAL_INSTALL" = "true" ]; then
-		_lib32name="lib" && _lib64name="lib64"
+		if [ "$_new_makefiles" = "true" ]; then
+			_lib32name="lib" && _lib64name="lib"
+		else
+			_lib32name="lib" && _lib64name="lib64"
+		fi
 		if [ "$_EXTERNAL_NOVER" = "true" ]; then
 			_prefix="$_DEFAULT_EXTERNAL_PATH/$pkgname"
 		else
@@ -452,14 +468,14 @@ _package_makepkg() {
 	fi
 
 	# This fix for new makefiles. Should work for old wine
-	if [ "$_NOLIB32" = "false" ]; then
-		cd "${pkgdir}$_prefix"/"$_lib32name"/wine/
-		ln -s ../../"$_lib64name"/wine/x86_64-windows ./
-  		ln -s ../../"$_lib64name"/wine/x86_64-unix ./
-		cd "${pkgdir}$_prefix"/"$_lib64name"/wine/
-		ln -s ../../"$_lib32name"/wine/i386-windows ./
-		ln -s ../../"$_lib32name"/wine/i386-unix ./
-	fi
+#	if [ "$_NOLIB32" = "false" ]; then
+#		cd "${pkgdir}$_prefix"/"$_lib32name"/wine/
+#		ln -s ../../"$_lib64name"/wine/x86_64-windows ./
+#  		ln -s ../../"$_lib64name"/wine/x86_64-unix ./
+#		cd "${pkgdir}$_prefix"/"$_lib64name"/wine/
+#		ln -s ../../"$_lib32name"/wine/i386-windows ./
+#		ln -s ../../"$_lib32name"/wine/i386-unix ./
+#	fi
 
 	# strip
 	if [ "$_EXTERNAL_INSTALL" != "proton" ]; then


### PR DESCRIPTION
Should fix configure since upstream check if lib files in one folder. If is not to give error

For proton-tkg script put lib files in `lib64` folder and create `lib` folder where put symlinks