### PR TITLE
Rebase LAA-unix patches against f4c5b041

### DIFF
--- a/wine-tkg-git/wine-tkg-patches/proton/LAA/LAA
+++ b/wine-tkg-git/wine-tkg-patches/proton/LAA/LAA
@@ -3,11 +3,17 @@
 	# IMAGE_FILE_LARGE_ADDRESS_AWARE override - Enable with WINE_LARGE_ADDRESS_AWARE=1
 	if [ "$_large_address_aware" = "true" ]; then
 		if [ "$_NOLIB32" != "wow64" ]; then
-			if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8cba5b8e0f58b529de71db529882aa358ee8fbb4 HEAD ); then
+			if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor f4c5b04148db5fc4e5265beec461d3b7d9f4a789 HEAD ); then
 				if [ "$_use_staging" = "true" ]; then
 					_patchname='LAA-unix-staging-wow64.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
 				else
 					_patchname='LAA-unix-wow64.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
+				fi
+			elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8cba5b8e0f58b529de71db529882aa358ee8fbb4 HEAD ); then
+				if [ "$_use_staging" = "true" ]; then
+					_patchname='LAA-unix-staging-wow64-f4c5b041.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
+				else
+					_patchname='LAA-unix-wow64-f4c5b041.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
 				fi
 			elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e377b7406859213adda6ccf912a4b64753fe88b3 HEAD ); then
 				if [ "$_use_staging" = "true" ]; then
@@ -101,11 +107,17 @@
 				fi
 			fi
 		elif [ "$_NOLIB32" = "wow64" ]; then
-			if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8cba5b8e0f58b529de71db529882aa358ee8fbb4 HEAD ); then
+			if ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor f4c5b04148db5fc4e5265beec461d3b7d9f4a789 HEAD ); then
 				if [ "$_use_staging" = "true" ]; then
 					_patchname='LAA-unix-staging-wow64.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
 				else
 					_patchname='LAA-unix-wow64.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
+				fi
+			elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor 8cba5b8e0f58b529de71db529882aa358ee8fbb4 HEAD ); then
+				if [ "$_use_staging" = "true" ]; then
+					_patchname='LAA-unix-staging-wow64-f4c5b041.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
+				else
+					_patchname='LAA-unix-wow64-f4c5b041.patch' && _patchmsg="Applied large address aware override support" && nonuser_patcher
 				fi
 			elif ( cd "${srcdir}"/"${_winesrcdir}" && git merge-base --is-ancestor e377b7406859213adda6ccf912a4b64753fe88b3 HEAD ); then
 				if [ "$_use_staging" = "true" ]; then

--- a/wine-tkg-git/wine-tkg-patches/proton/LAA/LAA-unix-wow64.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/LAA/LAA-unix-wow64.patch
@@ -1,4 +1,4 @@
-From 245dfe63a720eae04890a8d3e0f74ebae800ffbd Mon Sep 17 00:00:00 2001
+From 9bd9ea5e4dd8b9a33c8922562979ae4c9bb8a76b Mon Sep 17 00:00:00 2001
 From: Steven Noonan <steven@valvesoftware.com>
 Date: Wed, 17 Oct 2018 04:13:37 -0700
 Subject: [PATCH] ntdll/loader: add support for overriding
@@ -6,15 +6,15 @@ Subject: [PATCH] ntdll/loader: add support for overriding
 
 ---
  dlls/kernel32/heap.c           |  8 +++++++-
- dlls/ntdll/ntdll.spec          |  1 +
+ dlls/ntdll/ntdll.spec          |  3 +++
  dlls/ntdll/signal_arm64ec.c    |  1 +
  dlls/ntdll/unix/unix_private.h |  2 ++
  dlls/ntdll/unix/virtual.c      | 22 ++++++++++++++++++++--
  dlls/wow64/system.c            |  6 ++++++
- 6 files changed, 37 insertions(+), 3 deletions(-)
+ 6 files changed, 39 insertions(+), 3 deletions(-)
 
 diff --git a/dlls/kernel32/heap.c b/dlls/kernel32/heap.c
