### PR TITLE
Fix Fedora CI build by pinning to `fedora:42`

### DIFF
--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: fedora:42
     steps:
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the Fedora CI build that's been broken since Dec 4, 2025.

I've previously [opened this issue](https://github.com/Frogging-Family/wine-tkg-git/issues/1684) on this repo about the breaking CI build (since Dec 4, 2025). I investigated the problem and was able to provide and test a simple fix just pinning the base image to Fedora 42.

## What happened
The `fedora:latest` tag switched from Fedora 42 to Fedora 43 on Dec 4, which introduced breaking changes including:
- Removed `mesa-libOSMesa-devel` package (replaced with `mesa-compat-libOSMesa-devel`) and some of the other packages
- YASM deprecation
- GCC 15 with stricter requirements (I didn't dive deeper into that)

## The fix
Changed the Fedora workflow to use `fedora:42` instead of `fedora:latest`.

## Note
This is a temporary fix. I don't know if it makes sense to put effort into updating the build to work with Fedora 43, but this fixes #1684 and gets the CI working again for now.
