### PR TITLE
Apply ntsync if "_use_ntsync" set to "legacy"

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -68,8 +68,8 @@ _staging_version=""
 _use_fastsync="false"
 
 # NTsync5 - https://gitlab.winehq.org/wine/wine/-/merge_requests/7226
-# Set to true to build Pre-preparated version of ntsync5. Support up to Wine 10.11 (RECOMMENDED)
-# Set to inproc to build new version of ntsync called Inproc-sync. Supported for Wine 10.11+ (NOT RECOMMENDED! This version is WIP and have issues. Only for testing)
+# Set to true to build new version of ntsync called Inproc-sync. Supported for Wine 10.11+
+# Set to legacy to build Pre-preparated version of ntsync5. Support up to Wine 10.11
 # !! To build, requires full ntsync kernel UAPI header which is available in kernel 6.14+ (if applicable, replace broken ntsync.h from mainline >= 6.10) !!
 # !! For ntsync to be used by wine, requires kernel 6.14+ or ntsync kernel module (from special linux-tkg build, or separately built against kernel >= 6.8 from NTsync5 patchset) !!
 # !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!

--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
@@ -102,7 +102,7 @@
 	    _patchname='fastsync-clock_monotonic-fixup.patch' && _patchmsg="Applied fastsync fix due clock_monotonic" && nonuser_patcher
 	  fi
 
-	elif [ "$_use_ntsync" = "true" ]; then
+	elif [ "$_use_ntsync" = "legacy" ]; then
 
 	  check_ntsync_header
 	  check_esync_and_fsync
@@ -457,7 +457,7 @@
 		  fi
 		fi
 	  fi
-	elif  [ "$_use_ntsync" = "inproc" ]; then
+	elif  [ "$_use_ntsync" = "true" ]; then
 
 	  check_ntsync_header
 	  check_esync_and_fsync

--- a/wine-tkg-git/wine-tkg-patches/proton/proton-winevulkan/proton-winevulkan
+++ b/wine-tkg-git/wine-tkg-patches/proton/proton-winevulkan/proton-winevulkan
@@ -3,7 +3,7 @@
 	    if [ "$_protonify" = "false" ]; then
 	      _patchname='vulkan-1-Prefer-builtin.patch' && _patchmsg="Prefer build vulkan-1 patch" && nonuser_patcher
 		fi
-		if [ "$_use_ntsync" = "true" ]; then
+		if [ "$_use_ntsync" = "legacy" ]; then
 		  _patchname='ntoskrnl-server-Support-referencing-section-objects-ntsync.patch' && _patchmsg="ntoskrnl, server: Support referencing section objects. (Ntsync)" && nonuser_patcher
 		elif [ "$_use_ntsync" = "false" ]; then
 		  _patchname='ntoskrnl-server-Support-referencing-section-objects.patch' && _patchmsg="ntoskrnl, server: Support referencing section objects. (Server side)" && nonuser_patcher

--- a/wine-tkg-git/wine-tkg-scripts/build.sh
+++ b/wine-tkg-git/wine-tkg-scripts/build.sh
@@ -547,7 +547,7 @@ _package_makepkg() {
 		fi
 	fi
 
-	if [ "$_use_fastsync" = "true" ] || [ "$_use_ntsync" = "true" ]; then
+	if [ "$_use_fastsync" = "true" ] || [ "$_use_ntsync" = "legacy" ]; then
 		msg2 '##########################################################################################################################'
 		msg2 ''
 		msg2 'To disable NTsync, export WINE_DISABLE_FAST_SYNC=1'


### PR DESCRIPTION
inproc-sync now is only supported version of fastsync/ntsync