### PR TITLE
hotfixes: Disable hotfix for winedevice-Default_Drivers

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/winedevice-Default_Drivers/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/winedevice-Default_Drivers/hotfixes
@@ -2,7 +2,7 @@
 
 # Fix fail build caused by winedevice-Default_drivers
 
-if [ "$_use_staging" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 6912feaf6590508836f1cb521fd8a85896506789 HEAD ); then
+if [ "$_use_staging" = "true" ] && ( cd "${srcdir}"/"${_stgsrcdir}" && git merge-base --is-ancestor 6912feaf6590508836f1cb521fd8a85896506789 HEAD && ! git merge-base --is-ancestor 5f55fc20dca193a916db484c9833315d5c1445b4 HEAD ); then
   warning "Hotfix: Fix failed build with winedevice-Default_drivers"
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/winedevice-Default_Drivers/0001-wine-staging-Fix-build)
 fi


### PR DESCRIPTION
This no longer need since been fixed by upstream