### PR TITLE
Add customizations to proton to fix Warudo

### DIFF
--- a/proton-tkg/proton_template/conf/proton
+++ b/proton-tkg/proton_template/conf/proton
@@ -1354,6 +1354,11 @@ def default_compat_config():
         if appid in [
                 "2079120", #Warudo
                 ]:
+            ret.add("nonvapi")
+
+        if appid in [
+                "2079120", #Warudo
+                ]:
             ret.add("hidenvgpu")
     return ret
 

--- a/proton-tkg/proton_template/conf/proton
+++ b/proton-tkg/proton_template/conf/proton
@@ -1350,6 +1350,11 @@ def default_compat_config():
                 "1249800", #xuan-yuan sword VII
                 ]:
             ret.add("enablenvapi")
+
+        if appid in [
+                "2079120", #Warudo
+                ]:
+            ret.add("hidenvgpu")
     return ret
 
 class Session:


### PR DESCRIPTION
On Proton 9 and up Warudo will crash on launch with NVIDIA cards unless NVAPI is disabled.

This adds Warudo to the list of exceptions for disablenvapi

Also added Warudo to the hidenvgpu section. This prevents a "slow" memory leak, around 360MB an hour.