### PR TITLE
Fix arch linux ntsync build action

### DIFF
--- a/.github/workflows/proton-arch-ntsync-nopackage.yml
+++ b/.github/workflows/proton-arch-ntsync-nopackage.yml
@@ -24,15 +24,6 @@ jobs:
           useradd -m -G wheel -s /bin/bash user
           echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-      - name: Build and Install ntsync-header from PKGBUILD
-        run: |
-          sudo -u user bash -c "
-            cd ~
-            git clone https://aur.archlinux.org/ntsync.git
-            cd ntsync
-            makepkg -si --noconfirm
-          "
-
       - name: Compile Proton-TKG
         run: |
           chown -R user:user $PWD


### PR DESCRIPTION
ntsync header no longer need since this part of linux-headers