### PR TITLE
customization.cfg: Build with ntsync by default

### DIFF
--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -75,7 +75,7 @@ _use_fastsync="false"
 # !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!
 # !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
 # !! Not compatible with Valve trees currently !!
-_use_ntsync="true"
+_use_ntsync="false"
 
 # esync - Enable with WINEESYNC=1 envvar - Set to true to enable esync support on plain wine or wine-staging <4.6 (it got merged in wine-staging 4.6). The option is ignored on wine-staging 4.6+
 # You may need to raise your fd limits -> https://github.com/zfigura/wine/blob/esync/README.esync


### PR DESCRIPTION
Soon ntsync will be merged into upstream, there is only one MR left and it has already been approved https://gitlab.winehq.org/wine/wine/-/merge_requests/9091. Although I will still support esync/fsync (I'm not sure about fsync, whether it can be used anywhere other than Linux).

I just need to make sure that GitHub Actions continue to work.