-index 1ec2f5cce0d..10f6895478e 100644
+index 834f4d07e9b..4d27b38ddca 100644
 --- a/dlls/kernel32/heap.c
 +++ b/dlls/kernel32/heap.c
 @@ -42,6 +42,8 @@
@@ -54,13 +54,13 @@ index 1ec2f5cce0d..10f6895478e 100644
          if (lpBuffer->dwTotalPhys > MAXLONG) lpBuffer->dwTotalPhys = MAXLONG;
          if (lpBuffer->dwAvailPhys > MAXLONG) lpBuffer->dwAvailPhys = MAXLONG;
 diff --git a/dlls/ntdll/ntdll.spec b/dlls/ntdll/ntdll.spec
-index 620d96a5992..b3d93326d8c 100644
+index cdd28e31242..db139ca8f7d 100644
 --- a/dlls/ntdll/ntdll.spec
 +++ b/dlls/ntdll/ntdll.spec
-@@ -1625,6 +1625,9 @@
+@@ -1778,6 +1778,9 @@
  @ cdecl -norelay __wine_dbg_output(str)
  @ cdecl -norelay __wine_dbg_strdup(str)
-
+ 
 +# Virtual memory
 +@ stdcall -syscall __wine_needs_override_large_address_aware()
 +
@@ -68,33 +68,33 @@ index 620d96a5992..b3d93326d8c 100644
  @ cdecl wine_get_version()
  @ cdecl wine_get_build_id()
 diff --git a/dlls/ntdll/signal_arm64ec.c b/dlls/ntdll/signal_arm64ec.c
-index 4505aeacfba..d64647f7b45 100644
+index c9815c958c4..ea7243b8207 100644
 --- a/dlls/ntdll/signal_arm64ec.c
 +++ b/dlls/ntdll/signal_arm64ec.c
-@@ -580,6 +580,7 @@
+@@ -348,6 +348,7 @@ ALL_SYSCALLS
  
  #define SYSCALL_API __attribute__((hybrid_patchable))
  
 +DEFINE_SYSCALL_(BOOL, __wine_needs_override_large_address_aware, (void))
  DEFINE_SYSCALL(NtAcceptConnectPort, (HANDLE *handle, ULONG id, LPC_MESSAGE *msg, BOOLEAN accept, LPC_SECTION_WRITE *write, LPC_SECTION_READ *read))
  DEFINE_SYSCALL(NtAccessCheck, (PSECURITY_DESCRIPTOR descr, HANDLE token, ACCESS_MASK access, GENERIC_MAPPING *mapping, PRIVILEGE_SET *privs, ULONG *retlen, ULONG *access_granted, NTSTATUS *access_status))
- DEFINE_SYSCALL(NtAccessCheckAndAuditAlarm, (UNICODE_STRING *subsystem, HANDLE handle, UNICODE_STRING *typename, UNICODE_STRING *objectname, PSECURITY_DESCRIPTOR descr, ACCESS_MASK access, GENERIC_MAPPING *mapping, BOOLEAN creation, ACCESS_MASK *access_granted, BOOLEAN *access_status, BOOLEAN *onclose))
+ DEFINE_SYSCALL(NtAccessCheckAndAuditAlarm, (UNICODE_STRING *subsystem, HANDLE handle, UNICODE_STRING *typename, UNICODE_STRING *objectname, PSECURITY_DESCRIPTOR descr, ACCESS_MASK access, GENERIC_MAPPING *mapping, BOOLEAN creation, ACCESS_MASK *access_granted, NTSTATUS *access_status, BOOLEAN *onclose))
 diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
-index 2f956af6966..007b4fb85bc 100644
+index ef1d9ef5005..c168eccda38 100644
 --- a/dlls/ntdll/unix/unix_private.h
 +++ b/dlls/ntdll/unix/unix_private.h
