### PR TITLE
Update wow64_loader_hack.patch

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton_eac/wow64_loader_hack.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton-tkg-specific/proton_eac/wow64_loader_hack.patch
@@ -21,7 +21,7 @@ index dd139950e10..c03a5c8e760 100644
  
 -AC_SUBST(WINELOADER_PROGRAMS,"wine")
 +case "$HOST_ARCH,$PE_ARCHS" in
-+  x86_64,*i386*) wine_binary="wine" ;;
++  x86_64,i386) wine_binary="wine" ;;
 +  x86_64,*) wine_binary="wine64" ;;
 +  *) wine_binary="wine" ;;
 +esac


### PR DESCRIPTION
Hi! It's me... OZ.
With this modification... should also work with [_NOLIB32="wow64"](https://github.com/Frogging-Family/wine-tkg-git/issues/1395).