### PR TITLE
Rebase opencl hotfix against 018943e

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/hotfixes
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/hotfixes
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 # Patch opencl.h header to it's correct location without breaking successive autoconf call, as it was done by the sed workaround
-if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 56a40e1231324cbdba82b3722e163a3368f19a21 HEAD ); then
+if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 018943eb30cdcc13f8f2b25a7c369a9e66349149 HEAD ); then
   warning "Hotfix: Fix for CL/opencl.h header recognition"
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup)
+elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 56a40e1231324cbdba82b3722e163a3368f19a21 HEAD ); then
+  warning "Hotfix: Fix for CL/opencl.h header recognition"
+  _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup-018943e)
 elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 76a44d758b256f1bc91eb8e404f3c168bdb23e92 HEAD ); then
   warning "Hotfix: Fix for CL/opencl.h header recognition"
   _hotfixes+=("$_where"/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup-56a40e12)

--- a/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup-018943e.mypatch
+++ b/wine-tkg-git/wine-tkg-patches/hotfixes/autoconf-opencl-hotfix/opencl-fixup-018943e.mypatch
@@ -1,4 +1,4 @@
-From e4f6c729088ce9633f8b659ba4b98d215cb72372 Mon Sep 17 00:00:00 2001
+From 7b06d5e9906ebb92d4a1dae2fb04120e9c1b60dd Mon Sep 17 00:00:00 2001
 From: llde <lorenzofersteam@live.it>
 Date: Thu, 17 Nov 2022 15:25:45 +0100
 Subject: [PATCH] Explicitly define HAVE_OPENCL_OPENCL_H when checking opencl.h
@@ -9,27 +9,27 @@ Subject: [PATCH] Explicitly define HAVE_OPENCL_OPENCL_H when checking opencl.h
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 1059da94871..dbc8cd41b3a 100644
+index 2bb09f618c7..9cc74660864 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -47,7 +47,7 @@ AC_ARG_WITH(krb5,      AS_HELP_STRING([--without-krb5],[do not use krb5 (Kerbero
- AC_ARG_WITH(mingw,     AS_HELP_STRING([--without-mingw],[do not use the MinGW cross-compiler]))
- AC_ARG_WITH(netapi,    AS_HELP_STRING([--without-netapi],[do not use the Samba NetAPI library]))
+@@ -50,7 +50,7 @@ AC_ARG_WITH(netapi,    AS_HELP_STRING([--without-netapi],[do not use the Samba N
+ AC_ARG_WITH(openal,    AS_HELP_STRING([--without-openal],[do not use OpenAL]),
+             [if test "x$withval" = "xno"; then ac_cv_header_AL_al_h=no; ac_cv_header_OpenAL_al_h=no; fi])
  AC_ARG_WITH(opencl,    AS_HELP_STRING([--without-opencl],[do not use OpenCL]),
--            [if test "x$withval" = "xno"; then ac_cv_header_OpenCL_opencl_h=no; fi])
-+            [if test "x$withval" = "xno"; then ac_cv_header_CL_opencl_h=no; fi])
+-            [if test "x$withval" = "xno"; then ac_cv_header_CL_cl_h=no; ac_cv_header_OpenCL_opencl_h=no; fi])
++            [if test "x$withval" = "xno"; then ac_cv_header_CL_cl_h=no; ac_cv_header_CL_opencl_h=no; fi])
  AC_ARG_WITH(opengl,    AS_HELP_STRING([--without-opengl],[do not use OpenGL]))
+ AC_ARG_WITH(osmesa,     AS_HELP_STRING([--without-osmesa],[do not use the OSMesa library]))
  AC_ARG_WITH(oss,       AS_HELP_STRING([--without-oss],[do not use the OSS sound support]))
- AC_ARG_WITH(pcap,      AS_HELP_STRING([--without-pcap],[do not use the Packet Capture library]))
-@@ -723,7 +723,6 @@ m4_ifdef([AC_SYS_YEAR2038],
-          [test "$ac_cv_sys_file_offset_bits" = 64 && AC_DEFINE(_TIME_BITS,64,[Define to 64 to enable 64-bit time_t])])
+@@ -430,7 +430,6 @@ AC_CHECK_HEADERS(\
  
  AC_CHECK_HEADERS(\
+ 	CL/cl.h \
 -	OpenCL/opencl.h \
  	arpa/inet.h \
  	arpa/nameser.h \
  	asm/termbits.h \
-@@ -805,6 +804,8 @@ AC_CHECK_HEADERS(\
+@@ -515,6 +514,8 @@ AC_CHECK_HEADERS(\
  	valgrind/memcheck.h \
  	valgrind/valgrind.h
  )
@@ -38,15 +38,15 @@ index 1059da94871..dbc8cd41b3a 100644
  AC_HEADER_MAJOR()
  
  dnl **** Checks for headers that depend on other ones ****
-@@ -1025,7 +1026,7 @@ case $host_os in
-         AC_SUBST(COREAUDIO_LIBS,"-framework CoreFoundation -framework CoreAudio -framework AudioUnit -framework AudioToolbox -framework CoreMIDI")
-         enable_winecoreaudio_drv=${enable_winecoreaudio_drv:-yes}
+@@ -754,7 +755,7 @@ case $host_os in
+         AC_DEFINE_UNQUOTED(HAVE_OPENAL,1,[Define to 1 if OpenAL is available])
+         ac_cv_lib_openal=yes
      fi
 -    if test "$ac_cv_header_OpenCL_opencl_h" = "yes"
 +    if test "$ac_cv_header_CL_opencl_h" = "yes"
      then
          AC_SUBST(OPENCL_LIBS,"-framework OpenCL")
-         ac_cv_func_clGetPlatformInfo=yes
+         ac_cv_lib_OpenCL_clGetPlatformInfo=yes
 -- 
-2.55.0
+2.38.1
 


### PR DESCRIPTION
Rebases `opencl-fixup` hotfix to apply on newest Wine.

This patch previously did not apply when compiling 11.12 so I rebased it to work again. Everything compiles and works fine on my end now.

I hope I modified the hotfixes script correctly to account for older versions 🐸