-@@ -575,4 +575,6 @@ static inline NTSTATUS map_section( HANDLE mapping, void **ptr, SIZE_T *size, UL
-                                0, NULL, size, ViewShare, 0, protect );
- }
+@@ -738,4 +738,6 @@ static inline int is_gdt_sel( WORD sel )
+ 
+ #endif  /* defined(__i386__) || defined(__x86_64__) */
  
 +BOOL WINAPI __wine_needs_override_large_address_aware(void);
 +
  #endif /* __NTDLL_UNIX_PRIVATE_H */
 diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
-index 909c089cf07..31fa04fdab3 100644
+index 26afdae40fb..5d323eda8c7 100644
 --- a/dlls/ntdll/unix/virtual.c
 +++ b/dlls/ntdll/unix/virtual.c
-@@ -4904,6 +4904,24 @@ static void virtual_release_address_space(void)
+@@ -5096,6 +5096,24 @@ static void virtual_release_address_space(void)
  
  #endif  /* _WIN64 */
  
@@ -119,16 +119,16 @@ index 909c089cf07..31fa04fdab3 100644
  
  /***********************************************************************
   *           virtual_set_large_address_space
-@@ -4915,7 +4933,7 @@ void virtual_set_large_address_space(void)
+@@ -5115,7 +5133,7 @@ void virtual_set_large_address_space(void)
                  free_reserved_memory( 0, (char *)0x7ffe0000 );
  #endif
          }
--        else user_space_wow_limit = ((main_image_info.ImageCharacteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE) ? limit_4g : limit_2g) - 1;
-+        else user_space_wow_limit = (is_large_address_aware() ? limit_4g : limit_2g) - 1;
-     }
-     else
-     {
-@@ -4924,7 +4942,7 @@ void virtual_set_large_address_space(void)
+-        else if (main_image_info.ImageCharacteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE)
++        else if (is_large_address_aware())
+         {
+             user_space_wow_limit = limit_4g - 1;
+             /* reserve space for top-down allocations; some apps break if the entire high 2G is available */
+@@ -5125,7 +5143,7 @@ void virtual_set_large_address_space(void)
      }
      else
      {
@@ -138,10 +138,10 @@ index 909c089cf07..31fa04fdab3 100644
      }
      user_space_limit = working_set_limit = address_space_limit;
 diff --git a/dlls/wow64/system.c b/dlls/wow64/system.c
-index 5f3056a4179..2f466d869dd 100644
+index eb57d35f41e..8b108b406d6 100644
 --- a/dlls/wow64/system.c
 +++ b/dlls/wow64/system.c
-@@ -855,3 +855,9 @@ NTSTATUS WINAPI wow64_NtWow64GetNativeSystemInformation( UINT *args )
+@@ -886,3 +886,9 @@ NTSTATUS WINAPI wow64_NtWow64GetNativeSystemInformation( UINT *args )
          return STATUS_INVALID_INFO_CLASS;
      }
  }

--- a/wine-tkg-git/wine-tkg-patches/proton/LAA/legacy/LAA-unix-staging-wow64-f4c5b041.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/LAA/legacy/LAA-unix-staging-wow64-f4c5b041.patch
@@ -1,4 +1,4 @@
-From 9bd9ea5e4dd8b9a33c8922562979ae4c9bb8a76b Mon Sep 17 00:00:00 2001
+From 245dfe63a720eae04890a8d3e0f74ebae800ffbd Mon Sep 17 00:00:00 2001
 From: Steven Noonan <steven@valvesoftware.com>
 Date: Wed, 17 Oct 2018 04:13:37 -0700
 Subject: [PATCH] ntdll/loader: add support for overriding
@@ -6,15 +6,15 @@ Subject: [PATCH] ntdll/loader: add support for overriding
 
 ---
  dlls/kernel32/heap.c           |  8 +++++++-
- dlls/ntdll/ntdll.spec          |  3 +++
+ dlls/ntdll/ntdll.spec          |  1 +
  dlls/ntdll/signal_arm64ec.c    |  1 +
  dlls/ntdll/unix/unix_private.h |  2 ++
  dlls/ntdll/unix/virtual.c      | 22 ++++++++++++++++++++--
  dlls/wow64/system.c            |  6 ++++++
