### PR TITLE
legacy-ntdll-writecopy: Disable hotfix

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/legacy_ntdll_writecopy/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/legacy_ntdll_writecopy/hotfixes
@@ -1,10 +1,15 @@
 #!/bin/bash
 
 # legacy ntdll-WRITECOPY need for protonify
-if [ "$_protonify" = "true" ] && [ "$_NOLIB32" != "wow64" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 16dce521242b3f4a52cd2c8799ce6fe464fac83c HEAD ); then
+if [ "$_protonify" = "true" ] && [ "$_NOLIB32" != "wow64" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 16dce521242b3f4a52cd2c8799ce6fe464fac83c HEAD ) && ! ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor b201cd518f3448553c31e329d5504b94f21d84ce HEAD ); then
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/legacy_ntdll_writecopy/legacy-ntdll-writecopy)
   if [ "$_use_staging" = "false" ]; then
     _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/legacy_ntdll_writecopy/additional-for-nonstaging)
   fi
   warning "Hotfix: Apply legacy ntdll-WRITECOPY for protonify patches"
+fi
+
+if [ "$_use_staging" = "false" ] && [ "$_protonify" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor b201cd518f3448553c31e329d5504b94f21d84ce HEAD ); then
+  _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/legacy_ntdll_writecopy/additional-for-nonstaging)
+  warning "Hotfix: Apply ntdll-WRITECOPY for non-staging build"
 fi


### PR DESCRIPTION
This patch no longer using in proton, now this only apply additional-for-nonstaging.mypatch