### PR TITLE
Add fsync-git replacement to PKGBUILD

### DIFF
--- a/wine-tkg-git/PKGBUILD
+++ b/wine-tkg-git/PKGBUILD
@@ -256,6 +256,7 @@ else
   conflicts=('wine' 'wine-wow64' 'wine-staging' 'wine-esync')
   if [[ "$pkgname" == *-git ]]; then
     replaces=("${pkgname/%-git/-faudio-git}")
+	replaces=("${pkgname/%-git/-fsync-git}")
   fi
 fi
 


### PR DESCRIPTION
allows pacman to replace the previous default package with the new default package