- 6 files changed, 39 insertions(+), 3 deletions(-)
+ 6 files changed, 37 insertions(+), 3 deletions(-)
 
 diff --git a/dlls/kernel32/heap.c b/dlls/kernel32/heap.c
-index 834f4d07e9b..4d27b38ddca 100644
+index 1ec2f5cce0d..10f6895478e 100644
 --- a/dlls/kernel32/heap.c
 +++ b/dlls/kernel32/heap.c
 @@ -42,6 +42,8 @@
@@ -54,13 +54,13 @@ index 834f4d07e9b..4d27b38ddca 100644
          if (lpBuffer->dwTotalPhys > MAXLONG) lpBuffer->dwTotalPhys = MAXLONG;
          if (lpBuffer->dwAvailPhys > MAXLONG) lpBuffer->dwAvailPhys = MAXLONG;
 diff --git a/dlls/ntdll/ntdll.spec b/dlls/ntdll/ntdll.spec
-index cdd28e31242..db139ca8f7d 100644
+index 620d96a5992..b3d93326d8c 100644
 --- a/dlls/ntdll/ntdll.spec
 +++ b/dlls/ntdll/ntdll.spec
-@@ -1778,6 +1778,9 @@
+@@ -1625,6 +1625,9 @@
  @ cdecl -norelay __wine_dbg_output(str)
  @ cdecl -norelay __wine_dbg_strdup(str)
- 
+
 +# Virtual memory
 +@ stdcall -syscall __wine_needs_override_large_address_aware()
 +
@@ -68,33 +68,33 @@ index cdd28e31242..db139ca8f7d 100644
  @ cdecl wine_get_version()
  @ cdecl wine_get_build_id()
 diff --git a/dlls/ntdll/signal_arm64ec.c b/dlls/ntdll/signal_arm64ec.c
-index c9815c958c4..ea7243b8207 100644
+index 4505aeacfba..d64647f7b45 100644
 --- a/dlls/ntdll/signal_arm64ec.c
 +++ b/dlls/ntdll/signal_arm64ec.c
-@@ -348,6 +348,7 @@ ALL_SYSCALLS
+@@ -580,6 +580,7 @@
  
  #define SYSCALL_API __attribute__((hybrid_patchable))
  
 +DEFINE_SYSCALL_(BOOL, __wine_needs_override_large_address_aware, (void))
  DEFINE_SYSCALL(NtAcceptConnectPort, (HANDLE *handle, ULONG id, LPC_MESSAGE *msg, BOOLEAN accept, LPC_SECTION_WRITE *write, LPC_SECTION_READ *read))
  DEFINE_SYSCALL(NtAccessCheck, (PSECURITY_DESCRIPTOR descr, HANDLE token, ACCESS_MASK access, GENERIC_MAPPING *mapping, PRIVILEGE_SET *privs, ULONG *retlen, ULONG *access_granted, NTSTATUS *access_status))
- DEFINE_SYSCALL(NtAccessCheckAndAuditAlarm, (UNICODE_STRING *subsystem, HANDLE handle, UNICODE_STRING *typename, UNICODE_STRING *objectname, PSECURITY_DESCRIPTOR descr, ACCESS_MASK access, GENERIC_MAPPING *mapping, BOOLEAN creation, ACCESS_MASK *access_granted, NTSTATUS *access_status, BOOLEAN *onclose))
+ DEFINE_SYSCALL(NtAccessCheckAndAuditAlarm, (UNICODE_STRING *subsystem, HANDLE handle, UNICODE_STRING *typename, UNICODE_STRING *objectname, PSECURITY_DESCRIPTOR descr, ACCESS_MASK access, GENERIC_MAPPING *mapping, BOOLEAN creation, ACCESS_MASK *access_granted, BOOLEAN *access_status, BOOLEAN *onclose))
 diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
