### PR TITLE
hotfixes: Revert upstream commit causing flickering mangohud in wayland

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/hotfixer
@@ -46,6 +46,7 @@ if [ "$_unfrog" != "true" ]; then
   _hotfix="legacy_ntdll_writecopy" _hotfix_boundary="" _hotfix_import
   _hotfix="shm_esync_fsync" _hotfix_boundary="" _hotfix_import
   _hotfix="autoconf-opencl-hotfix" _hotfix_boundary="" _hotfix_import
+  _hotfix="winewayland" _hotfix_boundary="" _hotfix_import
 
   # Custom hotfix patches with a commit boundary
   _hotfix="fd799297" _hotfix_boundary="1f6423f778f7036a3875613e10b9c8c3b84584f0" _hotfix_import
@@ -68,7 +69,6 @@ if [ "$_unfrog" != "true" ]; then
   _hotfix="1e35966" _hotfix_boundary="7b51216198237c04a8994cda1bdb45fdb4482b32" _hotfix_import
   _hotfix="staging_aeddc19_SOURCES" _hotfix_boundary="137638e185e9302602bcd9cc796d7bcfa03caee5" _hotfix_import
   _hotfix="rdr2" _hotfix_boundary="ce2ae79f9d9c64bbac54701e6538cd9dca1b8ae7" _hotfix_import
