### PR TITLE
earlyhotfixer: Fix missing parenthesis that prevented build

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/earlyhotfixer
@@ -223,7 +223,7 @@ EOM
     fi
 
     # Fix broken staging commit 6912feaf
-    if ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 6912feaf6590508836f1cb521fd8a85896506789 HEAD; then
+    if ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 6912feaf6590508836f1cb521fd8a85896506789 HEAD; ) then
       warning "Disable broken winedevice-Default_Drivers patchset on staging 6912feaf"
       _staging_args+=(-W winedevice-Default_Drivers)
     fi


### PR DESCRIPTION
This PR fixes a syntax error caused by a missing parenthesis in earlyhotfixer. The issue was preventing the project from building successfully. 
This resolves the typo that broke the build when attempting to fix #1438.

Related to  #1440, #1438