-index ef1d9ef5005..c168eccda38 100644
+index 2f956af6966..007b4fb85bc 100644
 --- a/dlls/ntdll/unix/unix_private.h
 +++ b/dlls/ntdll/unix/unix_private.h
-@@ -738,4 +738,6 @@ static inline int is_gdt_sel( WORD sel )
- 
- #endif  /* defined(__i386__) || defined(__x86_64__) */
+@@ -575,4 +575,6 @@ static inline NTSTATUS map_section( HANDLE mapping, void **ptr, SIZE_T *size, UL
+                                0, NULL, size, ViewShare, 0, protect );
+ }
  
 +BOOL WINAPI __wine_needs_override_large_address_aware(void);
 +
  #endif /* __NTDLL_UNIX_PRIVATE_H */
 diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
-index 26afdae40fb..5d323eda8c7 100644
+index 909c089cf07..31fa04fdab3 100644
 --- a/dlls/ntdll/unix/virtual.c
 +++ b/dlls/ntdll/unix/virtual.c
-@@ -5096,6 +5096,24 @@ static void virtual_release_address_space(void)
+@@ -4904,6 +4904,24 @@ static void virtual_release_address_space(void)
  
  #endif  /* _WIN64 */
  
@@ -119,16 +119,16 @@ index 26afdae40fb..5d323eda8c7 100644
  
  /***********************************************************************
   *           virtual_set_large_address_space
-@@ -5115,7 +5133,7 @@ void virtual_set_large_address_space(void)
+@@ -4915,7 +4933,7 @@ void virtual_set_large_address_space(void)
                  free_reserved_memory( 0, (char *)0x7ffe0000 );
  #endif
          }
--        else if (main_image_info.ImageCharacteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE)
-+        else if (is_large_address_aware())
-         {
-             user_space_wow_limit = limit_4g - 1;
-             /* reserve space for top-down allocations; some apps break if the entire high 2G is available */
-@@ -5125,7 +5143,7 @@ void virtual_set_large_address_space(void)
+-        else user_space_wow_limit = ((main_image_info.ImageCharacteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE) ? limit_4g : limit_2g) - 1;
++        else user_space_wow_limit = (is_large_address_aware() ? limit_4g : limit_2g) - 1;
+     }
+     else
+     {
+@@ -4924,7 +4942,7 @@ void virtual_set_large_address_space(void)
      }
      else
      {
@@ -138,10 +138,10 @@ index 26afdae40fb..5d323eda8c7 100644
      }
      user_space_limit = working_set_limit = address_space_limit;
 diff --git a/dlls/wow64/system.c b/dlls/wow64/system.c
-index eb57d35f41e..8b108b406d6 100644
+index 5f3056a4179..2f466d869dd 100644
 --- a/dlls/wow64/system.c
 +++ b/dlls/wow64/system.c
-@@ -886,3 +886,9 @@ NTSTATUS WINAPI wow64_NtWow64GetNativeSystemInformation( UINT *args )
+@@ -855,3 +855,9 @@ NTSTATUS WINAPI wow64_NtWow64GetNativeSystemInformation( UINT *args )
          return STATUS_INVALID_INFO_CLASS;
      }
  }

--- a/wine-tkg-git/wine-tkg-patches/proton/LAA/legacy/LAA-unix-wow64-f4c5b041.patch
+++ b/wine-tkg-git/wine-tkg-patches/proton/LAA/legacy/LAA-unix-wow64-f4c5b041.patch
@@ -1,4 +1,4 @@
-From 9bd9ea5e4dd8b9a33c8922562979ae4c9bb8a76b Mon Sep 17 00:00:00 2001
+From 245dfe63a720eae04890a8d3e0f74ebae800ffbd Mon Sep 17 00:00:00 2001
 From: Steven Noonan <steven@valvesoftware.com>
 Date: Wed, 17 Oct 2018 04:13:37 -0700
 Subject: [PATCH] ntdll/loader: add support for overriding
@@ -6,15 +6,15 @@ Subject: [PATCH] ntdll/loader: add support for overriding
 
 ---
  dlls/kernel32/heap.c           |  8 +++++++-
