### PR TITLE
container fixes: Pass the correct flag to configure.sh if SELinux is enabled

### DIFF
--- a/proton-tkg/proton-tkg.sh
+++ b/proton-tkg/proton-tkg.sh
@@ -847,7 +847,11 @@ function build_in_valve_container {
   sed -i "s|STEAMRT_IMAGE ?= registry.gitlab.steamos.cloud.*|STEAMRT_IMAGE ?= ghcr.io/open-wine-components/umu-sdk:latest|g" Makefile.in
 
   mkdir build && cd build
-  ../configure.sh --enable-ccache --build-name=TKG
+  _configure_flags="--enable-ccache --build-name=TKG"
+  if command -v selinuxenabled > /dev/null && selinuxenabled; then
+    _configure_flags+=" --relabel-volumes"
+  fi
+  ../configure.sh $_configure_flags
   make redist
   echo "_proton_pkgdest='$_nowhere/external-resources/Proton/build/redist'" >> "$_nowhere"/proton_tkg_token
 }


### PR DESCRIPTION
This is required on systems with SELinux since containers won't be able to access any bindmounts and the Proton container engine test will fail.

This shouldn't cause problems on other distros (or ones where SELinux isn't enabled) since selinuxenabled will return a non-zero value if it is disabled (put present) or the command -v call will fail if it isn't found on PATH.

If you'd like me to adjust this in any way, let me know. :smile: 

