### PR TITLE
ADD FSR4 amdcxffx64.dll

### DIFF
--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -55,6 +55,13 @@ _use_dxvk="git"
 _proton_dxvk_hud=""
 _proton_dxvk_configfile=""
 
+# Add FSR4 amdxcffx64.dll to proton prefix, only works on 64 bit.
+# Valid options::
+# "latest" - use latest
+# "version" - set to a version, see subfolders: https://download.amd.com/dir/bin/amdxcffx64.dll 
+# "false" - disabled
+_use_fsr4="latest"
+
 
 # WINE FLAVOUR SETTINGS
 

--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -55,6 +55,9 @@ _use_dxvk="git"
 _proton_dxvk_hud=""
 _proton_dxvk_configfile=""
 
+
+# FSR4
+
 # Add FSR4 amdxcffx64.dll to proton prefix, only works on 64 bit.
 # Valid options::
 # "latest" - use latest

--- a/proton-tkg/proton_template/conf/proton
+++ b/proton-tkg/proton_template/conf/proton
@@ -804,6 +804,7 @@ class CompatData:
             use_custom9 = "custom9" in g_session.compat_config
             use_wine_dxgi = "WINEDLLOVERRIDES" in g_session.env and "dxgi=b" in g_session.env["WINEDLLOVERRIDES"]
             use_nvapi = 'enablenvapi' in g_session.compat_config
+            use_fsr4upgrade = 'fsr4upgrade' in g_session.compat_config
 
             builtin_dll_copy = os.environ.get("PROTON_DLL_COPY",
                     #dxsetup redist
@@ -1016,6 +1017,7 @@ class CompatData:
                 str(use_wine_dxgi),
                 builtin_dll_copy,
                 str(use_nvapi),
+                str(use_fsr4upgrade),
             ))
 
             # check whether any prefix config has changed
@@ -1102,6 +1104,15 @@ class CompatData:
                         try_copy(g_proton.lib_dir + "wine/dxvk/" + f + ".dll",
                                 self.prefix_dir + "drive_c/windows/syswow64/" + f + ".dll")
                         g_session.dlloverrides[f] = "n"
+
+                if use_fsr4upgrade and file_exists(g_proton.lib64_dir + "wine/amdxcffx64/amdxcffx64.dll", follow_symlinks=False):
+                    try_copy(g_proton.lib64_dir + "wine/amdxcffx64/amdxcffx64.dll", "drive_c/windows/system32",
+                            prefix=self.prefix_dir, track_file=tracked_files)
+                    g_session.dlloverrides["amdxcffx64"] = "n"
+                else:
+                    fsr4_dll = self.prefix_dir + "drive_c/windows/amdxcffx64/amdxcffx64.dll"
+                    if file_exists(fsr4_dll, follow_symlinks=False):
+                        os.unlink(fsr4_dll)
 
                 # If the user requested the NVAPI be available, copy it into place.
                 # If they didn't, clean up any stray nvapi DLLs.
@@ -1522,6 +1533,7 @@ class Session:
         self.check_environment("PROTON_NO_XIM", "noxim")
         self.check_environment("PROTON_HEAP_DELAY_FREE", "heapdelayfree")
         self.check_environment("PROTON_ENABLE_NVAPI", "enablenvapi")
+        self.check_environment("PROTON_FSR4_UPGRADE", "fsr4upgrade")
         self.check_environment("PROTON_NVAPI_DISABLE", "nonvapi")
         self.check_environment("PROTON_GLES2_DISABLE", "disablelibglesv2")
         self.check_environment("PROTON_GL_OSMESA", "useglosmesa")
@@ -1687,6 +1699,9 @@ class Session:
 
         if "enablenvapi" in self.compat_config:
             self.env["DXVK_ENABLE_NVAPI"] = "1"
+
+        if "fsr4upgrade" in self.compat_config:
+            self.env["FSR4_UPGRADE"] = "1"
 
         if "nonvapi" in self.compat_config and not "enablenvapi" in self.compat_config:
             self.dlloverrides["nvapi"] = "d"

--- a/proton-tkg/proton_template/conf/user_settings.py
+++ b/proton-tkg/proton_template/conf/user_settings.py
@@ -23,6 +23,9 @@ user_settings = {
     #Enable AMD FSR
      "WINE_FULLSCREEN_FSR": "1",
      "WINE_FULLSCREEN_FSR_STRENGTH": "2",
+    
+    # Enable FSR4 Upgrade
+#    "PROTON_FSR4_UPGRADE": "1",
 
     #Write the command proton sends to wine for targeted prefix (/prefix/path/launch_command) - Helpful to track bound executable
     "PROTON_LOG_COMMAND_TO_PREFIX": "1",

--- a/wine-tkg-git/wine-tkg-scripts/prepare.sh
+++ b/wine-tkg-git/wine-tkg-scripts/prepare.sh
@@ -50,6 +50,7 @@ _exit_cleanup() {
     echo "_proton_winetricks=${_proton_winetricks}" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_proton_use_steamhelper=${_proton_use_steamhelper}" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_proton_mf_hacks=${_proton_mf_hacks}" >> "$_proton_tkg_path"/proton_tkg_token
+    echo "_use_fsr4=${_use_fsr4}" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_use_dxvk=${_use_dxvk}" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_dxvk_version=${_dxvk_version}" >> "$_proton_tkg_path"/proton_tkg_token
     echo "_use_vkd3dlib='${_use_vkd3dlib}'" >> "$_proton_tkg_path"/proton_tkg_token


### PR DESCRIPTION
Add option to pull latest (or specified) amdcxffx64.dll for FSR4 upgrade. The patches are already present, so we might as well add it.
This also adds the option PROTON_FSR4_UPGRADE akin to proton-ge and enables it by default. 
I have tested it with OptiScaler and Cyberpunk 2077. OptiScaler picked up FSR4 without manually installing the DLL into the game directory.