- dlls/ntdll/ntdll.spec          |  3 +++
+ dlls/ntdll/ntdll.spec          |  1 +
  dlls/ntdll/signal_arm64ec.c    |  1 +
  dlls/ntdll/unix/unix_private.h |  2 ++
  dlls/ntdll/unix/virtual.c      | 22 ++++++++++++++++++++--
  dlls/wow64/system.c            |  6 ++++++
- 6 files changed, 39 insertions(+), 3 deletions(-)
+ 6 files changed, 37 insertions(+), 3 deletions(-)
 
 diff --git a/dlls/kernel32/heap.c b/dlls/kernel32/heap.c
-index 834f4d07e9b..4d27b38ddca 100644
+index 1ec2f5cce0d..10f6895478e 100644
 --- a/dlls/kernel32/heap.c
 +++ b/dlls/kernel32/heap.c
 @@ -42,6 +42,8 @@
@@ -54,13 +54,13 @@ index 834f4d07e9b..4d27b38ddca 100644
          if (lpBuffer->dwTotalPhys > MAXLONG) lpBuffer->dwTotalPhys = MAXLONG;
          if (lpBuffer->dwAvailPhys > MAXLONG) lpBuffer->dwAvailPhys = MAXLONG;
 diff --git a/dlls/ntdll/ntdll.spec b/dlls/ntdll/ntdll.spec
-index cdd28e31242..db139ca8f7d 100644
+index 620d96a5992..b3d93326d8c 100644
 --- a/dlls/ntdll/ntdll.spec
 +++ b/dlls/ntdll/ntdll.spec
-@@ -1778,6 +1778,9 @@
+@@ -1625,6 +1625,9 @@
  @ cdecl -norelay __wine_dbg_output(str)
  @ cdecl -norelay __wine_dbg_strdup(str)
- 
+
 +# Virtual memory
 +@ stdcall -syscall __wine_needs_override_large_address_aware()
 +
@@ -68,33 +68,33 @@ index cdd28e31242..db139ca8f7d 100644
  @ cdecl wine_get_version()
  @ cdecl wine_get_build_id()
 diff --git a/dlls/ntdll/signal_arm64ec.c b/dlls/ntdll/signal_arm64ec.c
-index c9815c958c4..ea7243b8207 100644
+index 4505aeacfba..d64647f7b45 100644
 --- a/dlls/ntdll/signal_arm64ec.c
 +++ b/dlls/ntdll/signal_arm64ec.c
-@@ -348,6 +348,7 @@ ALL_SYSCALLS
+@@ -580,6 +580,7 @@
  
  #define SYSCALL_API __attribute__((hybrid_patchable))
  
 +DEFINE_SYSCALL_(BOOL, __wine_needs_override_large_address_aware, (void))
  DEFINE_SYSCALL(NtAcceptConnectPort, (HANDLE *handle, ULONG id, LPC_MESSAGE *msg, BOOLEAN accept, LPC_SECTION_WRITE *write, LPC_SECTION_READ *read))
  DEFINE_SYSCALL(NtAccessCheck, (PSECURITY_DESCRIPTOR descr, HANDLE token, ACCESS_MASK access, GENERIC_MAPPING *mapping, PRIVILEGE_SET *privs, ULONG *retlen, ULONG *access_granted, NTSTATUS *access_status))
- DEFINE_SYSCALL(NtAccessCheckAndAuditAlarm, (UNICODE_STRING *subsystem, HANDLE handle, UNICODE_STRING *typename, UNICODE_STRING *objectname, PSECURITY_DESCRIPTOR descr, ACCESS_MASK access, GENERIC_MAPPING *mapping, BOOLEAN creation, ACCESS_MASK *access_granted, NTSTATUS *access_status, BOOLEAN *onclose))
+ DEFINE_SYSCALL(NtAccessCheckAndAuditAlarm, (UNICODE_STRING *subsystem, HANDLE handle, UNICODE_STRING *typename, UNICODE_STRING *objectname, PSECURITY_DESCRIPTOR descr, ACCESS_MASK access, GENERIC_MAPPING *mapping, BOOLEAN creation, ACCESS_MASK *access_granted, BOOLEAN *access_status, BOOLEAN *onclose))
 diff --git a/dlls/ntdll/unix/unix_private.h b/dlls/ntdll/unix/unix_private.h
