### PR TITLE
fastsync: Don't apply patches on Wine 10.16

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
+++ b/wine-tkg-git/wine-tkg-patches/misc/fastsync/fastsync
@@ -33,6 +33,8 @@
 	# fastsync / winesync
 	if [ "$_use_fastsync" = "true" ] || [ "$_use_ntsync" != "false" ] && [[ "$_custom_wine_source" = *"ValveSoftware"* ]]; then # not allowed on Valve tree
 	  error "NTsync/Winesync is not currently supported on Valve trees. It'll be forcibly disabled."
+	elif [ "$_use_fastsync" = "true" ] || [ "$_use_ntsync" != "false" ] && ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor beaa4f3b74b79746b6d9b01fdf8cba53d9b8cc98 HEAD ); then
+	  warning "NTsync was already implemented in Wine 10.16. Don't applying fastsync patches"
 	elif [ "$_use_fastsync" = "true" ]; then
 	  warning "fastsync/Winesync is deprecated and unmaintained and thus its use is discouraged - You're invited to move to its newer NTsync iteration"
 	  # check Linux headers


### PR DESCRIPTION
Wine 10.16 already implement ntsync, so script only print warning and continue.

Should fix #1648 