### PR TITLE
Properly name the NTSYNC action

### DIFF
--- a/.github/workflows/proton-arch-ntsync-nopackage.yml
+++ b/.github/workflows/proton-arch-ntsync-nopackage.yml
@@ -1,4 +1,4 @@
-name: Proton nopackage Arch Linux CI
+name: Proton nopackage Arch Linux NTSYNC CI
 
 on:
   schedule:


### PR DESCRIPTION
The ntsync action was using the same name as the regular one, making it difficult to single out from the rest