### PR TITLE
proton-tkg: Add support for PROTON_ENABLE_WAYLAND and PROTON_HDR

### DIFF
--- a/proton-tkg/proton_template/conf/proton
+++ b/proton-tkg/proton_template/conf/proton
@@ -1501,6 +1501,8 @@ class Session:
             self.check_environment("PROTON_USE_WINED3D11", "wined3d11only")
             self.check_environment("PROTON_USE_WINED3D9", "wined3d9only")
 
+        self.check_environment("PROTON_ENABLE_WAYLAND", "enablewayland")
+        self.check_environment("PROTON_ENABLE_HDR", "enablehdr")
         self.check_environment("PROTON_USE_WINE_DXGI", "winedxgi")
         self.check_environment("PROTON_NO_D3D11", "nod3d11")
         self.check_environment("PROTON_NO_D3D10", "nod3d10")
@@ -1542,6 +1544,14 @@ class Session:
             self.env.setdefault("MESA_SHADER_CACHE_DIR", g_compatdata.prefix_dir)
         elif "shadercachepath" in self.compat_config:
             self.env["MESA_SHADER_CACHE_DIR"] = self.env["PROTON_BYPASS_SHADERCACHE_PATH"] + "/" + os.environ["SteamGameId"]
+
+        if "enablewayland" in self.compat_config:
+            if self.env.get("WAYLAND_DISPLAY", False):
+                self.dlloverrides["winex11.drv"] = "d"
+                self.dlloverrides["winewayland.drv"] = "b"
+                self.env["WINE_WAYLAND_HACKS"] = "1"
+                if "enablehdr" in self.compat_config:
+                    self.env["DXVK_HDR"] = "1"
 
         if "noesync" in self.compat_config:
             self.env.pop("WINEESYNC", "")


### PR DESCRIPTION
For now WINE_WAYLAND_HACKS don't work (Missing patches for wine)