-index ef1d9ef5005..c168eccda38 100644
+index 2f956af6966..007b4fb85bc 100644
 --- a/dlls/ntdll/unix/unix_private.h
 +++ b/dlls/ntdll/unix/unix_private.h
-@@ -738,4 +738,6 @@ static inline int is_gdt_sel( WORD sel )
- 
- #endif  /* defined(__i386__) || defined(__x86_64__) */
+@@ -575,4 +575,6 @@ static inline NTSTATUS map_section( HANDLE mapping, void **ptr, SIZE_T *size, UL
+                                0, NULL, size, ViewShare, 0, protect );
+ }
  
 +BOOL WINAPI __wine_needs_override_large_address_aware(void);
 +
  #endif /* __NTDLL_UNIX_PRIVATE_H */
 diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
-index 26afdae40fb..5d323eda8c7 100644
+index 909c089cf07..31fa04fdab3 100644
 --- a/dlls/ntdll/unix/virtual.c
 +++ b/dlls/ntdll/unix/virtual.c
-@@ -5096,6 +5096,24 @@ static void virtual_release_address_space(void)
+@@ -4904,6 +4904,24 @@ static void virtual_release_address_space(void)
  
  #endif  /* _WIN64 */
  
@@ -119,16 +119,16 @@ index 26afdae40fb..5d323eda8c7 100644
  
  /***********************************************************************
   *           virtual_set_large_address_space
-@@ -5115,7 +5133,7 @@ void virtual_set_large_address_space(void)
+@@ -4915,7 +4933,7 @@ void virtual_set_large_address_space(void)
                  free_reserved_memory( 0, (char *)0x7ffe0000 );
  #endif
          }
--        else if (main_image_info.ImageCharacteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE)
-+        else if (is_large_address_aware())
-         {
-             user_space_wow_limit = limit_4g - 1;
-             /* reserve space for top-down allocations; some apps break if the entire high 2G is available */
-@@ -5125,7 +5143,7 @@ void virtual_set_large_address_space(void)
+-        else user_space_wow_limit = ((main_image_info.ImageCharacteristics & IMAGE_FILE_LARGE_ADDRESS_AWARE) ? limit_4g : limit_2g) - 1;
++        else user_space_wow_limit = (is_large_address_aware() ? limit_4g : limit_2g) - 1;
+     }
+     else
+     {
+@@ -4924,7 +4942,7 @@ void virtual_set_large_address_space(void)
      }
      else
      {
@@ -138,10 +138,10 @@ index 26afdae40fb..5d323eda8c7 100644
      }
      user_space_limit = working_set_limit = address_space_limit;
 diff --git a/dlls/wow64/system.c b/dlls/wow64/system.c
-index eb57d35f41e..8b108b406d6 100644
+index 5f3056a4179..2f466d869dd 100644
 --- a/dlls/wow64/system.c
 +++ b/dlls/wow64/system.c
-@@ -886,3 +886,9 @@ NTSTATUS WINAPI wow64_NtWow64GetNativeSystemInformation( UINT *args )
+@@ -855,3 +855,9 @@ NTSTATUS WINAPI wow64_NtWow64GetNativeSystemInformation( UINT *args )
          return STATUS_INVALID_INFO_CLASS;
      }
  }


### PR DESCRIPTION
Time for another rebase! 🐸

Upstream Wine commit `f4c5b04148db5fc4e5265beec461d3b7d9f4a789` broke the LAA-unix patches for wow64 builds and I have rebased the patches to work again. Everything seems to compile and work on my end.

I don't think I see any mistakes in the LAA script from my perspective, but if you catch any let me know! 🐸