### PR TITLE
Enable wayland driver by default

### DIFF
--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -94,7 +94,7 @@ _use_fsync="true"
 
 # Set to true to pass --with-wayland --with-vulkan configure arguments
 # !! Requires a compatible wine tree (9.0+ recommended) !!
-_wayland_driver="false"
+_wayland_driver="true"
 
 _plain_version=""
 _use_staging="true"

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -86,7 +86,7 @@ _use_fsync="true"
 
 # Set to true to pass --with-wayland --with-vulkan configure arguments
 # !! Requires a compatible wine tree (9.0+ recommended) !!
-_wayland_driver="false"
+_wayland_driver="true"
 
 
 #### GAME-SPECIFIC PATCHES ####

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -82,6 +82,8 @@ _prebuild_common() {
 		# Wayland driver
 		if [ "$_wayland_driver" = "true" ]; then
 			_configure_args+=(--with-wayland --with-vulkan)
+		else
+			_configure_args+=(--without-wayland)
 		fi
 	fi
 


### PR DESCRIPTION
We build wayland driver long ago since --with-wayland been default looks like between 9.21 and 10.0
Should fix #1502 