-  _hotfix="winewayland" _hotfix_boundary="1e701a6b3798ecfd688ad1ff405dbb62b3d214c6" _hotfix_import
   _hotfix="binutils" _hotfix_boundary="c9519f68ea04915a60704534ab3afec5ec1b8fd7" _hotfix_import
   _hotfix="makefiles" _hotfix_boundary="9a7d0ffbfe32d295720b2fcb8ef8699ec7dab923" _hotfix_import
 else

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/de0fc7fd95074cfdeb032d36246c56247d2bd82b.myrevert
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/de0fc7fd95074cfdeb032d36246c56247d2bd82b.myrevert
@@ -1,0 +1,143 @@
+From de0fc7fd95074cfdeb032d36246c56247d2bd82b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Fri, 30 May 2025 10:24:20 +0200
+Subject: [PATCH 6/6] winewayland: Switch client surfaces when presenting.
+
+---
+ dlls/winewayland.drv/opengl.c     |  5 +++-
+ dlls/winewayland.drv/vulkan.c     |  5 +++-
+ dlls/winewayland.drv/waylanddrv.h |  1 +
+ dlls/winewayland.drv/window.c     | 41 +++++++++++--------------------
+ 4 files changed, 23 insertions(+), 29 deletions(-)
+
+diff --git a/dlls/winewayland.drv/opengl.c b/dlls/winewayland.drv/opengl.c
+index a9f0e2d259e..0b7595c3dcf 100644
+--- a/dlls/winewayland.drv/opengl.c
++++ b/dlls/winewayland.drv/opengl.c
+@@ -179,7 +179,8 @@ static struct wayland_gl_drawable *wayland_gl_drawable_create(HWND hwnd, HDC hdc
+     /* Get the client surface for the HWND. If don't have a wayland surface
+      * (e.g., HWND_MESSAGE windows) just create a dummy surface to act as the
+      * target render surface. */
+-    if (!(gl->client = get_client_surface(hwnd))) goto err;
++    if (!(gl->client = wayland_client_surface_create(hwnd))) goto err;
++    set_client_surface(hwnd, gl->client);
+ 
+     gl->wl_egl_window = wl_egl_window_create(gl->client->wl_surface, width, height);
+     if (!gl->wl_egl_window)
+@@ -493,6 +494,8 @@ static BOOL wayland_swap_buffers(void *private, HWND hwnd, HDC hdc, int interval
+ 
+     if (ctx) wayland_context_refresh(ctx);
+     ensure_window_surface_contents(toplevel);
++    set_client_surface(hwnd, gl->client);
++
+     /* Although all the EGL surfaces we create are double-buffered, we want to
+      * use some as single-buffered, so avoid swapping those. */
+     if (gl->double_buffered) funcs->p_eglSwapBuffers(egl->display, gl->surface);
+diff --git a/dlls/winewayland.drv/vulkan.c b/dlls/winewayland.drv/vulkan.c
+index 4774f11771c..e619cfb4fa0 100644
+--- a/dlls/winewayland.drv/vulkan.c
++++ b/dlls/winewayland.drv/vulkan.c
+@@ -74,7 +74,7 @@ static VkResult wayland_vulkan_surface_create(HWND hwnd, const struct vulkan_ins
+ 
+     TRACE("%p %p %p %p\n", hwnd, instance, surface, private);
+ 
+-    if (!(client = get_client_surface(hwnd)))
++    if (!(client = wayland_client_surface_create(hwnd)))
+     {
+         ERR("Failed to create client surface for hwnd=%p\n", hwnd);
+         return VK_ERROR_OUT_OF_HOST_MEMORY;
+@@ -96,6 +96,7 @@ static VkResult wayland_vulkan_surface_create(HWND hwnd, const struct vulkan_ins
+         return res;
+     }
+ 
++    set_client_surface(hwnd, client);
+     *private = client;
+ 
+     TRACE("Created surface=0x%s, private=%p\n", wine_dbgstr_longlong(*surface), *private);
+@@ -121,8 +122,10 @@ static void wayland_vulkan_surface_update(HWND hwnd, void *private)
+ 
+ static void wayland_vulkan_surface_presented(HWND hwnd, void *private, VkResult result)
+ {
++    struct wayland_client_surface *client = private;
+     HWND toplevel = NtUserGetAncestor(hwnd, GA_ROOT);
+     ensure_window_surface_contents(toplevel);
++    set_client_surface(hwnd, client);
+ }
+ 
+ static VkBool32 wayland_vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice phys_dev,
+diff --git a/dlls/winewayland.drv/waylanddrv.h b/dlls/winewayland.drv/waylanddrv.h
+index 001cb29e05e..e0be6970b05 100644
+--- a/dlls/winewayland.drv/waylanddrv.h
++++ b/dlls/winewayland.drv/waylanddrv.h
+@@ -377,6 +377,7 @@ struct wayland_win_data *wayland_win_data_get_nolock(HWND hwnd);
+ void wayland_win_data_release(struct wayland_win_data *data);
+ 
+ struct wayland_client_surface *get_client_surface(HWND hwnd);
++void set_client_surface(HWND hwnd, struct wayland_client_surface *client);
+ BOOL set_window_surface_contents(HWND hwnd, struct wayland_shm_buffer *shm_buffer, HRGN damage_region);
+ struct wayland_shm_buffer *get_window_surface_contents(HWND hwnd);
+ void ensure_window_surface_contents(HWND hwnd);
+diff --git a/dlls/winewayland.drv/window.c b/dlls/winewayland.drv/window.c
+index ce5b6bb5143..dbcbd90be00 100644
+--- a/dlls/winewayland.drv/window.c
++++ b/dlls/winewayland.drv/window.c
+@@ -775,42 +775,29 @@ LRESULT WAYLAND_SysCommand(HWND hwnd, WPARAM wparam, LPARAM lparam, const POINT
+     return ret;
+ }
+ 
+-/**********************************************************************
+- *          get_client_surface
+- */
+-struct wayland_client_surface *get_client_surface(HWND hwnd)
++void set_client_surface(HWND hwnd, struct wayland_client_surface *new_client)
+ {
+     HWND toplevel = NtUserGetAncestor(hwnd, GA_ROOT);
+-    struct wayland_client_surface *client;
++    struct wayland_client_surface *old_client;
+     struct wayland_win_data *data;
+ 
+-    if ((data = wayland_win_data_get(hwnd)))
+-    {
+-        /* ownership is shared with one of the callers, the last caller to release
+-         * its reference will also destroy it and clear our pointer. */
+-        if ((client = data->client_surface)) InterlockedIncrement(&client->ref);
+-    }
+-    else
+-    {
+-        client = NULL;
+-    }
++    /* ownership is shared with the callers, the last caller to release
++     * its reference will also destroy it and clear our pointer. */
+ 
+-    if (!client && !(client = wayland_client_surface_create(hwnd)))
+-    {
+-        if (data) wayland_win_data_release(data);
+-        return NULL;
+-    }
+-    if (!data) return client;
++    if (!(data = wayland_win_data_get(hwnd))) return;
+ 
+-    if (toplevel && NtUserIsWindowVisible(hwnd))
+-        wayland_client_surface_attach(client, toplevel);
+-    else
+-        wayland_client_surface_detach(client);
++    if ((old_client = data->client_surface))
++        wayland_client_surface_detach(old_client);
+ 
+-    if (!data->client_surface) data->client_surface = client;
++    if ((data->client_surface = new_client))
++    {
++        if (toplevel && NtUserIsWindowVisible(hwnd))
++            wayland_client_surface_attach(new_client, toplevel);
++        else
++            wayland_client_surface_detach(new_client);
++    }
+ 
+     wayland_win_data_release(data);
+-    return client;
+ }
+ 
+ BOOL set_window_surface_contents(HWND hwnd, struct wayland_shm_buffer *shm_buffer, HRGN damage_region)
+-- 
+GitLab
+

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/winewayland/hotfixes
@@ -1,7 +1,18 @@
 #!/bin/bash
 
+# Fix Weird behavior on vulkan caused by regression
+if [ "$_wayland_driver" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor de0fc7fd95074cfdeb032d36246c56247d2bd82b HEAD); then
+  if [ "$_hotfixes_no_confirm" != "true" ] && [ "$_hotfixes_no_confirm" != "ignore" ]; then
+    warning "Hotfix: Upstream commit de0fc7f cause flickering in DXVK and VKD3D on winewayland."
+    read -rp "Are you okay to revert this ?"$'\n> N/y : ' _hotfixansw;
+  fi
+  if [[ "$_hotfixansw" =~ [yY] ]] || [ "$_hotfixes_no_confirm" = "true" ]; then
+    _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/winewayland/de0fc7fd95074cfdeb032d36246c56247d2bd82b)
+  fi
+fi
+
 # Fix wine freeze when run with wine wayland driver
-if [ "$_wayland_driver" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fe7e94d58c2596c23b407c5a0cd11b57f001d4dd HEAD ); then
+if [ "$_wayland_driver" = "true" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor fe7e94d58c2596c23b407c5a0cd11b57f001d4dd HEAD && ! git merge-base --is-ancestor 1e701a6b3798ecfd688ad1ff405dbb62b3d214c6 HEAD ); then
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/winewayland/winewayland-avoid-crashing)
   warning "Hotfix: Fix wayland driver crash"
 fi


### PR DESCRIPTION
This bug caused by commit de0fc7fd95074cfdeb032d36246c56247d2bd82b (winewayland: Switch client surfaces when presenting)
I found bug in unreal engine games using DXVK and VKD3D.